### PR TITLE
Restore the original home icon size

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3573,7 +3573,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                                         class="logoImage"
                                         data-euiicon-type="/ui/logos/wazuh_mark_on_light.svg"
                                         data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-                                        data-test-subj="homeIcon"
+                                        data-test-subj="defaultMark"
                                         title="Wazuh dashboards home"
                                       />
                                     </div>
@@ -3702,8 +3702,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                                       <EuiIcon
                                         className="logoImage"
                                         data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-                                        data-test-subj="homeIcon"
-                                        size="m"
+                                        data-test-subj="defaultMark"
+                                        size="l"
                                         title="Wazuh dashboards home"
                                         type="/ui/logos/wazuh_mark_on_light.svg"
                                       >
@@ -3711,8 +3711,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                                           className="logoImage"
                                           data-euiicon-type="/ui/logos/wazuh_mark_on_light.svg"
                                           data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-                                          data-test-subj="homeIcon"
-                                          size="m"
+                                          data-test-subj="defaultMark"
+                                          size="l"
                                           title="Wazuh dashboards home"
                                         />
                                       </EuiIcon>
@@ -9111,7 +9111,7 @@ exports[`Header renders condensed header 1`] = `
                                         class="logoImage"
                                         data-euiicon-type="/ui/logos/wazuh_mark_on_light.svg"
                                         data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-                                        data-test-subj="homeIcon"
+                                        data-test-subj="defaultMark"
                                         title="Wazuh dashboards home"
                                       />
                                     </div>
@@ -9244,8 +9244,8 @@ exports[`Header renders condensed header 1`] = `
                                       <EuiIcon
                                         className="logoImage"
                                         data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-                                        data-test-subj="homeIcon"
-                                        size="m"
+                                        data-test-subj="defaultMark"
+                                        size="l"
                                         title="Wazuh dashboards home"
                                         type="/ui/logos/wazuh_mark_on_light.svg"
                                       >
@@ -9253,8 +9253,8 @@ exports[`Header renders condensed header 1`] = `
                                           className="logoImage"
                                           data-euiicon-type="/ui/logos/wazuh_mark_on_light.svg"
                                           data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-                                          data-test-subj="homeIcon"
-                                          size="m"
+                                          data-test-subj="defaultMark"
+                                          size="l"
                                           title="Wazuh dashboards home"
                                         />
                                       </EuiIcon>

--- a/src/core/public/chrome/ui/header/__snapshots__/home_icon.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/home_icon.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`Home icon, unbranded, uses the mark logo when header is not expanded 1`
 <EuiIcon
   className="logoImage"
   data-test-image-url="/ui/logos/wazuh_mark_on_light.svg"
-  data-test-subj="homeIcon"
-  size="m"
+  data-test-subj="defaultMark"
+  size="l"
   title="Wazuh dashboards home"
   type="/ui/logos/wazuh_mark_on_light.svg"
 />

--- a/src/core/public/chrome/ui/header/home_icon.test.tsx
+++ b/src/core/public/chrome/ui/header/home_icon.test.tsx
@@ -18,7 +18,12 @@ describe('Home icon,', () => {
     });
 
     it('uses the home icon by default', () => {
-      const props = mockProps();
+      const props = {
+        ...mockProps(),
+        branding: {
+          useExpandedHeader: true,
+        },
+      };
       const component = shallow(<HomeIcon {...props} />);
       const icon = component.find('EuiIcon');
       expect(icon.prop('data-test-subj')).toEqual('homeIcon');
@@ -53,9 +58,9 @@ describe('Home icon,', () => {
       };
       const component = shallow(<HomeIcon {...props} />);
       const icon = component.find('EuiIcon');
-      expect(icon.prop('data-test-subj')).toEqual('homeIcon');
+      expect(icon.prop('data-test-subj')).toEqual('defaultMark');
       expect(icon.prop('type')).toEqual(props.logos.Mark.url);
-      expect(icon.prop('size')).toEqual('m');
+      expect(icon.prop('size')).toEqual('l');
       expect(icon.prop('title')).toEqual('Wazuh dashboards home');
 
       expect(component).toMatchSnapshot();

--- a/src/core/public/chrome/ui/header/home_icon.tsx
+++ b/src/core/public/chrome/ui/header/home_icon.tsx
@@ -18,7 +18,7 @@ interface Props {
  */
 export const HomeIcon = ({ branding, logos }: Props) => {
   // Removed prop unnecessary useExpandedHeader Wazuh dashboards
-  const { applicationTitle = 'Wazuh dashboards' } = branding;
+  const { applicationTitle = 'Wazuh dashboards', useExpandedHeader } = branding;
 
   const { url: markURL, type: markType } = logos.Mark;
 
@@ -27,7 +27,7 @@ export const HomeIcon = ({ branding, logos }: Props) => {
   let markIconSize: IconSize = 'l';
 
   // If no custom branded mark was set, use `home` icon Wazuh dashboards
-  if (markType !== 'custom') {
+  if (markType !== 'custom' && useExpandedHeader) {
     testSubj = 'homeIcon';
     // Home icon should be medium to fit in with other icons
     markIconSize = 'm';


### PR DESCRIPTION
### Description

Return the home icon to the size it had in previous versions.

### Issues Resolved

- #242

## Changelog

It checks if the expanded headers are enabled or not as opensearch does.

https://github.com/opensearch-project/OpenSearch-Dashboards/blob/2.13.0/src/core/public/chrome/ui/header/home_icon.tsx#L30

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
