### PR TITLE
Fix 4.9.0 alpha2 build package GHA

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -103,21 +103,21 @@ jobs:
   build-base:
     needs: [validate-inputs]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.9.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.9.0-alpha2
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
 
   build-main-plugins:
     needs: [validate-inputs]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.9.0
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.9.0-alpha2
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-inputs]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.9.0
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.9.0-alpha2
     with:
       reference: ${{ inputs.reference_security_plugins }}
 


### PR DESCRIPTION
### Description
This pull request fixes the tag on the GHA build workflow.

### Issues Resolved
#235

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] Commits are signed per the DCO using --signoff
