### PR TITLE
Change GitHub action version 4.9.0 reference to alpha1 tag

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -103,21 +103,21 @@ jobs:
   build-base:
     needs: [validate-inputs]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.9.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.9.0-alpha1
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
 
   build-main-plugins:
     needs: [validate-inputs]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.9.0
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.9.0-alpha1
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-inputs]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.9.0
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.9.0-alpha1
     with:
       reference: ${{ inputs.reference_security_plugins }}
 


### PR DESCRIPTION
### Description

This PR changes the build Github action reference to use v4.9.0-alpha1 tag.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
