### PR TITLE
Added S3 URI output to package generation upload

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -217,7 +217,14 @@ jobs:
         run: |
           echo "Uploading package"
           aws s3 cp  ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-          if [ "${{ inputs.checksum }}" = "true" ]; then
-            echo "Uploading checksum"
-            aws s3 cp  ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-          fi
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{env.PACKAGE_NAME}}"
+          echo "S3 URI: ${s3uri}"
+
+
+      - name: Upload SHA512
+        if: ${{ inputs.checksum }}
+        run: |
+          echo "Uploading checksum"
+          aws s3 cp ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{env.PACKAGE_NAME}}.sha512"
+          echo "S3 sha512 URI: ${s3uri}"


### PR DESCRIPTION
### Description

This PR adds an S3 URI output in the Wazuh dashboard package generation to comply with an objective requisite
This output is standardized and used on all package generation workflows
This output is used by the stage generation script to obtain the S3 object URI
This PR also improves the checksum upload

### Issues Related

- https://github.com/wazuh/wazuh-jenkins/issues/6371

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

### Workflow functionality

- https://github.com/wazuh/wazuh-dashboard/actions/runs/9372989192
- https://github.com/wazuh/wazuh-dashboard/actions/runs/9372989188

```
 Completed 166.1 MiB/166.1 MiB (98.3 MiB/s) with 1 file(s) remaining 
upload: dev-tools/build-packages/output/deb/wazuh-dashboard_4.9.0-99_amd64.deb to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-dashboard_4.9.0-99_amd64.deb
S3 URI: s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-dashboard_4.9.0-99_amd64.deb

Run echo "Uploading checksum"
Uploading checksum
Completed 165 Bytes/165 Bytes (481 Bytes/s) with 1 file(s) remaining
upload: dev-tools/build-packages/output/deb/wazuh-dashboard_4.9.0-99_amd64.deb.sha512 to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-dashboard_4.9.0-99_amd64.deb.sha512
S3 sha512 URI: s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-dashboard_4.9.0-99_amd64.deb.sha512
```