### PR TITLE
Add action to keep branches synced with OSD's

### DIFF
--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -1,0 +1,25 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # At 00:00 on Monday.
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [main, 2.x, 2.3.0] # branches to track and sync from OSD
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.6.3
+        with:
+          head: ${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          merge_method: rebase
+          pr_title: Sync Wazuh Dashboard fork
+          pr_message: Update Wazuh Dashboard with lastest changes from OpenSearch Dashboards using the rebase strategy to replay our work on top.
+          auto_merge: false


### PR DESCRIPTION
### Description
This pull request adds a GitHub Action to automatically fetch and include new changes from the OpenSearch Dashboards repository, keeping the fork in sync.

The action is scheduled to run weekly, at 00:00h each Monday.

The branches to keep in sync are `main`, `2.x` and `2.3`.
 
### Issues Resolved
#2
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 