### PR TITLE
Added  NodeJS options in the node exec command 

### DIFF
--- a/scripts/use_node
+++ b/scripts/use_node
@@ -97,7 +97,9 @@ fi
 
 # If a file path was provided for execution, prefix with OSD_HOME; use relative paths to avoid the need for this.
 if [ ! -z "$OSD_USE_NODE_JS_FILE_PATH" ]; then
-  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS" exec "${NODE}" "${OSD_HOME}${OSD_USE_NODE_JS_FILE_PATH}" "${@}"
+  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"
+  exec "${NODE}" ${NODE_OPTIONS} "${OSD_HOME}${OSD_USE_NODE_JS_FILE_PATH}" "${@}"
 elif [ $# -ne 0 ]; then
-  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS" exec "${NODE}" "${@}"
+  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"
+  exec "${NODE}" ${NODE_OPTIONS} "${@}"
 fi


### PR DESCRIPTION
### Description

Added ${NODE_OPTIONS} to use_node

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard/issues/468

## Evidences

![Sin título](https://github.com/user-attachments/assets/1861b2dd-4d38-4ce3-a593-3c1559c81272)
![Sin título2](https://github.com/user-attachments/assets/d55f5e03-c227-489a-aacc-e3d8661ab4f3)


### Test

-  [ ] Setup the environment and test that this command don't stop the dashboard.service

`curl https://192.168.33.10 -H "Host: %22%3E%3Cscript%3Ealert('Qualys_XSS_Joomla_2.5.3')%3C%2Fscript%3E" -k`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
