### PR TITLE
Unzip command not found in package generation action

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -172,21 +172,21 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@bug/430-unzip-command-not-found-in-package-generation-action
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.10.0-beta1
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
 
   build-main-plugins:
     needs: [validate-job]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@bug/430-unzip-command-not-found-in-package-generation-action
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.10.0-beta1
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-job]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@bug/430-unzip-command-not-found-in-package-generation-action
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.10.0-beta1
     with:
       reference: ${{ inputs.reference_security_plugins }}
 
@@ -257,31 +257,24 @@ jobs:
           bash ./test-packages.sh \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
-      - uses: actions/upload-artifact@v3
-        if: success()
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          name: ${{ needs.setup-variables.outputs.PACKAGE_NAME }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{ needs.setup-variables.outputs.PACKAGE_NAME }}
-          retention-days: 30
+          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
-      # - name: Set up AWS CLI
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
-      #     aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
-      #     aws-region: ${{ secrets.CI_AWS_REGION }}
+      - name: Upload package
+        run: |
+          echo "Uploading package"
+          aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}"
+          echo "S3 URI: ${s3uri}"
 
-      # - name: Upload package
-      #   run: |
-      #     echo "Uploading package"
-      #     aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-      #     s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}"
-      #     echo "S3 URI: ${s3uri}"
-
-      # - name: Upload SHA512
-      #   if: ${{ inputs.checksum }}
-      #   run: |
-      #     echo "Uploading checksum"
-      #     aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-      #     s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512"
-      #     echo "S3 sha512 URI: ${s3uri}"
+      - name: Upload SHA512
+        if: ${{ inputs.checksum }}
+        run: |
+          echo "Uploading checksum"
+          aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512"
+          echo "S3 sha512 URI: ${s3uri}"

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -257,24 +257,31 @@ jobs:
           bash ./test-packages.sh \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
-      - name: Set up AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/upload-artifact@v3
+        if: success()
         with:
-          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
-          aws-region: ${{ secrets.CI_AWS_REGION }}
+          name: ${{ needs.setup-variables.outputs.PACKAGE_NAME }}
+          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ needs.setup-variables.outputs.PACKAGE_NAME }}
+          retention-days: 30
 
-      - name: Upload package
-        run: |
-          echo "Uploading package"
-          aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}"
-          echo "S3 URI: ${s3uri}"
+      # - name: Set up AWS CLI
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
+      #     aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
+      #     aws-region: ${{ secrets.CI_AWS_REGION }}
 
-      - name: Upload SHA512
-        if: ${{ inputs.checksum }}
-        run: |
-          echo "Uploading checksum"
-          aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512"
-          echo "S3 sha512 URI: ${s3uri}"
+      # - name: Upload package
+      #   run: |
+      #     echo "Uploading package"
+      #     aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+      #     s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}"
+      #     echo "S3 URI: ${s3uri}"
+
+      # - name: Upload SHA512
+      #   if: ${{ inputs.checksum }}
+      #   run: |
+      #     echo "Uploading checksum"
+      #     aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+      #     s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512"
+      #     echo "S3 sha512 URI: ${s3uri}"

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -117,10 +117,10 @@ jobs:
             PRODUCTION=""
           fi
           WAZUH_DASHBOARD_SLIM=wazuh-dashboard_${VERSION}-${REVISION}_x64.tar.gz
-          WAZUH_SECURITY_PLUGIN=wazuh-security-dashboards-plugin_${VERSION}-${REVISION}_${{ inputs.reference_security_plugins }}.zip
-          WAZUH_PLUGINS_WAZUH=wazuh-dashboard-plugins_wazuh_${VERSION}-${REVISION}_${{ inputs.reference_wazuh_plugins }}.zip
-          WAZUH_PLUGINS_CORE=wazuh-dashboard-plugins_wazuh-core_${VERSION}-${REVISION}_${{ inputs.reference_wazuh_plugins }}.zip
-          WAZUH_PLUGINS_CHECK_UPDATES=wazuh-dashboard-plugins_wazuh-check-updates_${VERSION}-${REVISION}_${{ inputs.reference_wazuh_plugins }}.zip
+          WAZUH_SECURITY_PLUGIN=wazuh-security-dashboards-plugin_${VERSION}-${REVISION}_$(echo ${{ inputs.reference_security_plugins }} | sed 's/\//-/g').zip
+          WAZUH_PLUGINS_WAZUH=wazuh-dashboard-plugins_wazuh_${VERSION}-${REVISION}_$(echo ${{ inputs.reference_wazuh_plugins }} | sed 's/\//-/g').zip
+          WAZUH_PLUGINS_CORE=wazuh-dashboard-plugins_wazuh-core_${VERSION}-${REVISION}_$(echo ${{ inputs.reference_wazuh_plugins }} | sed 's/\//-/g').zip
+          WAZUH_PLUGINS_CHECK_UPDATES=wazuh-dashboard-plugins_wazuh-check-updates_${VERSION}-${REVISION}_$(echo ${{ inputs.reference_wazuh_plugins }} | sed 's/\//-/g').zip
           if [ "${{ inputs.system }}" = "deb" ]; then
             if [ "${{ inputs.is_stage }}" = "true" ]; then
               PACKAGE_NAME=wazuh-dashboard_${VERSION}-${{ inputs.revision }}_${{ inputs.architecture }}.deb
@@ -172,21 +172,21 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.10.0-beta1
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@bug/430-unzip-command-not-found-in-package-generation-action
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
 
   build-main-plugins:
     needs: [validate-job]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.10.0-beta1
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@bug/430-unzip-command-not-found-in-package-generation-action
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-job]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.10.0-beta1
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@bug/430-unzip-command-not-found-in-package-generation-action
     with:
       reference: ${{ inputs.reference_security_plugins }}
 

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -216,17 +216,17 @@ jobs:
           name: ${{ needs.setup-variables.outputs.WAZUH_SECURITY_PLUGIN }}
           path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-plugin
 
-      - name: Download plugins artifacts
+      - name: Download main plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_WAZUH }}
           path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
-      - name: Download plugins artifacts
+      - name: Download core plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CORE }}
           path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
-      - name: Download plugins artifacts
+      - name: Download check update plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
@@ -261,7 +261,7 @@ jobs:
         if: success()
         with:
           name: ${{ needs.setup-variables.outputs.PACKAGE_NAME }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ needs.setup-variables.outputs.PACKAGE_NAME }}
+          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{ inputs.system }}/${{ needs.setup-variables.outputs.PACKAGE_NAME }}
           retention-days: 30
 
       # - name: Set up AWS CLI


### PR DESCRIPTION
### Description

This pull request fixes an error in the packages building workflow. It also adds logic to allow the workflow running in branches that contains `/`.

### Issues Resolved
#430 

### Evidence
- https://github.com/wazuh/wazuh-dashboard/actions/runs/12056050079

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
