### PR TITLE
Fix tar error in build workflow

### DIFF
--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -137,16 +137,12 @@ build() {
             install=$plugin
         fi
         echo "Installing ${plugin%.*} plugin"
-        if bin/opensearch-dashboards-plugin install $install |  grep -ie 'unsuccessful|error|fail'; then
+        if ! bin/opensearch-dashboards-plugin install $install 2>&1 > /dev/null; then
           echo "Plugin installation failed"
-          fail=1
-          break
+          clean 1
         fi
     done
 
-    if [[ $fail = 1 ]]; then
-      clean 1
-    fi
     echo
     echo Finished installing plugins
     echo

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -84,21 +84,15 @@ build() {
                 clean 1
             else
                 echo "Extracting Wazuh Dashboard base"
-                echo "a"
-                ls -l .
                 unzip -q wazuh-dashboard.zip -d ./dashboards/
                 rm wazuh-dashboard.zip
                 mv ./dashboards/$(ls ./dashboards) wazuh-dashboard.tar.gz
-                echo "B"
-                ls -l .
             fi
         else
             if ! curl --output wazuh-dashboard.tar.gz --silent --fail "${base}"; then
                 echo "The given URL or Path to the Wazuh Dashboard base is not working: ${base}"
                 clean 1
             fi
-            echo "D"
-            ls -l .
         fi
     else
         echo "The given URL or Path to the Wazuh Dashboard base is not valid: ${base}"
@@ -123,14 +117,10 @@ build() {
         clean 1
     fi
 
-    echo "c"
-    ls -l
-    echo "Tar1"
-
     tar -zxf wazuh-dashboard.tar.gz
-
-    echo "Tar2"
-    directory_name=$(tar -tf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
+    echo "a" $(tar -tf wazuh-dashboard.tar.gz)
+    echo "b"
+    directory_name=$(tar -tvf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
     working_dir="wazuh-dashboard-$version-$revision-linux-x64"
     echo $directory_name $working_dir
     mv $directory_name $working_dir

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -137,12 +137,16 @@ build() {
             install=$plugin
         fi
         echo "Installing ${plugin%.*} plugin"
-        if bin/opensearch-dashboards-plugin install $install |  grep -iE 'unsuccessful|error|fail'; then
+        if bin/opensearch-dashboards-plugin install $install |  grep -iE 'extract|unsuccessful|error|fail'; then
           echo "Plugin installation failed"
-          clean 1
+          fail=1
+          break
         fi
     done
 
+    if [[ $fail = 1 ]]; then
+      clean 1
+    fi
     echo
     echo Finished installing plugins
     echo

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -84,15 +84,21 @@ build() {
                 clean 1
             else
                 echo "Extracting Wazuh Dashboard base"
+                echo "a"
+                ls -l .
                 unzip -q wazuh-dashboard.zip -d ./dashboards/
                 rm wazuh-dashboard.zip
                 mv ./dashboards/$(ls ./dashboards) wazuh-dashboard.tar.gz
+                echo "B"
+                ls -l .
             fi
         else
             if ! curl --output wazuh-dashboard.tar.gz --silent --fail "${base}"; then
                 echo "The given URL or Path to the Wazuh Dashboard base is not working: ${base}"
                 clean 1
             fi
+            echo "D"
+            ls -l .
         fi
     else
         echo "The given URL or Path to the Wazuh Dashboard base is not valid: ${base}"
@@ -117,9 +123,12 @@ build() {
         clean 1
     fi
 
+    echo "c"
+    ls -l
     tar -zxf wazuh-dashboard.tar.gz
     directory_name=$(tar tf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
     working_dir="wazuh-dashboard-$version-$revision-linux-x64"
+    echo $directory_name $working_dir
     mv $directory_name $working_dir
     cd $working_dir
 

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -136,7 +136,8 @@ build() {
         else
             install=$plugin
         fi
-        if bin/opensearch-dashboards-plugin install $install | tee /dev/tty | grep -iE 'unsuccessful|error|fail' > /dev/null; then
+        echo "Installing ${plugin%.*} plugin"
+        if bin/opensearch-dashboards-plugin install $install |  grep -iE 'unsuccessful|error|fail'; then
           echo "Plugin installation failed"
           clean 1
         fi

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -127,23 +127,24 @@ build() {
     echo Building the package...
     echo
 
-    # Install plugins
-    bin/opensearch-dashboards-plugin install alertingDashboards
-    bin/opensearch-dashboards-plugin install customImportMapDashboards
-    bin/opensearch-dashboards-plugin install ganttChartDashboards
-    bin/opensearch-dashboards-plugin install indexManagementDashboards
-    bin/opensearch-dashboards-plugin install notificationsDashboards
-    bin/opensearch-dashboards-plugin install reportsDashboards
     # Install Wazuh apps and Security app
-    plugins=$(ls $tmp_dir/applications)
-    echo $plugins
+
+    plugins=$(ls $tmp_dir/applications)' '$(cat ../../plugins)
     for plugin in $plugins; do
-        echo $plugin
         if [[ $plugin =~ .*\.zip ]]; then
-            bin/opensearch-dashboards-plugin install file:../applications/$plugin
+            install='file:../applications/'$plugin
+        else
+            install=$plugin
+        fi
+        if bin/opensearch-dashboards-plugin install $install | tee /dev/tty | grep -iE 'unsuccessful|error|fail' > /dev/null; then
+          echo "Plugin installation failed"
+          clean 1
         fi
     done
 
+    echo
+    echo Finished installing plugins
+    echo
 
     # Move installed plugins from categories after generating the package
     category_explore='{id:"explore",label:"Explore",order:100,euiIconType:"search"}'

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -118,11 +118,10 @@ build() {
     fi
 
     tar -zxf wazuh-dashboard.tar.gz
-    echo "a" $(tar -tf wazuh-dashboard.tar.gz)
-    echo "b"
-    directory_name=$(tar -tvf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
+    a=$(tar -tzf wazuh-dashboard.tar.gz |head -1| sed 's#/.*##' | sort -u)
+    echo "A" $a
+    directory_name=$(tar -tzf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
     working_dir="wazuh-dashboard-$version-$revision-linux-x64"
-    echo $directory_name $working_dir
     mv $directory_name $working_dir
     cd $working_dir
 

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -137,7 +137,7 @@ build() {
             install=$plugin
         fi
         echo "Installing ${plugin%.*} plugin"
-        if bin/opensearch-dashboards-plugin install $install |  grep -iE 'extract|unsuccessful|error|fail'; then
+        if bin/opensearch-dashboards-plugin install $install |  grep -ie 'unsuccessful|error|fail'; then
           echo "Plugin installation failed"
           fail=1
           break

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -118,9 +118,8 @@ build() {
     fi
 
     tar -zxf wazuh-dashboard.tar.gz
-    a=$(tar -tzf wazuh-dashboard.tar.gz |head -1| sed 's#/.*##' | sort -u)
-    echo "A" $a
-    directory_name=$(tar -tzf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
+    tar -tzf wazuh-dashboard.tar.gz > gzContent
+    directory_name=$(head -1 gzContent | sed 's#/.*##' | sort -u)
     working_dir="wazuh-dashboard-$version-$revision-linux-x64"
     mv $directory_name $working_dir
     cd $working_dir

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -118,8 +118,7 @@ build() {
     fi
 
     tar -zxf wazuh-dashboard.tar.gz
-    tar -tzf wazuh-dashboard.tar.gz > gzContent
-    directory_name=$(head -1 gzContent | sed 's#/.*##' | sort -u)
+    directory_name=$(ls -t | head -1)
     working_dir="wazuh-dashboard-$version-$revision-linux-x64"
     mv $directory_name $working_dir
     cd $working_dir

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -125,8 +125,12 @@ build() {
 
     echo "c"
     ls -l
+    echo "Tar1"
+
     tar -zxf wazuh-dashboard.tar.gz
-    directory_name=$(tar tf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
+
+    echo "Tar2"
+    directory_name=$(tar -tf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
     working_dir="wazuh-dashboard-$version-$revision-linux-x64"
     echo $directory_name $working_dir
     mv $directory_name $working_dir

--- a/dev-tools/build-packages/base/plugins
+++ b/dev-tools/build-packages/base/plugins
@@ -1,0 +1,6 @@
+alertingDashboards
+customImportMapDashboards
+ganttChartDashboards
+indexManagementDashboards
+notificationsDashboards
+reportsDashboards

--- a/dev-tools/build-packages/deb/launcher.sh
+++ b/dev-tools/build-packages/deb/launcher.sh
@@ -81,8 +81,8 @@ build_deb() {
     echo
 
     # Prepare the package
-    directory_name=$(tar tf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
     tar -zxf wazuh-dashboard.tar.gz
+    directory_name=$(ls -t | head -1)
     rm wazuh-dashboard.tar.gz
     mv $directory_name wazuh-dashboard-base
     jq '.wazuh.revision="'${revision}'"' wazuh-dashboard-base/package.json > pkgtmp.json && mv pkgtmp.json wazuh-dashboard-base/package.json

--- a/dev-tools/build-packages/rpm/launcher.sh
+++ b/dev-tools/build-packages/rpm/launcher.sh
@@ -82,8 +82,8 @@ build_rpm() {
     echo
 
     # Prepare the package
-    directory_name=$(tar tf wazuh-dashboard.tar.gz | head -1 | sed 's#/.*##' | sort -u)
     tar -zxf wazuh-dashboard.tar.gz
+    directory_name=$(ls -t | head -1)
     rm wazuh-dashboard.tar.gz
     mv $directory_name wazuh-dashboard-base
     jq '.wazuh.revision="'${revision}'"' wazuh-dashboard-base/package.json > pkgtmp.json && mv pkgtmp.json wazuh-dashboard-base/package.json


### PR DESCRIPTION
### Description

This PR aims to fix a tar error that is visible when running the package build workflow. 

Additionally, it adds error controls to abort the building process if a plugin is not correctly installed


### Issues Resolved
#167 

### Evidence
Now the workflow fails if a plugin is not correctly installed, and the stdout error is no longer present
![image](https://github.com/wazuh/wazuh-dashboard/assets/42900763/192214dc-4ced-4c28-9ab6-510644f5c0c0)


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
