### PR TITLE
Add default value to the configuration for wazuh_core.hosts setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Added
 
-- Added default value to the ocnfiguration for `wazuh_core.hosts` setting [#505](https://github.com/wazuh/wazuh-dashboard/pull/505)
+- Added default value to the configuration for `wazuh_core.hosts` setting [#505](https://github.com/wazuh/wazuh-dashboard/pull/505)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 2.18.0 - Revision 00
 
+### Added
+
+- Added default value to the ocnfiguration for `wazuh_core.hosts` setting [#505](https://github.com/wazuh/wazuh-dashboard/pull/505)
+
 ### Changed
 
 - Changed the reportingDashboards platform plugin to a customized one and adapt the build tools [#340](https://github.com/wazuh/wazuh-dashboard/pull/340)

--- a/config/opensearch_dashboards.prod.yml
+++ b/config/opensearch_dashboards.prod.yml
@@ -12,3 +12,10 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/home
+wazuh_core.hosts:
+  manager:
+    url: 'https://localhost'
+    port: 55000
+    username: wazuh-wui
+    password: wazuh-wui
+    run_as: false


### PR DESCRIPTION
### Description

This pull request adds the `wazuh_core.hosts` setting to the default configuration of Wazuh dashboard. This addition avoids the errors related to missing setting in the Wazuh dashboard configuration.

### Issues Resolved

#339

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
