### PR TITLE
Adds workflow retry if it fails

### DIFF
--- a/dev-tools/build-packages/build-packages.sh
+++ b/dev-tools/build-packages/build-packages.sh
@@ -81,6 +81,8 @@ get_packages(){
   cd ..
 }
 
+source ../utils/retry-operation.sh
+
 build_tar() {
   log
   log "Building base package..."
@@ -92,21 +94,12 @@ build_tar() {
   container_name="dashboard-base-builder"
   cp ./base-builder.sh ${dockerfile_path}
   cp ./plugins ${dockerfile_path}
-  for i in {1..5}; do
-    if docker build -t ${container_name} ${dockerfile_path} && \
-      docker run -t --rm \
-        -v ${tmp_dir}/:/tmp:Z \
-        -v ${output_dir}/:/output:Z \
-        ${container_name} ${version} ${revision} ${architecture} ${verbose}; then
-        break
-    else
-      if [ $i -eq 5 ]; then
-        echo "Failed to build the base package after 5 attempts"
-        exit 1
-      fi
-      sleep 15
-    fi
-  done
+  retry_operation "build base package" 5 15 \
+        "docker build -t ${container_name} ${dockerfile_path} && \
+         docker run -t --rm \
+         -v ${tmp_dir}/:/tmp:Z \
+         -v ${output_dir}/:/output:Z \
+         ${container_name} ${version} ${revision} ${architecture} ${verbose}" || exit 1
   cd ..
 }
 
@@ -118,22 +111,13 @@ build_rpm() {
   cp -r ${package_config_dir} ${tmp_dir}
   cp ./rpm-builder.sh ${dockerfile_path}
   cp ./wazuh-dashboard.spec ${dockerfile_path}
-  for i in {1..5}; do
-    if docker build -t ${container_name} ${dockerfile_path} && \
-      docker run -t --rm \
+  retry_operation "build rpm package" 5 15 \
+      "docker build -t ${container_name} ${dockerfile_path} && \
+        docker run -t --rm \
         -v ${tmp_dir}/:/tmp:Z \
         -v ${output_dir}/:/output:Z \
         ${container_name} ${version} ${revision} ${architecture} \
-        ${commit_sha} ${production} ${verbose}; then
-        break
-    else
-      if [ $i -eq 5 ]; then
-        echo "Failed to build the rpm package after 5 attempts"
-        exit 1
-      fi
-      sleep 15
-    fi
-  done
+        ${commit_sha} ${production} ${verbose}" || exit 1
   cd ../
 }
 
@@ -147,22 +131,13 @@ build_deb() {
   cp ./deb-builder.sh ${dockerfile_path}
   cp -r ./debian ${dockerfile_path}
   docker build -t ${container_name} ${dockerfile_path} || return 1
-  for i in {1..5}; do
-    if docker build -t ${container_name} ${dockerfile_path} && \
-      docker run -t --rm \
-        -v ${tmp_dir}/:/tmp:Z \
-        -v ${output_dir}/:/output:Z \
-        ${container_name} ${version} ${revision} ${architecture} \
-        ${commit_sha} ${production} ${verbose}; then
-        break
-    else
-      if [ $i -eq 5 ]; then
-        echo "Failed to build the deb package after 5 attempts"
-        exit 1
-      fi
-      sleep 15
-    fi
-  done
+  retry_operation "build deb package" 5 15 \
+        "docker build -t ${container_name} ${dockerfile_path} && \
+         docker run -t --rm \
+         -v ${tmp_dir}/:/tmp:Z \
+         -v ${output_dir}/:/output:Z \
+         ${container_name} ${version} ${revision} ${architecture} \
+         ${commit_sha} ${production} ${verbose}" || exit 1
   cd ..
 }
 

--- a/dev-tools/build-packages/build-packages.sh
+++ b/dev-tools/build-packages/build-packages.sh
@@ -92,9 +92,21 @@ build_tar() {
   container_name="dashboard-base-builder"
   cp ./base-builder.sh ${dockerfile_path}
   cp ./plugins ${dockerfile_path}
-  docker build -t ${container_name} ${dockerfile_path} || return 1
-  docker run -t --rm -v ${tmp_dir}/:/tmp:Z -v ${output_dir}/:/output:Z\
-  ${container_name} ${version} ${revision} ${architecture} ${verbose}|| return 1
+  for i in {1..5}; do
+    if docker build -t ${container_name} ${dockerfile_path} && \
+      docker run -t --rm \
+        -v ${tmp_dir}/:/tmp:Z \
+        -v ${output_dir}/:/output:Z \
+        ${container_name} ${version} ${revision} ${architecture} ${verbose}; then
+        break
+    else
+      if [ $i -eq 5 ]; then
+        echo "Failed to build the base package after 5 attempts"
+        exit 1
+      fi
+      sleep 15
+    fi
+  done
   cd ..
 }
 
@@ -106,10 +118,22 @@ build_rpm() {
   cp -r ${package_config_dir} ${tmp_dir}
   cp ./rpm-builder.sh ${dockerfile_path}
   cp ./wazuh-dashboard.spec ${dockerfile_path}
-  docker build -t ${container_name} ${dockerfile_path} || return 1
-  docker run -t --rm -v ${tmp_dir}/:/tmp:Z -v ${output_dir}/:/output:Z\
-  ${container_name} ${version} ${revision} ${architecture}\
-  ${commit_sha} ${production} ${verbose}|| return 1
+  for i in {1..5}; do
+    if docker build -t ${container_name} ${dockerfile_path} && \
+      docker run -t --rm \
+        -v ${tmp_dir}/:/tmp:Z \
+        -v ${output_dir}/:/output:Z \
+        ${container_name} ${version} ${revision} ${architecture} \
+        ${commit_sha} ${production} ${verbose}; then
+        break
+    else
+      if [ $i -eq 5 ]; then
+        echo "Failed to build the rpm package after 5 attempts"
+        exit 1
+      fi
+      sleep 15
+    fi
+  done
   cd ../
 }
 
@@ -123,9 +147,22 @@ build_deb() {
   cp ./deb-builder.sh ${dockerfile_path}
   cp -r ./debian ${dockerfile_path}
   docker build -t ${container_name} ${dockerfile_path} || return 1
-  docker run -t --rm -v ${tmp_dir}/:/tmp:Z -v ${output_dir}/:/output:Z \
-  ${container_name} ${version} ${revision} ${architecture}\
-  ${commit_sha} ${production} ${verbose}|| return 1
+  for i in {1..5}; do
+    if docker build -t ${container_name} ${dockerfile_path} && \
+      docker run -t --rm \
+        -v ${tmp_dir}/:/tmp:Z \
+        -v ${output_dir}/:/output:Z \
+        ${container_name} ${version} ${revision} ${architecture} \
+        ${commit_sha} ${production} ${verbose}; then
+        break
+    else
+      if [ $i -eq 5 ]; then
+        echo "Failed to build the deb package after 5 attempts"
+        exit 1
+      fi
+      sleep 15
+    fi
+  done
   cd ..
 }
 

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -111,13 +111,33 @@ check_metadata_rpm() {
 test() {
 
   if [[ $PACKAGE == *".deb" ]]; then
-    docker build --build-arg PACKAGE=$PACKAGE -t $CONTAINER_NAME ./deb/
-    docker run -it --rm -d --name $CONTAINER_NAME $CONTAINER_NAME
-    check_metadata_deb
+    for i in {1..5}; do
+      if docker build --build-arg PACKAGE=$PACKAGE -t $CONTAINER_NAME ./deb/ && \
+        docker run -it --rm -d --name $CONTAINER_NAME $CONTAINER_NAME && \
+        check_metadata_deb; then
+        break
+      else
+        if [ $i -eq 5 ]; then
+          echo "Failed to test the deb package after 5 attempts"
+          exit 1
+        fi
+        sleep 15
+      fi
+    done
   elif [[ $PACKAGE == *".rpm" ]]; then
-    docker build --build-arg PACKAGE=$PACKAGE -t $CONTAINER_NAME ./rpm/
-    docker run -it --rm -d --name $CONTAINER_NAME $CONTAINER_NAME
-    check_metadata_rpm
+    for i in {1..5}; do
+      if docker build --build-arg PACKAGE=$PACKAGE -t $CONTAINER_NAME ./rpm/ && \
+        docker run -it --rm -d --name $CONTAINER_NAME $CONTAINER_NAME && \
+        check_metadata_rpm; then
+        break
+      else
+        if [ $i -eq 5 ]; then
+          echo "Failed to test the rpm package after 5 attempts"
+          exit 1
+        fi
+        sleep 15
+      fi
+    done
   else
     echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm ))"
     exit 1

--- a/dev-tools/utils/retry-operation.sh
+++ b/dev-tools/utils/retry-operation.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Function to retry an operation a number of times
+# Arguments:
+# $1: Name of the operation
+# $2: Number of attempts
+# $3: Delay between attempts
+# $4+: Command to execute
+retry_operation() {
+    local operation_name=$1
+    local max_attempts=$2
+    local sleep_time=$3
+    shift 3  # Delete the first 3 arguments
+
+    for i in $(seq 1 $max_attempts); do
+        if eval "$@"; then
+            return 0
+        else
+            if [ $i -eq $max_attempts ]; then
+                echo "Failed to $operation_name after $max_attempts attempts"
+                return 1
+            fi
+            sleep $sleep_time
+        fi
+    done
+}


### PR DESCRIPTION
### Description

Retries are added if package creation action fails

### Issues Resolved

- #354 

### Test

Run the package creation script, it should create the packages correctly.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
