### PR TITLE
Corrections to indexer management and dashboard management in the left menu

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -2,24 +2,24 @@ version: "3.9"
 
 services:
   # Runs the bootstrap and exits
-  # installer:
-  #   image: node:${NODE_VERSION}
-  #   container_name: installer-${OPENSEARCH_VERSION}
-  #   volumes:
-  #     - ${REPO_PATH}:/home/node/app
-  #   user: "1000:1000"
-  #   working_dir: /home/node/app
-  #   command: >
-  #     /bin/bash -c "
-  #       yarn osd bootstrap
-  #     "
+  installer:
+    image: node:${NODE_VERSION}
+    container_name: installer-${OPENSEARCH_VERSION}
+    volumes:
+      - ${REPO_PATH}:/home/node/app
+    user: "1000:1000"
+    working_dir: /home/node/app
+    command: >
+      /bin/bash -c "
+        yarn osd bootstrap
+      "
 
   wazuh-dashboard:
     image: node:${NODE_VERSION}
     container_name: wazuh-dashboard-${OPENSEARCH_VERSION}
-    # depends_on:
-    #   installer:
-    #     condition: service_completed_successfully
+    depends_on:
+      installer:
+        condition: service_completed_successfully
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601
     expose:

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -2,24 +2,24 @@ version: "3.9"
 
 services:
   # Runs the bootstrap and exits
-  installer:
-    image: node:${NODE_VERSION}
-    container_name: installer-${OPENSEARCH_VERSION}
-    volumes:
-      - ${REPO_PATH}:/home/node/app
-    user: "1000:1000"
-    working_dir: /home/node/app
-    command: >
-      /bin/bash -c "
-        yarn osd bootstrap
-      "
+  # installer:
+  #   image: node:${NODE_VERSION}
+  #   container_name: installer-${OPENSEARCH_VERSION}
+  #   volumes:
+  #     - ${REPO_PATH}:/home/node/app
+  #   user: "1000:1000"
+  #   working_dir: /home/node/app
+  #   command: >
+  #     /bin/bash -c "
+  #       yarn osd bootstrap
+  #     "
 
   wazuh-dashboard:
     image: node:${NODE_VERSION}
     container_name: wazuh-dashboard-${OPENSEARCH_VERSION}
-    depends_on:
-      installer:
-        condition: service_completed_successfully
+    # depends_on:
+    #   installer:
+    #     condition: service_completed_successfully
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601
     expose:

--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -239,7 +239,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
           "category": Object {
             "euiIconType": "managementApp",
             "id": "management",
-            "label": "Index management",
+            "label": "Indexer management",
             "order": 5000,
           },
           "data-test-subj": "monitoring",
@@ -1592,7 +1592,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               isCollapsible={true}
               key="management"
               onToggle={[Function]}
-              title="Index management"
+              title="Indexer management"
             >
               <EuiAccordion
                 arrowDisplay="right"
@@ -1619,7 +1619,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                           className="euiCollapsibleNavGroup__title"
                           id="mockId__title"
                         >
-                          Index management
+                          Indexer management
                         </h3>
                       </EuiTitle>
                     </EuiFlexItem>
@@ -1706,7 +1706,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                                     className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
                                     id="mockId__title"
                                   >
-                                    Index management
+                                    Indexer management
                                   </h3>
                                 </EuiTitle>
                               </div>
@@ -1734,7 +1734,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                             className="euiCollapsibleNavGroup__children"
                           >
                             <EuiListGroup
-                              aria-label="Primary navigation links, Index management"
+                              aria-label="Primary navigation links, Indexer management"
                               color="subdued"
                               gutterSize="none"
                               listItems={
@@ -1753,7 +1753,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                               size="s"
                             >
                               <ul
-                                aria-label="Primary navigation links, Index management"
+                                aria-label="Primary navigation links, Indexer management"
                                 className="euiListGroup"
                                 style={
                                   Object {

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -78,13 +78,13 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze
     label: i18n.translate('core.ui.dashboardManagementNavList.label', {
       defaultMessage: 'Dashboard management',
     }),
-    order: 700,
+    order: 6000,
     euiIconType: 'dashboardApp',
   },
   management: {
     id: 'management',
     label: i18n.translate('core.ui.managementNavList.label', {
-      defaultMessage: 'Index management',
+      defaultMessage: 'Indexer management',
     }),
     order: 5000,
     euiIconType: 'managementApp',

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -81,6 +81,7 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze
     order: 6000,
     euiIconType: 'dashboardApp',
   },
+  
   management: {
     id: 'management',
     label: i18n.translate('core.ui.managementNavList.label', {

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -81,7 +81,6 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze
     order: 6000,
     euiIconType: 'dashboardApp',
   },
-  
   management: {
     id: 'management',
     label: i18n.translate('core.ui.managementNavList.label', {

--- a/src/plugins/console/public/application/components/import_flyout.test.tsx
+++ b/src/plugins/console/public/application/components/import_flyout.test.tsx
@@ -111,8 +111,8 @@ describe('ImportFlyout Component', () => {
     component.update();
 
     await act(async () => {
-      await nextTick();
       component.find(confirmBtnIdentifier).first().simulate('click');
+      await nextTick();
     });
 
     component.update();


### PR DESCRIPTION
### Description

This PR resolves:

- Fix wrong order of `Indexer management` and `Dashboard management` app category on the left-side menu.
- Fix wrong app category name `Index management` to `Indexer management` on the left-side menu.

### Evidence

<img width="1790" alt="image" src="https://github.com/user-attachments/assets/0d758c2c-b21d-4d21-9ff2-29c59c463b14">

### Issues Resolved

[6823](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6823)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
