### PR TITLE
Remove validation for duplicate packages

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -163,19 +163,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
           aws-region: ${{ secrets.CI_AWS_REGION }}
 
-
-      # - name: Verify if package is already built
-      #   run: |
-      #     set +e
-      #     echo "Verifying package"
-      #     PACKAGE_NAME=${{ needs.setup-variables.outputs.PACKAGE_NAME }}
-      #     exists=$(aws s3 ls s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/$PACKAGE_NAME)
-      #     if [ -n "$exists" ]; then
-      #       echo "Package already exists"
-      #       exit 1
-      #     fi
-      #     set -e
-
   build-base:
     needs: [validate-job]
     name: Build dashboard

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -163,17 +163,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
           aws-region: ${{ secrets.CI_AWS_REGION }}
 
-      - name: Verify if package is already built
-        run: |
-          set +e
-          echo "Verifying package"
-          PACKAGE_NAME=${{ needs.setup-variables.outputs.PACKAGE_NAME }}
-          exists=$(aws s3 ls s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/$PACKAGE_NAME)
-          if [ -n "$exists" ]; then
-            echo "Package already exists"
-            exit 1
-          fi
-          set -e
+
+      # - name: Verify if package is already built
+      #   run: |
+      #     set +e
+      #     echo "Verifying package"
+      #     PACKAGE_NAME=${{ needs.setup-variables.outputs.PACKAGE_NAME }}
+      #     exists=$(aws s3 ls s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/$PACKAGE_NAME)
+      #     if [ -n "$exists" ]; then
+      #       echo "Package already exists"
+      #       exit 1
+      #     fi
+      #     set -e
 
   build-base:
     needs: [validate-job]


### PR DESCRIPTION
### Description

This PR removes the validation that prevents generating a package if the package already was generated.


### Evidence

Workflows were launched to test the functionality
- `deb` package if it doesn't exist: https://github.com/wazuh/wazuh-dashboard/actions/runs/11783649696
- `deb` package if it already exist: https://github.com/wazuh/wazuh-dashboard/actions/runs/11784006245
- `rpm` package if it doesn't exist: https://github.com/wazuh/wazuh-dashboard/actions/runs/11783838627
- `rpm` package if it already exist: https://github.com/wazuh/wazuh-dashboard/actions/runs/11784370479

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
