### PR TITLE
Add ID input to workflows

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -1,4 +1,4 @@
-name: Build packages
+name: Build packages ${{ inputs.id }}
 
 on:
   workflow_dispatch:
@@ -44,6 +44,10 @@ on:
         description: 'Generate package checksum'
         required: true
         default: false
+      id:
+        description: "ID used to identify the workflow uniquely."
+        type: string
+        required: false
 
 jobs:
   validate-inputs:

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -49,6 +49,40 @@ on:
         type: string
         required: false
 
+  workflow_call:
+    inputs:
+      system:
+        type: string
+        required: true
+        default: 'deb'
+      architecture:
+        type: string
+        required: true
+        default: amd64
+      revision:
+        type: string
+        required: true
+        default: '0'
+      reference_security_plugins:
+        type: string
+        required: true
+        default: 'master'
+      reference_wazuh_plugins:
+        type: string
+        required: true
+        default: 'master'
+      is_stage:
+        type: boolean
+        required: true
+        default: false
+      checksum:
+        type: boolean
+        required: true
+        default: false
+      id:
+        type: string
+        required: false
+
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -1,4 +1,4 @@
-name: Build packages ${{ inputs.id }}
+run-name: Build packages ${{ inputs.id }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description

This PR adds the `id` input to the packages generation workflows so the workflow can be identified with a unique string

The workflow can be executed with or without the input, as it is not required

Tests: 
- https://github.com/wazuh/wazuh-jenkins/issues/6371#issuecomment-2115914391
- https://github.com/wazuh/wazuh-dashboard/actions/runs/9117577629 without ID
- https://github.com/wazuh/wazuh-dashboard/actions/runs/9117577607 without ID
- https://github.com/wazuh/wazuh-dashboard/actions/runs/9117563903 with ID
- https://github.com/wazuh/wazuh-dashboard/actions/runs/9117563782 with ID

Package error reported at https://github.com/wazuh/wazuh-dashboard/issues/180