### PR TITLE
Update build GitHub actions to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Build
     defaults:
       run:

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -86,7 +86,7 @@ on:
 
 jobs:
   setup-variables:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Setup variables
     outputs:
       CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
@@ -153,7 +153,7 @@ jobs:
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_OUTPUT
 
   validate-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: setup-variables
     name: Validate inputs
     steps:
@@ -198,7 +198,7 @@ jobs:
 
   build-and-test-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Generate packages
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Description

This pull request changes the use of `ubuntu-latest` image on our package building GitHub actions to `ubuntu-24.04`. This is to prevent sudden changes in the version.

### Issues Resolved

#535 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
