### PR TITLE
Add commit sha of all repositories in package name

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -122,44 +122,23 @@ jobs:
     steps:
       - name: Get SHA of wazuh-dashboard-plugins
         id: get-plugins-sha
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const response = await github.repos.getBranch({
-              owner: 'wazuh',
-              repo: 'wazuh-dashboard-plugins',
-              branch: '${{ inputs.reference_wazuh_plugins }}'
-            });
-            return response.data.commit.sha;
-      - name: Set SHA environment variable
-        run: echo "WAZUH_PLUGINS_SHA=${{ steps.get-sha.outputs.result }}" 
+        run: |
+            git clone -b ${{ inputs.reference_wazuh_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboard-plugins.git wzdp
+            cd wzdp
+            echo "WAZUH_PLUGINS_SHA=$(git rev-parse --short HEAD)" 
       - name: Get SHA of wazuh-security-dashboards-plugin
         id: get-security-sha
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const response = await github.repos.getBranch({
-              owner: 'wazuh',
-              repo: 'wazuh-security-dashboards-plugin',
-              branch: '${{ inputs.reference_security_plugins }}'
-            });
-            return response.data.commit.sha;
-      - name: Set SHA environment variable
-        run: echo "WAZUH_SECURITY_SHA=${{ steps.get-sha.outputs.result }}"
+        run: |
+            git clone -b ${{ inputs.reference_security_plugins }} --single-branch https://github.com/wazuh/wazuh-security-dashboards-plugin.git wzsp
+            cd wzsp
+            echo "WAZUH_SECURITY_SHA=$(git rev-parse --short HEAD)" 
       - name: Get SHA of wazuh-dashboards-reporting
-        id: get-sha
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const response = await github.repos.getBranch({
-              owner: 'wazuh',
-              repo: 'wazuh-dashboards-reporting',
-              branch: '${{ inputs.reference_report_plugins }}'
-            });
-            return response.data.commit.sha;
-      - name: Set SHA environment variable
-        run: echo "WAZUH_REPORTING_SHA=${{ steps.get-sha.outputs.result }}" 
-             
+        id: get-reporting-sha
+        run: |
+            git clone -b ${{ inputs.reference_report_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboards-reporting.git wzrp
+            cd wzrp
+            echo "WAZUH_REPORTING_SHA=$(git rev-parse --short HEAD)"   
+            exit 1
 
         
   build-base:

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -125,20 +125,19 @@ jobs:
         run: |
             git clone -b ${{ inputs.reference_wazuh_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboard-plugins.git wzdp
             cd wzdp
-            echo "WAZUH_PLUGINS_SHA=$(git rev-parse --short HEAD)" 
+            echo "WAZUH_PLUGINS_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Get SHA of wazuh-security-dashboards-plugin
         id: get-security-sha
         run: |
             git clone -b ${{ inputs.reference_security_plugins }} --single-branch https://github.com/wazuh/wazuh-security-dashboards-plugin.git wzsp
             cd wzsp
-            echo "WAZUH_SECURITY_SHA=$(git rev-parse --short HEAD)" 
+            echo "WAZUH_SECURITY_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Get SHA of wazuh-dashboards-reporting
         id: get-reporting-sha
         run: |
             git clone -b ${{ inputs.reference_report_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboards-reporting.git wzrp
             cd wzrp
-            echo "WAZUH_REPORTING_SHA=$(git rev-parse --short HEAD)"   
-            exit 1
+            echo "WAZUH_REPORTING_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV    
 
         
   build-base:
@@ -203,13 +202,13 @@ jobs:
             if [ "${{ inputs.is_stage }}" = "true" ]; then
               echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}.deb" >> $GITHUB_ENV
             else
-              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}.deb" >> $GITHUB_ENV
+              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}-${{ env.WAZUH_PLUGINS_SHA}}-${{ env.WAZUH_SECURITY_SHA}}-${{ env.WAZUH_REPORTING_SHA}}.deb" >> $GITHUB_ENV
             fi
           else
             if [ "${{ inputs.is_stage }}" = "true" ]; then
               echo "PACKAGE_NAME=wazuh-dashboard-${{ env.VERSION }}-${{ inputs.revision }}.${{ inputs.architecture }}.rpm" >> $GITHUB_ENV
             else
-              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}.rpm" >> $GITHUB_ENV
+              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}-${{ env.WAZUH_PLUGINS_SHA}}-${{ env.WAZUH_SECURITY_SHA}}-${{ env.WAZUH_REPORTING_SHA}}.rpm" >> $GITHUB_ENV
             fi
           fi
 

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -146,7 +146,7 @@ jobs:
       reference: ${{ inputs.reference_report_plugins }}
 
   build-and-test-package:
-    needs: [build-main-plugins, build-base, build-security-plugin, build-report-plugin,get-shas]
+    needs: [build-main-plugins, build-base, build-security-plugin, build-report-plugin]
     runs-on: ubuntu-latest
     name: Generate packages
     steps:

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -116,29 +116,6 @@ jobs:
             exit 1
           fi
 
-  get-shas:
-    runs-on: ubuntu-latest
-    needs: [validate-inputs]
-    steps:
-      - name: Get SHA of wazuh-dashboard-plugins
-        id: get-plugins-sha
-        run: |
-            git clone -b ${{ inputs.reference_wazuh_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboard-plugins.git wzdp
-            cd wzdp
-            echo "WAZUH_PLUGINS_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: Get SHA of wazuh-security-dashboards-plugin
-        id: get-security-sha
-        run: |
-            git clone -b ${{ inputs.reference_security_plugins }} --single-branch https://github.com/wazuh/wazuh-security-dashboards-plugin.git wzsp
-            cd wzsp
-            echo "WAZUH_SECURITY_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: Get SHA of wazuh-dashboards-reporting
-        id: get-reporting-sha
-        run: |
-            git clone -b ${{ inputs.reference_report_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboards-reporting.git wzrp
-            cd wzrp
-            echo "WAZUH_REPORTING_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV    
-
         
   build-base:
     needs: [validate-inputs]
@@ -192,6 +169,25 @@ jobs:
             echo "PRODUCTION=--production" >> $GITHUB_ENV
           fi
 
+      - name: Get SHA of wazuh-dashboard-plugins
+        id: get-plugins-sha
+        run: |
+            git clone -b ${{ inputs.reference_wazuh_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboard-plugins.git wzdp
+            cd wzdp
+            echo "WAZUH_PLUGINS_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Get SHA of wazuh-security-dashboards-plugin
+        id: get-security-sha
+        run: |
+            git clone -b ${{ inputs.reference_security_plugins }} --single-branch https://github.com/wazuh/wazuh-security-dashboards-plugin.git wzsp
+            cd wzsp
+            echo "WAZUH_SECURITY_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Get SHA of wazuh-dashboards-reporting
+        id: get-reporting-sha
+        run: |
+            git clone -b ${{ inputs.reference_report_plugins }} --single-branch https://github.com/wazuh/wazuh-dashboards-reporting.git wzrp
+            cd wzrp
+            echo "WAZUH_REPORTING_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV    
+
       - name: Setup packages names
         run: |
           echo "WAZUH_DASHBOARD_SLIM=wazuh-dashboard_${{ env.VERSION }}-${{ env.REVISION }}_x64.tar.gz" >> $GITHUB_ENV
@@ -201,14 +197,18 @@ jobs:
           if [ "${{ inputs.system }}" = "deb" ]; then
             if [ "${{ inputs.is_stage }}" = "true" ]; then
               echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}.deb" >> $GITHUB_ENV
+              echo "FINAL_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}.deb" >> $GITHUB_ENV
             else
-              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}-${{ env.WAZUH_PLUGINS_SHA}}-${{ env.WAZUH_SECURITY_SHA}}-${{ env.WAZUH_REPORTING_SHA}}.deb" >> $GITHUB_ENV
+              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}.deb" >> $GITHUB_ENV
+              echo "FINAL_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}-${{ env.WAZUH_PLUGINS_SHA}}-${{ env.WAZUH_SECURITY_SHA}}-${{ env.WAZUH_REPORTING_SHA}}.deb" >> $GITHUB_ENV
             fi
           else
             if [ "${{ inputs.is_stage }}" = "true" ]; then
               echo "PACKAGE_NAME=wazuh-dashboard-${{ env.VERSION }}-${{ inputs.revision }}.${{ inputs.architecture }}.rpm" >> $GITHUB_ENV
+              echo "FINAL_NAME=wazuh-dashboard-${{ env.VERSION }}-${{ inputs.revision }}.${{ inputs.architecture }}.rpm" >> $GITHUB_ENV
             else
-              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}-${{ env.WAZUH_PLUGINS_SHA}}-${{ env.WAZUH_SECURITY_SHA}}-${{ env.WAZUH_REPORTING_SHA}}.rpm" >> $GITHUB_ENV
+              echo "PACKAGE_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}.rpm" >> $GITHUB_ENV
+              echo "FINAL_NAME=wazuh-dashboard_${{ env.VERSION }}-${{ inputs.revision }}_${{ inputs.architecture }}_${{ env.COMMIT_SHA}}-${{ env.WAZUH_PLUGINS_SHA}}-${{ env.WAZUH_SECURITY_SHA}}-${{ env.WAZUH_REPORTING_SHA}}.rpm" >> $GITHUB_ENV
             fi
           fi
 
@@ -263,11 +263,21 @@ jobs:
           bash ./test-packages.sh \
             -p ${{env.PACKAGE_NAME}}
 
+      - name: Set package final name
+        run: |
+          mv ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}} ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.FINAL_NAME}}
+      - name: Set SHA final name
+        if: ${{ inputs.checksum }}
+        run: |
+          mv ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}}.sha512 ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.FINAL_NAME}}.sha512
+       
+  
+     
       - uses: actions/upload-artifact@v3
         if: success()
         with:
           name: ${{ env.PACKAGE_NAME }}
