### PR TITLE
Change order of menu sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Removed the setting home:useNewHomePage from the advanced settings because the views are not finished. [#282](https://github.com/wazuh/wazuh-dashboard/pull/282)
 
+### Changed
+
+- Changed the order of the “Dashboard management” and “Indexer management” sections.
+
 ## Wazuh dashboard v4.9.1 - OpenSearch Dashboards 2.13.0 - Revision 04
 
 ### Added

--- a/dev-tools/build-packages/base/generate_base.sh
+++ b/dev-tools/build-packages/base/generate_base.sh
@@ -148,7 +148,7 @@ build() {
 
     # Move installed plugins from categories after generating the package
     category_explore='{id:"explore",label:"Explore",order:100,euiIconType:"search"}'
-    category_dashboard_management='{id:"management",label:"Indexer management",order:5e3,euiIconType:"managementApp"}'
+    category_dashboard_management='{id:"management",label:"Indexer management",order:6e3,euiIconType:"managementApp"}'
 
     # Replace app category to Reporting app
     sed -i -e "s|category:{id:\"opensearch\",label:_i18n.i18n.translate(\"opensearch.reports.categoryName\",{defaultMessage:\"OpenSearch Plugins\"}),order:2e3}|category:${category_explore}|" ./plugins/reportsDashboards/target/public/reportsDashboards.plugin.js

--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
             "euiIconType": "managementApp",
             "id": "management",
             "label": "Indexer management",
-            "order": 5000,
+            "order": 6000,
           },
           "data-test-subj": "monitoring",
           "href": "monitoring",

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -78,7 +78,7 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze
     label: i18n.translate('core.ui.dashboardManagementNavList.label', {
       defaultMessage: 'Dashboard management',
     }),
-    order: 6000,
+    order: 5000,
     euiIconType: 'dashboardApp',
   },
   management: {
@@ -86,7 +86,7 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze
     label: i18n.translate('core.ui.managementNavList.label', {
       defaultMessage: 'Indexer management',
     }),
-    order: 5000,
+    order: 6000,
     euiIconType: 'managementApp',
   },
   investigate: {


### PR DESCRIPTION
### Description

Show the dashboard management section first and then the indexer management section.

### Issues Resolved



## Evidence

<img width="402" alt="Captura de pantalla 2024-10-18 a la(s) 5 32 07 p  m" src="https://github.com/user-attachments/assets/10a65420-a65b-4f33-b2eb-60dd946758ed">

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
