### PR TITLE
Modify link to sample data in the section dashboards and references to opensearch dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh dashboard v4.9.1 - OpenSearch Dashboards 2.13.0 - Revision 00
+
+### Added
+
+- Support for Wazuh 4.9.1
+
+### Changed
+
+- Changed link to sample data in the section dashboards and references to Opensearch Dashboards [#311](https://github.com/wazuh/wazuh-dashboard/pull/311)
+
 ## Wazuh dashboard v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 07
 
 ### Added
@@ -14,7 +24,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed default logos and main menu app categories [141](https://github.com/wazuh/wazuh-dashboard/pull/141)
 - Changed default value of useExpandedHeader to false [#247](https://github.com/wazuh/wazuh-dashboard/pull/247)
 - Changed build number to match the Wazuh standard [#284](https://github.com/wazuh/wazuh-dashboard/pull/284)
-- Changed link to sample data in the section dashboards and references to opensearch dashboards [#311](https://github.com/wazuh/wazuh-dashboard/pull/311)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed default logos and main menu app categories [141](https://github.com/wazuh/wazuh-dashboard/pull/141)
 - Changed default value of useExpandedHeader to false [#247](https://github.com/wazuh/wazuh-dashboard/pull/247)
 - Changed build number to match the Wazuh standard [#284](https://github.com/wazuh/wazuh-dashboard/pull/284)
+- Changed link to sample data in the section dashboards and references to opensearch dashboards [#311](https://github.com/wazuh/wazuh-dashboard/pull/311)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Changed link to sample data in the section dashboards and references to Opensearch Dashboards [#311](https://github.com/wazuh/wazuh-dashboard/pull/311)
+- Changed link to sample data in the dashboards section and references to Opensearch Dashboards [#311](https://github.com/wazuh/wazuh-dashboard/pull/311)
 
 ## Wazuh dashboard v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 07
 

--- a/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
@@ -8,6 +8,7 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { EuiButton, EuiEmptyPrompt, EuiLink } from '@elastic/eui';
 import { ApplicationStart } from 'opensearch-dashboards/public';
 
+const appName = 'Wazuh dashboard';
 export const getNoItemsMessage = (
   hideWriteControls: boolean,
   createItem: () => void,
@@ -45,14 +46,18 @@ export const getNoItemsMessage = (
           <p>
             <FormattedMessage
               id="dashboard.listing.createNewDashboard.combineDataViewFromOpenSearchDashboardsAppDescription"
-              defaultMessage="You can combine data views from any Wazuh Dashboards app into one dashboard and see everything in one place."
+              defaultMessage="You can combine data views from any {appName} app into one dashboard and see everything in one place."
+              values={{
+                appName,
+              }}
             />
           </p>
           <p>
             <FormattedMessage
               id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
-              defaultMessage="New to Wazuh Dashboards? {sampleDataInstallLink} to take a test drive."
+              defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
               values={{
+                appName,
                 sampleDataInstallLink: (
                   <EuiLink onClick={() => application.navigateToApp('sample-data')}>
                     <FormattedMessage

--- a/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
@@ -54,11 +54,7 @@ export const getNoItemsMessage = (
               defaultMessage="New to Wazuh Dashboards? {sampleDataInstallLink} to take a test drive."
               values={{
                 sampleDataInstallLink: (
-                  <EuiLink
-                    onClick={() =>
-                      application.navigateToApp('sample-data')
-                    }
-                  >
+                  <EuiLink onClick={() => application.navigateToApp('sample-data')}>
                     <FormattedMessage
                       id="dashboard.listing.createNewDashboard.sampleDataInstallLinkText"
                       defaultMessage="Install some sample data"

--- a/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
@@ -45,20 +45,18 @@ export const getNoItemsMessage = (
           <p>
             <FormattedMessage
               id="dashboard.listing.createNewDashboard.combineDataViewFromOpenSearchDashboardsAppDescription"
-              defaultMessage="You can combine data views from any OpenSearch Dashboards app into one dashboard and see everything in one place."
+              defaultMessage="You can combine data views from any Wazuh Dashboards app into one dashboard and see everything in one place."
             />
           </p>
           <p>
             <FormattedMessage
               id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
-              defaultMessage="New to OpenSearch Dashboards? {sampleDataInstallLink} to take a test drive."
+              defaultMessage="New to Wazuh Dashboards? {sampleDataInstallLink} to take a test drive."
               values={{
                 sampleDataInstallLink: (
                   <EuiLink
                     onClick={() =>
-                      application.navigateToApp('home', {
-                        path: '#/tutorial_directory/sampleData',
-                      })
+                      application.navigateToApp('sample-data')
                     }
                   >
                     <FormattedMessage


### PR DESCRIPTION
### Description

Modify link to sample data in the section dashboards and references to Opensearch dashboards

### Issues Resolved

#307 

## Evidence

https://github.com/user-attachments/assets/2329937d-8732-47c3-99c3-d7fca53f1952

### Test

In order to test this PR you must: 

From the `wazuh-dashboard` environment:

- Add this configuration to the `wazuh.yml` file: `checks.template: false`

- You must also mount as volume the plugins inside your `wazuh-dashboard` container in the `dev.yml` file:

  - ${REPO_PATH}:/home/node/kbn/plugins/wazuh
  - ${REPO_PATH}/home/node/kbn/plugins/wazuh-core
  - ${REPO_PATH}/home/node/kbn/plugins/wazuh-check-updates

From `wazuh-dashboard-plugins` environments raise a rel.sh environment:

- Set up a `rel` environment

- Comment out the `wazuh-dashboard` container

- Map the port in the container `wazuh-manager`:

  ```
  ports:
        - 55000:55000
  ```

Go to the side menu click on the Dashboards tab and verify:

- Verify that the link with the message “Install some sample data” redirects to sample data

- Verify that where it used to say Opensearch dashboards it now says Wazuh dashboards

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
