### PR TITLE
Fix home logo link

### DIFF
--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -252,7 +252,7 @@ export class ChromeService {
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}
-          homeHref={http.basePath.prepend('/app/wz-home')}
+          homeHref={http.basePath.prepend('/wz-home')}
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getWazuhVersion()}
           navLinks$={navLinks.getNavLinks$()}


### PR DESCRIPTION
### Description

This PR addresses the issue where the home logo link in the top bar contains a repeated app, causing the application to not load correctly when opened in a new tab. The link has been corrected to ensure the application loads correctly in all scenarios.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/228

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
