### PR TITLE
Fix error generating packages in branches that contain `/`

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] #Removed 'windows-latest'
-        group: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 13]
+        group: [1, 2, 4, 6, 7, 8, 9, 10, 11, 13]
         include:
           - os: ubuntu-latest
             name: Linux

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -27,8 +27,8 @@ jobs:
         working-directory: ./artifacts
     strategy:
       matrix:
-        DISTRIBUTION: [ tar.gz ]
-        ARCHITECTURE: [ x64 ]
+        DISTRIBUTION: [tar.gz]
+        ARCHITECTURE: [x64]
 
     steps:
       - name: Checkout code
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get artifact build name
         run: |
-          echo "ARTIFACT_BUILD_NAME=wazuh-dashboard_${{ env.WZD_VERSION }}-${{ env.WZD_REVISION }}_${{ matrix.ARCHITECTURE }}_${{ inputs.CHECKOUT_TO }}.${{ matrix.DISTRIBUTION }}" >> $GITHUB_ENV
+          echo "ARTIFACT_BUILD_NAME=wazuh-dashboard_${{ env.WZD_VERSION }}-${{ env.WZD_REVISION }}_${{ matrix.ARCHITECTURE }}.${{ matrix.DISTRIBUTION }}" >> $GITHUB_ENV
 
       - name: Run bootstrap
         run: yarn osd bootstrap

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -45,7 +45,7 @@ on:
         required: true
         default: false
       id:
-        description: "ID used to identify the workflow uniquely."
+        description: 'ID used to identify the workflow uniquely.'
         type: string
         required: false
 
@@ -146,7 +146,7 @@ jobs:
 
       - name: Setup packages names
         run: |
-          echo "WAZUH_DASHBOARD_SLIM=wazuh-dashboard_${{ env.VERSION }}-${{ env.REVISION }}_x64_${{ github.head_ref || github.ref_name }}.tar.gz" >> $GITHUB_ENV
+          echo "WAZUH_DASHBOARD_SLIM=wazuh-dashboard_${{ env.VERSION }}-${{ env.REVISION }}_x64_.tar.gz" >> $GITHUB_ENV
           echo "WAZUH_SECURITY_PLUGIN=wazuh-security-dashboards-plugin_${{ env.VERSION }}-${{ env.REVISION }}_${{ inputs.reference_security_plugins }}.zip" >> $GITHUB_ENV
           echo "WAZUH_PLUGINS=wazuh-dashboard-plugins_${{ env.VERSION }}-${{ env.REVISION }}_${{ inputs.reference_wazuh_plugins }}.zip" >> $GITHUB_ENV
           if [ "${{ inputs.system }}" = "deb" ]; then

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -102,7 +102,7 @@ jobs:
   build-base:
     needs: [validate-inputs]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@bug/package-generation-branch-with-slash
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.9.0
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
 

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Setup packages names
         run: |
-          echo "WAZUH_DASHBOARD_SLIM=wazuh-dashboard_${{ env.VERSION }}-${{ env.REVISION }}_x64_.tar.gz" >> $GITHUB_ENV
+          echo "WAZUH_DASHBOARD_SLIM=wazuh-dashboard_${{ env.VERSION }}-${{ env.REVISION }}_x64.tar.gz" >> $GITHUB_ENV
           echo "WAZUH_SECURITY_PLUGIN=wazuh-security-dashboards-plugin_${{ env.VERSION }}-${{ env.REVISION }}_${{ inputs.reference_security_plugins }}.zip" >> $GITHUB_ENV
           echo "WAZUH_PLUGINS=wazuh-dashboard-plugins_${{ env.VERSION }}-${{ env.REVISION }}_${{ inputs.reference_wazuh_plugins }}.zip" >> $GITHUB_ENV
           if [ "${{ inputs.system }}" = "deb" ]; then

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -102,7 +102,7 @@ jobs:
   build-base:
     needs: [validate-inputs]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.9.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@bug/package-generation-branch-with-slash
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
 

--- a/dev-tools/test-packages/deb/Dockerfile
+++ b/dev-tools/test-packages/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 ARG PACKAGE
 RUN mkdir -p /tmp
 RUN apt-get update --fix-missing


### PR DESCRIPTION
### Description

This PR fixes the package generation procedure, which failed when the branch contained a `/`

### Issues Resolved

#180 


### Evidence

Workflow successfully completed using a branch named `bug/package-generation-branch-with-slash`

https://github.com/wazuh/wazuh-dashboard/actions/runs/9161475445

For that test, I had to replace a reference that otherwise would point to 4.9.0. After testing, I set the reference back to its original name. 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
