### PR TITLE
Add development environments for Wazuh Dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.git
+# .git
 Dockerfile
 node_modules
-packages/
+# packages/

--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -1,0 +1,28 @@
+name: Docker Image CI
+
+on:
+  push:
+    tag:
+      - "v*.*.*"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: Dockerfile.dev
+          context: .
+          push: true
+          tags: wazuh/wzd-dev:${{ github.ref_name }}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,20 @@
+ARG NODE_VERSION=14.20.0
+FROM node:${NODE_VERSION} AS base
+ARG WDSECURITYVERSION=2.4
+
+USER node
+ADD --chown=node:node ./ /home/node/wazuh-dashboard
+WORKDIR /home/node/wazuh-dashboard
+RUN yarn osd bootstrap
+
+WORKDIR /home/node/wazuh-dashboard/plugins
+RUN git clone --depth 1 --branch $WDSECURITYVERSION https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+WORKDIR /home/node/wazuh-dashboard/plugins/wazuh-security-dashboards-plugin
+RUN yarn install
+
+RUN mkdir -p /home/node/wazuh-dashboard/data/wazuh/config
+
+FROM node:${NODE_VERSION}
+USER node
+COPY --from=base /home/node/wazuh-dashboard /home/node/wazuh-dashboard
+WORKDIR /home/node/wazuh-dashboard


### PR DESCRIPTION
### Description
We want to add a development environment for wazuh dashboard.

Creating the dockerfile, a github actions and a docker-compose to be able to build all the necessary stack. 
 
### Issues Resolved
- #21 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 