### PR TITLE
Add setcap for node fallback

### DIFF
--- a/dev-tools/build-packages/deb/debian/postinst
+++ b/dev-tools/build-packages/deb/debian/postinst
@@ -25,6 +25,7 @@ configure)
     chmod 750 "${TARGET_DIR}""${INSTALLATION_DIR}"
     chown -R "${NAME}":"${NAME}" "${TARGET_DIR}""${INSTALLATION_DIR}"
     setcap 'cap_net_bind_service=+ep' "${INSTALLATION_DIR}"/node/bin/node
+    setcap 'cap_net_bind_service=+ep' "${INSTALLATION_DIR}"/node/fallback/bin/node
     if [ -f "${INSTALLATION_DIR}"/"${NAME}".restart ]; then
         rm -f "${INSTALLATION_DIR}"/"${NAME}".restart
         if command -v systemctl >/dev/null 2>&1 && systemctl >/dev/null 2>&1; then

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -125,6 +125,7 @@ fi
 
 %post
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/bin/node
+setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/fallback/bin/node
 
 if [ ! -f %{INSTALLATION_DIR}/config/opensearch_dashboards.keystore ]; then
   runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1


### PR DESCRIPTION
### Description

This PR fixes compatibility with certain operating systems that require older versions of node.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/223

### Test
1. Generate wazuh-dashboard rpm package by followign this [documentation](https://github.com/wazuh/wazuh-documentation/blob/v4.9.0-alpha1/source/development/packaging/generate-dashboard-package.rst).
2. Create Vagrant box: `bento/amazonlinux-2`
3. Perform step by step installation with these [considerations](https://docs.google.com/document/d/1fW8koy8P8OMvcxzIOXWGDw9qmKlju-XuRHD-Bdv3uP4/edit)(v4.9.0).
  - In the Dashboard installation use the generated package:
```
yum -y install [package_name]
```
4. Wait around 10 seconds. Check the Wazuh dashboard status with
```
systemctl status wazuh-dashboard.
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
