### PR TITLE
Terminal freezes on deb upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed link to sample data in the dashboards section and references to Opensearch Dashboards [#311](https://github.com/wazuh/wazuh-dashboard/pull/311)
 
+### Fixed
+
+- Fixed bug that caused the terminal to freeze on deb upgrades [#301](https://github.com/wazuh/wazuh-dashboard/pull/301)
+
 ## Wazuh dashboard v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 07
 
 ### Added

--- a/dev-tools/build-packages/deb/debian/postinst
+++ b/dev-tools/build-packages/deb/debian/postinst
@@ -35,7 +35,7 @@ configure)
             service wazuh-dashboard restart >/dev/null 2>&1
         fi
     fi
-    if [ ! -f "${INSTALLATION_DIR}"/config/opensearch_dashboards.keystore ]; then
+    if [ ! -f "${CONFIG_DIR}"/opensearch_dashboards.keystore ]; then
         runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create" >/dev/null 2>&1
         runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" >/dev/null 2>&1
         runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" >/dev/null 2>&1

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -130,7 +130,7 @@ fi
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/bin/node
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/fallback/bin/node
 
-if [ ! -f %{INSTALLATION_DIR}/config/opensearch_dashboards.keystore ]; then
+if [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
   runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/__snapshots__/dashboard_listing.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/__snapshots__/dashboard_listing.test.tsx.snap
@@ -2236,17 +2236,22 @@ exports[`dashboard listing render table listing with initial filters from URL 1`
                   <React.Fragment>
                     <p>
                       <FormattedMessage
-                        defaultMessage="You can combine data views from any OpenSearch Dashboards app into one dashboard and see everything in one place."
+                        defaultMessage="You can combine data views from any {appName} app into one dashboard and see everything in one place."
                         id="dashboard.listing.createNewDashboard.combineDataViewFromOpenSearchDashboardsAppDescription"
-                        values={Object {}}
+                        values={
+                          Object {
+                            "appName": "Wazuh dashboard",
+                          }
+                        }
                       />
                     </p>
                     <p>
                       <FormattedMessage
-                        defaultMessage="New to OpenSearch Dashboards? {sampleDataInstallLink} to take a test drive."
+                        defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
                         id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
                         values={
                           Object {
+                            "appName": "Wazuh dashboard",
                             "sampleDataInstallLink": <EuiLink
                               onClick={[Function]}
                             >
@@ -3440,17 +3445,22 @@ exports[`dashboard listing renders call to action when no dashboards exist 1`] =
                   <React.Fragment>
                     <p>
                       <FormattedMessage
-                        defaultMessage="You can combine data views from any OpenSearch Dashboards app into one dashboard and see everything in one place."
+                        defaultMessage="You can combine data views from any {appName} app into one dashboard and see everything in one place."
                         id="dashboard.listing.createNewDashboard.combineDataViewFromOpenSearchDashboardsAppDescription"
-                        values={Object {}}
+                        values={
+                          Object {
+                            "appName": "Wazuh dashboard",
+                          }
+                        }
                       />
                     </p>
                     <p>
                       <FormattedMessage
-                        defaultMessage="New to OpenSearch Dashboards? {sampleDataInstallLink} to take a test drive."
+                        defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
                         id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
                         values={
                           Object {
+                            "appName": "Wazuh dashboard",
                             "sampleDataInstallLink": <EuiLink
                               onClick={[Function]}
                             >
@@ -4644,17 +4654,22 @@ exports[`dashboard listing renders table rows 1`] = `
                   <React.Fragment>
                     <p>
                       <FormattedMessage
-                        defaultMessage="You can combine data views from any OpenSearch Dashboards app into one dashboard and see everything in one place."
+                        defaultMessage="You can combine data views from any {appName} app into one dashboard and see everything in one place."
                         id="dashboard.listing.createNewDashboard.combineDataViewFromOpenSearchDashboardsAppDescription"
-                        values={Object {}}
+                        values={
+                          Object {
+                            "appName": "Wazuh dashboard",
+                          }
+                        }
                       />
                     </p>
                     <p>
                       <FormattedMessage
-                        defaultMessage="New to OpenSearch Dashboards? {sampleDataInstallLink} to take a test drive."
+                        defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
                         id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
                         values={
                           Object {
+                            "appName": "Wazuh dashboard",
                             "sampleDataInstallLink": <EuiLink
                               onClick={[Function]}
                             >
@@ -5848,17 +5863,22 @@ exports[`dashboard listing renders warning when listingLimit is exceeded 1`] = `
                   <React.Fragment>
                     <p>
                       <FormattedMessage
-                        defaultMessage="You can combine data views from any OpenSearch Dashboards app into one dashboard and see everything in one place."
+                        defaultMessage="You can combine data views from any {appName} app into one dashboard and see everything in one place."
                         id="dashboard.listing.createNewDashboard.combineDataViewFromOpenSearchDashboardsAppDescription"
-                        values={Object {}}
+                        values={
+                          Object {
+                            "appName": "Wazuh dashboard",
+                          }
+                        }
                       />
                     </p>
                     <p>
                       <FormattedMessage
-                        defaultMessage="New to OpenSearch Dashboards? {sampleDataInstallLink} to take a test drive."
+                        defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
                         id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
                         values={
                           Object {
+                            "appName": "Wazuh dashboard",
                             "sampleDataInstallLink": <EuiLink
                               onClick={[Function]}
                             >


### PR DESCRIPTION
### Description

This PR fixes a problem that caused upgrades in `deb` environments to freeze the terminal until the user presses enter. The problem was also in `rpm` packages, but it didn't cause any terminal issues. 

### Issues Resolved

#301

## Test
### RPM
- Install a previous wazuh version

```bash
yum install libcap
rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages.wazuh.com/4.x/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo
yum -y install wazuh-dashboard
```

- Install the new package on top of it. Verify that the installation ends successfully, the terminal doesn't freeze and no errors are shown. 
```bash
yum localinstall <package>
```

### DEB
- Install a previous wazuh version

```bash
apt-get update
apt-get install debhelper tar curl libcap2-bin #debhelper version 9 or later
apt-get install gnupg apt-transport-https
curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
apt-get update
apt-get -y install wazuh-dashboard
```

- Install the new package on top of it. Verify that the installation ends successfully, the terminal doesn't freeze and no errors are shown. 

```bash
dpkg -i <package>
```
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
