### PR TITLE
Add Wazuh version and links

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "number": 8467,
     "sha": "6cb7fec4e154faa0a4a3fee4b33dfef91b9870d9"
   },
+  "wazuh": {
+    "version": "4.4.0"
+  },
   "homepage": "https://opensearch.org",
   "bugs": {
     "url": "http://github.com/opensearch-project/OpenSearch-Dashboards/issues"

--- a/packages/osd-config/src/__snapshots__/env.test.ts.snap
+++ b/packages/osd-config/src/__snapshots__/env.test.ts.snap
@@ -34,6 +34,7 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "v1",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -77,6 +78,7 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "v1",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -119,6 +121,7 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "some-version",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -161,6 +164,7 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "some-version",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -203,6 +207,7 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "some-version",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -245,6 +250,7 @@ Env {
     "buildSha": "feature-v1-build-sha",
     "dist": true,
     "version": "v1",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -287,6 +293,7 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "v1",
+    "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
     "/test/opensearchDashboardsRoot/src/plugins",
@@ -329,6 +336,7 @@ Env {
     "buildSha": "feature-v1-build-sha",
     "dist": true,
     "version": "v1",
+    "wazuhVersion": "4.4.0",
   },
   "pluginSearchPaths": Array [
     "/some/home/dir/src/plugins",

--- a/packages/osd-config/src/config_service.test.ts
+++ b/packages/osd-config/src/config_service.test.ts
@@ -48,6 +48,9 @@ const packageInfos: RawPackageInfo = {
     number: 42,
     sha: 'one',
   },
+  wazuh: {
+    version: '4.4.0',
+  },
 };
 const emptyArgv = getEnvOptions();
 const defaultEnv = new Env('/opensearch-dashboards', packageInfos, emptyArgv);
@@ -269,6 +272,9 @@ test('correctly passes context', async () => {
       distributable: true,
       number: 100,
       sha: 'feature-v1-build-sha',
+    },
+    wazuh: {
+      version: '4.4.0',
     },
   };
 

--- a/packages/osd-config/src/env.test.ts
+++ b/packages/osd-config/src/env.test.ts
@@ -42,6 +42,9 @@ const packageInfos: RawPackageInfo = {
     number: 42,
     sha: 'one',
   },
+  wazuh: {
+    version: '4.4.0',
+  },
 };
 
 beforeEach(() => {
@@ -52,6 +55,9 @@ test('correctly creates default environment in dev mode when isDevClusterMaster 
   mockPackage.raw = {
     branch: 'some-branch',
     version: 'some-version',
+    wazuh: {
+      version: '4.x.x',
+    },
   };
 
   const defaultEnv = Env.createDefault(
@@ -71,6 +77,9 @@ test('correctly creates default environment in dev mode when isDevClusterManager
   mockPackage.raw = {
     branch: 'some-branch',
     version: 'some-version',
+    wazuh: {
+      version: '4.x.x',
+    },
   };
 
   const defaultEnv = Env.createDefault(
@@ -90,6 +99,9 @@ test('correctly creates default environment in dev mode when isDevClusterManager
   mockPackage.raw = {
     branch: 'some-branch',
     version: 'some-version',
+    wazuh: {
+      version: '4.x.x',
+    },
   };
 
   const defaultEnv = Env.createDefault(
@@ -114,6 +126,9 @@ test('correctly creates default environment in prod distributable mode.', () => 
       number: 100,
       sha: 'feature-v1-build-sha',
     },
+    wazuh: {
+      version: '4.x.x',
+    },
   };
 
   const defaultEnv = Env.createDefault(
@@ -136,6 +151,9 @@ test('correctly creates default environment in prod non-distributable mode.', ()
       number: 100,
       sha: 'feature-v1-build-sha',
     },
+    wazuh: {
+      version: '4.x.x',
+    },
   };
 
   const defaultEnv = Env.createDefault(
@@ -157,6 +175,9 @@ test('correctly creates default environment if `--env.name` is supplied.', () =>
       distributable: false,
       number: 100,
       sha: 'feature-v1-build-sha',
+    },
+    wazuh: {
+      version: '4.x.x',
     },
   };
 
@@ -190,6 +211,9 @@ test('correctly creates environment with constructor.', () => {
         distributable: true,
         number: 100,
         sha: 'feature-v1-build-sha',
+      },
+      wazuh: {
+        version: '4.4.0',
       },
     },
     getEnvOptions({

--- a/packages/osd-config/src/env.ts
+++ b/packages/osd-config/src/env.ts
@@ -67,6 +67,9 @@ export interface RawPackageInfo {
     number: number;
     sha: string;
   };
+  wazuh: {
+    version: string;
+  };
 }
 
 export class Env {
@@ -159,6 +162,7 @@ export class Env {
         : 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       version: pkg.version,
       dist: isOpenSearchDashboardsDistributable,
+      wazuhVersion: pkg.wazuh.version,
     });
   }
 }

--- a/packages/osd-config/src/types.ts
+++ b/packages/osd-config/src/types.ts
@@ -37,6 +37,7 @@ export interface PackageInfo {
   buildNum: number;
   buildSha: string;
   dist: boolean;
+  wazuhVersion: string;
 }
 
 /**

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -245,7 +245,7 @@ export class ChromeService {
           basePath={http.basePath}
           breadcrumbs$={breadcrumbs$.pipe(takeUntil(this.stop$))}
           customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
-          opensearchDashboardsDocLink={docLinks.links.wazuh.gettingStarted}
+          opensearchDashboardsDocLink={docLinks.links.wazuh.index}
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -245,13 +245,13 @@ export class ChromeService {
           basePath={http.basePath}
           breadcrumbs$={breadcrumbs$.pipe(takeUntil(this.stop$))}
           customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
-          opensearchDashboardsDocLink={docLinks.links.opensearchDashboards.introduction}
+          opensearchDashboardsDocLink={docLinks.links.wazuh.gettingStarted}
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}
           homeHref={http.basePath.prepend('/app/home')}
           isVisible$={this.isVisible$}
-          opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
+          opensearchDashboardsVersion={injectedMetadata.getWazuhVersion()}
           navLinks$={navLinks.getNavLinks$()}
           recentlyAccessed$={recentlyAccessed.get$()}
           navControlsLeft$={navControls.getLeft$()}

--- a/src/core/public/chrome/constants.ts
+++ b/src/core/public/chrome/constants.ts
@@ -28,7 +28,6 @@
  * under the License.
  */
 
-export const OPENSEARCH_DASHBOARDS_FEEDBACK_LINK = 'https://github.com/opensearch-project';
-export const OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK = 'https://github.com/opensearch-project';
-export const GITHUB_CREATE_ISSUE_LINK =
-  'https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose';
+export const OPENSEARCH_DASHBOARDS_FEEDBACK_LINK = 'https://wazuh.com/community/join-us-on-slack';
+export const OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK = OPENSEARCH_DASHBOARDS_FEEDBACK_LINK;
+export const GITHUB_CREATE_ISSUE_LINK = 'https://github.com/wazuh/wazuh/issues/new/choose';

--- a/src/core/public/chrome/ui/header/header_help_menu.tsx
+++ b/src/core/public/chrome/ui/header/header_help_menu.tsx
@@ -206,7 +206,7 @@ class HeaderHelpMenuUI extends Component<Props, State> {
         <EuiButtonEmpty href={opensearchDashboardsDocLink} target="_blank" size="xs" flush="left">
           <FormattedMessage
             id="core.ui.chrome.headerGlobalNav.helpMenuOpenSearchDashboardsDocumentationTitle"
-            defaultMessage="OpenSearch Dashboards documentation"
+            defaultMessage="Wazuh documentation"
           />
         </EuiButtonEmpty>
 

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -48,10 +48,20 @@ export class DocLinksService {
     const OPENSEARCH_VERSIONED_DOCS = `${OPENSEARCH_WEBSITE_DOCS}/opensearch/`;
     const OPENSEARCH_DASHBOARDS_VERSIONED_DOCS = `${OPENSEARCH_WEBSITE_DOCS}/dashboards/`;
 
+    // - Note .- Using the getting-started link instead of the index link
+    //           because the index link is inconsistent with older versions.
+    // https://documentation.wazuh.com/current/getting-started/index.html
+    const WAZUH_LINK_VERSION = injectedMetadata.getWazuhVersion().slice(0, 3) || 'current';
+    const WAZUH_WEBSITE_DOCS = `https://documentation.wazuh.com/${WAZUH_LINK_VERSION}/getting-started/index.html`;
+
     return deepFreeze({
       DOC_LINK_VERSION,
       OPENSEARCH_WEBSITE_URL,
+      WAZUH_LINK_VERSION,
       links: {
+        wazuh: {
+          gettingStarted: WAZUH_WEBSITE_DOCS,
+        },
         opensearch: {
           // https://opensearch.org/docs/latest/opensearch/index/
           introduction: `${OPENSEARCH_VERSIONED_DOCS}index/`,
@@ -552,7 +562,11 @@ export class DocLinksService {
 export interface DocLinksStart {
   readonly DOC_LINK_VERSION: string;
   readonly OPENSEARCH_WEBSITE_URL: string;
+  readonly WAZUH_LINK_VERSION: string;
   readonly links: {
+    readonly wazuh: {
+      readonly gettingStarted: string;
+    };
     readonly opensearch: {
       readonly introduction: string;
       readonly installation: {

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -47,20 +47,16 @@ export class DocLinksService {
     const OPENSEARCH_WEBSITE_DOCS = `${OPENSEARCH_WEBSITE_URL}docs/${DOC_LINK_VERSION}`;
     const OPENSEARCH_VERSIONED_DOCS = `${OPENSEARCH_WEBSITE_DOCS}/opensearch/`;
     const OPENSEARCH_DASHBOARDS_VERSIONED_DOCS = `${OPENSEARCH_WEBSITE_DOCS}/dashboards/`;
-
-    // - Note .- Using the getting-started link instead of the index link
-    //           because the index link is inconsistent with older versions.
-    // https://documentation.wazuh.com/current/getting-started/index.html
-    const WAZUH_LINK_VERSION = injectedMetadata.getWazuhVersion().slice(0, 3) || 'current';
-    const WAZUH_WEBSITE_DOCS = `https://documentation.wazuh.com/${WAZUH_LINK_VERSION}/getting-started/index.html`;
+    const WAZUH_DOC_VERSION = injectedMetadata.getWazuhDocVersion();
+    const WAZUH_WEBSITE_DOCS = `https://documentation.wazuh.com/${WAZUH_DOC_VERSION}`;
 
     return deepFreeze({
       DOC_LINK_VERSION,
       OPENSEARCH_WEBSITE_URL,
-      WAZUH_LINK_VERSION,
+      WAZUH_DOC_VERSION,
       links: {
         wazuh: {
-          gettingStarted: WAZUH_WEBSITE_DOCS,
+          index: `${WAZUH_WEBSITE_DOCS}/index.html`,
         },
         opensearch: {
           // https://opensearch.org/docs/latest/opensearch/index/
@@ -562,10 +558,10 @@ export class DocLinksService {
 export interface DocLinksStart {
   readonly DOC_LINK_VERSION: string;
   readonly OPENSEARCH_WEBSITE_URL: string;
-  readonly WAZUH_LINK_VERSION: string;
+  readonly WAZUH_DOC_VERSION: string;
   readonly links: {
     readonly wazuh: {
-      readonly gettingStarted: string;
+      readonly index: string;
     };
     readonly opensearch: {
       readonly introduction: string;

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -46,6 +46,7 @@ const createSetupContractMock = () => {
     getOpenSearchDashboardsBuildNumber: jest.fn(),
     getBranding: jest.fn(),
     getWazuhVersion: jest.fn(),
+    getWazuhDocVersion: jest.fn(),
   };
   setupContract.getCspConfig.mockReturnValue({ warnLegacyBrowsers: true });
   setupContract.getOpenSearchDashboardsVersion.mockReturnValue('opensearchDashboardsVersion');
@@ -63,6 +64,7 @@ const createSetupContractMock = () => {
   } as any);
   setupContract.getPlugins.mockReturnValue([]);
   setupContract.getWazuhVersion.mockReturnValue('4.x.x');
+  setupContract.getWazuhDocVersion.mockReturnValue('4.x');
   return setupContract;
 };
 

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -45,6 +45,7 @@ const createSetupContractMock = () => {
     getInjectedVars: jest.fn(),
     getOpenSearchDashboardsBuildNumber: jest.fn(),
     getBranding: jest.fn(),
+    getWazuhVersion: jest.fn(),
   };
   setupContract.getCspConfig.mockReturnValue({ warnLegacyBrowsers: true });
   setupContract.getOpenSearchDashboardsVersion.mockReturnValue('opensearchDashboardsVersion');
@@ -61,6 +62,7 @@ const createSetupContractMock = () => {
     },
   } as any);
   setupContract.getPlugins.mockReturnValue([]);
+  setupContract.getWazuhVersion.mockReturnValue('4.x.x');
   return setupContract;
 };
 

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -53,6 +53,7 @@ export interface InjectedMetadataParams {
     version: string;
     buildNumber: number;
     branch: string;
+    wazuhVersion: string;
     basePath: string;
     serverBasePath: string;
     category?: AppCategory;
@@ -146,6 +147,10 @@ export class InjectedMetadataService {
       getBranding: () => {
         return this.state.branding;
       },
+
+      getWazuhVersion: () => {
+        return this.state.wazuhVersion;
+      },
     };
   }
 }
@@ -180,6 +185,7 @@ export interface InjectedMetadataSetup {
     [key: string]: unknown;
   };
   getBranding: () => Branding;
+  getWazuhVersion: () => string;
 }
 
 /** @internal */

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -151,6 +151,10 @@ export class InjectedMetadataService {
       getWazuhVersion: () => {
         return this.state.wazuhVersion;
       },
+
+      getWazuhDocVersion: () => {
+        return this.state.wazuhVersion.slice(0, 3) || 'current';
+      },
     };
   }
 }
@@ -186,6 +190,7 @@ export interface InjectedMetadataSetup {
   };
   getBranding: () => Branding;
   getWazuhVersion: () => string;
+  getWazuhDocVersion: () => string;
 }
 
 /** @internal */

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -126,6 +126,7 @@ function pluginInitializerContextMock() {
         buildNum: 100,
         buildSha: 'buildSha',
         dist: false,
+        wazuhVersion: 'wazuhVersion',
       },
     },
     config: {
@@ -151,6 +152,7 @@ function createCoreContext(): CoreContext {
         buildNum: 100,
         buildSha: 'buildSha',
         dist: false,
+        wazuhVersion: 'wazuhVersion',
       },
     },
   };

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -113,6 +113,7 @@ function pluginInitializerContextMock<T>(config: T = {} as T) {
         buildNum: 100,
         buildSha: 'buildSha',
         dist: false,
+        wazuhVersion: 'wazuhVersion',
       },
       instanceUuid: 'instance-uuid',
     },

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
@@ -45,6 +45,7 @@ const packageInfo = {
   buildSha: '',
   version: '7.0.0-alpha1',
   dist: false,
+  wazuhVersion: '4.0.0',
 };
 
 afterEach(() => {

--- a/src/core/server/plugins/discovery/plugins_discovery.test.ts
+++ b/src/core/server/plugins/discovery/plugins_discovery.test.ts
@@ -82,6 +82,9 @@ const packageMock = {
     number: 1,
     sha: '',
   },
+  wazuh: {
+    version: '4.x.x',
+  },
 };
 
 const manifestPath = (...pluginPath: string[]) =>

--- a/src/core/server/plugins/integration_tests/plugins_service.test.ts
+++ b/src/core/server/plugins/integration_tests/plugins_service.test.ts
@@ -103,6 +103,9 @@ describe('PluginsService', () => {
         number: 100,
         sha: 'feature-v1-build-sha',
       },
+      wazuh: {
+        version: '4.x.x',
+      },
     };
 
     const env = Env.createDefault(REPO_ROOT, getEnvOptions());

--- a/src/core/server/plugins/plugins_service.test.ts
+++ b/src/core/server/plugins/plugins_service.test.ts
@@ -125,6 +125,9 @@ describe('PluginsService', () => {
         number: 100,
         sha: 'feature-v1-build-sha',
       },
+      wazuh: {
+        version: '4.x.x',
+      },
     };
 
     coreId = Symbol('core');

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -30,6 +30,7 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhVersion": "4.4.0",
     },
   },
   "i18n": Object {
@@ -49,6 +50,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
+  "wazuhVersion": "4.4.0",
 }
 `;
 
@@ -82,6 +84,7 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhVersion": "4.4.0",
     },
   },
   "i18n": Object {
@@ -101,6 +104,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
+  "wazuhVersion": "4.4.0",
 }
 `;
 
@@ -134,6 +138,7 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhVersion": "4.4.0",
     },
   },
   "i18n": Object {
@@ -157,6 +162,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
+  "wazuhVersion": "4.4.0",
 }
 `;
 
@@ -190,6 +196,7 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhVersion": "4.4.0",
     },
   },
   "i18n": Object {
@@ -209,6 +216,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
+  "wazuhVersion": "4.4.0",
 }
 `;
 
@@ -242,6 +250,7 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhVersion": "4.4.0",
     },
   },
   "i18n": Object {
@@ -261,5 +270,6 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
+  "wazuhVersion": "4.4.0",
 }
 `;

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -115,6 +115,7 @@ export class RenderingService {
             version: env.packageInfo.version,
             buildNumber: env.packageInfo.buildNum,
             branch: env.packageInfo.branch,
+            wazuhVersion: env.packageInfo.wazuhVersion,
             basePath,
             serverBasePath,
             env,

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -50,6 +50,7 @@ export interface RenderingMetadata {
     version: string;
     buildNumber: number;
     branch: string;
+    wazuhVersion: string;
     basePath: string;
     serverBasePath: string;
     env: {

--- a/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
+++ b/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
@@ -64,7 +64,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/defaultModeLoadingLogo\\",\\"darkModeUrl\\":\\"/darkModeLoadingLogo\\"},\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/defaultModeLoadingLogo\\",\\"darkModeUrl\\":\\"/darkModeLoadingLogo\\"},\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -202,7 +202,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/defaultModeLoadingLogo\\"},\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/defaultModeLoadingLogo\\"},\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -340,7 +340,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -481,7 +481,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -622,7 +622,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -783,7 +783,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"defaultModeLoadingLogo/\\"},\\"applicationTitle\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"defaultModeLoadingLogo/\\"},\\"applicationTitle\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -923,7 +923,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -1066,7 +1066,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -1225,7 +1225,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"faviconUrl\\":\\"/customFavicon\\",\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"faviconUrl\\":\\"/customFavicon\\",\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -1384,7 +1384,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"wazuhVersion\\":\\"4.x.x\\",\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true,\\"wazuhVersion\\":\\"\\"},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
   />,
   <div
     class="osdWelcomeView"

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -24,6 +24,7 @@ function mockProps() {
       version: injectedMetadata.getOpenSearchDashboardsVersion(),
       buildNumber: 1,
       branch: injectedMetadata.getBasePath(),
+      wazuhVersion: injectedMetadata.getWazuhVersion(),
       basePath: '',
       serverBasePath: '',
       env: {
@@ -33,6 +34,7 @@ function mockProps() {
           buildNum: 1,
           buildSha: '',
           dist: true,
+          wazuhVersion: '',
         },
         mode: {
           name: 'production' as 'development' | 'production',

--- a/src/core/server/status/routes/integration_tests/status.test.ts
+++ b/src/core/server/status/routes/integration_tests/status.test.ts
@@ -79,6 +79,7 @@ describe('GET /api/status', () => {
           buildSha: 'xsha',
           dist: true,
           version: '9.9.9-SNAPSHOT',
+          wazuhVersion: '4.2.0',
         },
         serverName: 'xopensearchDashboards',
         uuid: 'xxxx-xxxxx',

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -54,6 +54,7 @@ interface Package {
   workspaces: {
     packages: string[];
   };
+  wazuh: { version: string };
   [key: string]: unknown;
 }
 

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -51,6 +51,9 @@ export const CreatePackageJson: Task = {
         distributable: true,
         release: config.isRelease,
       },
+      wazuh: {
+        version: pkg.wazuh.version,
+      },
       repository: pkg.repository,
       engines: {
         node: pkg.engines.node,


### PR DESCRIPTION
### Description

**Partially depends on #50 **

This pull request completes some of the changes applied in #50 to add the documentation links of Wazuh to the help menu. The OpenSearch's links are replaced.

The documentation links are generated to match the version of the app, meaning that a Wazuh Dashboard at version 4.4.1 will link to the documentation of that version (4.4).

The version of the app is also shown in the menu. The version of Wazuh is defined in the `package.json` file, the loaded during runtime and injected to the <head> section of the main HTML file.
 
This is how it looks with the changes from  #50 also applied (which changes the texts).

![image](https://user-images.githubusercontent.com/15186973/220157095-3da18cfc-7c81-42ae-8583-a391076fdb83.png)

The links generated are:

- [Wazuh documentation](https://documentation.wazuh.com/4.4/index.html)
- [Ask Wazuh](https://wazuh.com/community/join-us-on-slack)
- [Give feedback](https://wazuh.com/community/join-us-on-slack)
- [Open an issue in GitHub](https://github.com/wazuh/wazuh/issues/new/choose)

### Issues Resolved
 #18 
 
### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 