### PR TITLE
Remove setting new home

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -343,11 +343,7 @@
 
 # Set the value to true to enable workspace feature
 # Please note, workspace will not work with multi-tenancy. To enable workspace feature, you need to disable multi-tenancy first with `opensearch_security.multitenancy.enabled: false`
-# Please uncomment below uiSettings to enable new home/navigation experience when workspace is enabled
 # workspace.enabled: false
-# uiSettings:
-#   overrides:
-#     "home:useNewHomePage": true
 
 # Optional settings to specify saved object types to be deleted during migration.
 # This feature can help address compatibility issues that may arise during the migration of saved objects, such as types defined by legacy applications.

--- a/src/plugins/home/public/application/components/home_app.js
+++ b/src/plugins/home/public/application/components/home_app.js
@@ -36,8 +36,8 @@ import { FeatureDirectory } from './feature_directory';
 import { HashRouter as Router, Switch, Route } from 'react-router-dom';
 import { getServices } from '../opensearch_dashboards_services';
 import { useMount } from 'react-use';
-import { USE_NEW_HOME_PAGE, HOME_PAGE_ID } from '../../../common/constants';
-
+// import { USE_NEW_HOME_PAGE, HOME_PAGE_ID } from '../../../common/constants';
+import { HOME_PAGE_ID } from '../../../common/constants';
 const RedirectToDefaultApp = () => {
   useMount(() => {
     const { urlForwarding } = getServices();
@@ -52,7 +52,7 @@ export function HomeApp({ directories, solutions }) {
     getBasePath,
     addBasePath,
     telemetry,
-    uiSettings,
+    // uiSettings,
     contentManagement,
   } = getServices();
 
@@ -77,7 +77,10 @@ export function HomeApp({ directories, solutions }) {
           <Route exact path="/feature_directory">
             <FeatureDirectory addBasePath={addBasePath} directories={directories} />
           </Route>
-          {uiSettings.get(USE_NEW_HOME_PAGE) ? (
+          {/*
+          Wazuh: The check whether the new activated menu is enabled or not is removed,
+          since we remove the option to activate it until it is working correctly.
+           {uiSettings.get(USE_NEW_HOME_PAGE) ? (
             <>
               <Route exact path="/legacy-home">
                 {legacyHome}
@@ -86,16 +89,16 @@ export function HomeApp({ directories, solutions }) {
                 {homepage}
               </Route>
             </>
-          ) : (
-            <>
-              <Route exact path="/next-home">
-                {homepage}
-              </Route>
-              <Route exact path="/">
-                {legacyHome}
-              </Route>
-            </>
-          )}
+          ) : ( */}
+          <>
+            <Route exact path="/next-home">
+              {homepage}
+            </Route>
+            <Route exact path="/">
+              {legacyHome}
+            </Route>
+          </>
+          {/* )} */}
           <Route path="*" exact={true} component={RedirectToDefaultApp} />
         </Switch>
       </Router>

--- a/src/plugins/home/server/ui_settings.ts
+++ b/src/plugins/home/server/ui_settings.ts
@@ -15,7 +15,10 @@ import { schema } from '@osd/config-schema';
 import { UiSettingsParams } from 'opensearch-dashboards/server';
 import { USE_NEW_HOME_PAGE } from '../common/constants';
 
-export const uiSettings: Record<string, UiSettingsParams> = {
+// Wazuh: Remove the new home page configuration for now because it is not ready yet.
+// To add it again it must be exported
+// export const uiSettings: Record<string, UiSettingsParams> = {
+const uiSettings: Record<string, UiSettingsParams> = {
   [USE_NEW_HOME_PAGE]: {
     name: i18n.translate('core.ui_settings.params.useNewHomePage', {
       defaultMessage: 'Use New Home Page',


### PR DESCRIPTION
### Description

The setting to configure the new home page is deleted because it is not finished and has some errors to use it at the moment.

### Issues Resolved

- #280 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [c] Commits are signed per the DCO using --signoff
