### PR TITLE
Reduced the loading logo size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh dashboard v4.10.0 - OpenSearch Dashboards 2.16.0 - Revision 03
 
+### Changed
+
+- Reduced the size of the loading logo [#373](https://github.com/wazuh/wazuh-dashboard/pull/373)
+
 ### Removed
 
 - Removed the setting home:useNewHomePage from the advanced settings because the views are not finished. [#282](https://github.com/wazuh/wazuh-dashboard/pull/282)

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -169,7 +169,7 @@ export const Styles: FunctionComponent<Props> = ({ theme, darkMode }) => {
           }
 
           .loadingLogoContainer {
-            height: 150px; /* Wazuh */
+            height: 100px; /* Wazuh */
             padding: 10px 10px 10px 10px;
           }
 


### PR DESCRIPTION
### Description
This pull request reduces the size of the loading logo container 33% of the previous size.

- Reduced the size of the loading logo container from 150px to 100px (height)

### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7102

### Evidences
![image](https://github.com/user-attachments/assets/fc160e73-935c-48f1-b87d-683d82f369b7)

### Test

# wd-pr-373

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Ensure the size of the loading logo is 100px of height | :black_circle: | :black_circle: | :black_circle: |

**Details**

<details>
<summary>:black_circle: Ensure the size of the loading logo is 100px of height</summary>

> How to test:
> 1. Download the branch `4.10.0` of `wazuh-security-dashboards-plugin`
> 2. Ensure/change the path of security plugin defined in the `SECURITY_PLUGIN_REPO_PATH` of `docker/dev.sh` file
> 3. Run the enviroment with security
> ```
> cd docker
> ./dev.sh up security

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