-          path: ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}}
+          path: ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.FINAL_NAME}}
           retention-days: 30
 
       - name: Set up AWS CLI
@@ -282,14 +292,14 @@ jobs:
         if: ${{ inputs.upload }}
         run: |
           echo "Uploading package"
-          aws s3 cp  ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{env.PACKAGE_NAME}}"
+          aws s3 cp  ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.FINAL_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{env.FINAL_NAME}}"
           echo "S3 URI: ${s3uri}"
 
       - name: Upload SHA512
         if: ${{ inputs.upload && inputs.checksum }}
         run: |
           echo "Uploading checksum"
-          aws s3 cp ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{env.PACKAGE_NAME}}.sha512"
+          aws s3 cp ${{ env.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{env.FINAL_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{env.FINAL_NAME}}.sha512"
           echo "S3 sha512 URI: ${s3uri}"

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -116,6 +116,52 @@ jobs:
             exit 1
           fi
 
+  get-shas:
+    runs-on: ubuntu-latest
+    needs: [validate-inputs]
+    steps:
+      - name: Get SHA of wazuh-dashboard-plugins
+        id: get-plugins-sha
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const response = await github.repos.getBranch({
+              owner: 'wazuh',
+              repo: 'wazuh-dashboard-plugins',
+              branch: '${{ inputs.reference_wazuh_plugins }}'
+            });
+            return response.data.commit.sha;
+      - name: Set SHA environment variable
+        run: echo "WAZUH_PLUGINS_SHA=${{ steps.get-sha.outputs.result }}" 
+      - name: Get SHA of wazuh-security-dashboards-plugin
+        id: get-security-sha
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const response = await github.repos.getBranch({
+              owner: 'wazuh',
+              repo: 'wazuh-security-dashboards-plugin',
+              branch: '${{ inputs.reference_security_plugins }}'
+            });
+            return response.data.commit.sha;
+      - name: Set SHA environment variable
+        run: echo "WAZUH_SECURITY_SHA=${{ steps.get-sha.outputs.result }}"
+      - name: Get SHA of wazuh-dashboards-reporting
+        id: get-sha
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const response = await github.repos.getBranch({
+              owner: 'wazuh',
+              repo: 'wazuh-dashboards-reporting',
+              branch: '${{ inputs.reference_report_plugins }}'
+            });
+            return response.data.commit.sha;
+      - name: Set SHA environment variable
+        run: echo "WAZUH_REPORTING_SHA=${{ steps.get-sha.outputs.result }}" 
+             
+
+        
   build-base:
     needs: [validate-inputs]
     name: Build dashboard
@@ -145,7 +191,7 @@ jobs:
       reference: ${{ inputs.reference_report_plugins }}
 
   build-and-test-package:
-    needs: [build-main-plugins, build-base, build-security-plugin, build-report-plugin]
+    needs: [build-main-plugins, build-base, build-security-plugin, build-report-plugin,get-shas]
     runs-on: ubuntu-latest
     name: Generate packages
     steps:


### PR DESCRIPTION
### Description

This PR changes the package generation to add the sha of all the repositories in the package name

### Issues Resolved

#389 

## Screenshot
![imagen](https://github.com/user-attachments/assets/594afdb9-2f84-4c00-adb8-a810d4491ca1)

## Evidence
https://github.com/wazuh/wazuh-dashboard/actions/runs/11634349751


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
