### PR TITLE
Modify the `wazuh-dashboard` package build workflow to upload a `latest` package besides the one with the `commit`

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -347,8 +347,15 @@ jobs:
         run: |
           echo "Uploading package"
           aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
+          if [ ! -z "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
+            aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.LATEST_NAME}}
+          fi
           s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}"
           echo "S3 URI: ${s3uri}"
+          if [ ! -z "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
+            s3uri_latest="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.LATEST_NAME}}"
+            echo "S3 Latest URI: ${s3uri_latest}"
+          fi
 
       - name: Upload SHA512
         if: ${{ inputs.checksum }}

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -120,8 +120,8 @@ jobs:
       WAZUH_REPORT_PLUGIN: ${{ steps.setup-variables.outputs.WAZUH_REPORT_PLUGIN }}
       WAZUH_PLUGINS_CORE: ${{ steps.setup-variables.outputs.WAZUH_PLUGINS_CORE }}
       WAZUH_PLUGINS_CHECK_UPDATES: ${{ steps.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
-      PACKAGE_NAME: ${{ steps.setup-variables.outputs.PACKAGE_NAME }}
       FINAL_NAME: ${{ steps.setup-variables.outputs.FINAL_NAME }}
+      LATEST_NAME: ${{ steps.setup-variables.outputs.LATEST_NAME }}
       ARCHITECTURE_FLAG: ${{ steps.setup-variables.outputs.ARCHITECTURE_FLAG }}
     steps:
       - name: Checkout code
@@ -174,15 +174,14 @@ jobs:
           WAZUH_PLUGINS_CHECK_UPDATES=wazuh-dashboard-plugins_wazuh-check-updates_${VERSION}-${REVISION}_$(echo ${{ inputs.reference_wazuh_plugins }} | sed 's/\//-/g').zip
           if [ "${{ inputs.is_stage }}" = "true" ]; then
             if [ "${{ inputs.system }}" = "deb" ]; then
-              PACKAGE_NAME=wazuh-dashboard_${VERSION}-${{ inputs.revision }}_${{ inputs.architecture }}.deb
+              FINAL_NAME=wazuh-dashboard_${VERSION}-${{ inputs.revision }}_${{ inputs.architecture }}.deb
             else
-              PACKAGE_NAME=wazuh-dashboard-${VERSION}-${{ inputs.revision }}.${{ inputs.architecture }}.rpm
+              FINAL_NAME=wazuh-dashboard-${VERSION}-${{ inputs.revision }}.${{ inputs.architecture }}.rpm
             fi
-            FINAL_NAME=${PACKAGE_NAME}
           else
-            PACKAGE_BASE_NAME=wazuh-dashboard_${VERSION}-${{ inputs.revision }}_${{ inputs.architecture }}_${COMMIT_SHA}
-            PACKAGE_NAME=${PACKAGE_BASE_NAME}.${{ inputs.system }}
-            FINAL_NAME=${PACKAGE_BASE_NAME}-${PLUGINS_SHA}-${SECURITY_SHA}-${REPORTING_SHA}.${{ inputs.system }}
+            PACKAGE_BASE_NAME=wazuh-dashboard_${VERSION}-${{ inputs.revision }}_${{ inputs.architecture }}
+            FINAL_NAME=${PACKAGE_BASE_NAME}_${COMMIT_SHA}-${PLUGINS_SHA}-${SECURITY_SHA}-${REPORTING_SHA}.${{ inputs.system }}
+            LATEST_NAME=${PACKAGE_BASE_NAME}_latest.${{ inputs.system }}
           fi
           if [[ "${{ inputs.architecture }}" == "x86_64" || "${{ inputs.architecture }}" == "amd64" ]]; then
             ARCHITECTURE_FLAG=""
@@ -202,8 +201,8 @@ jobs:
           echo "WAZUH_REPORT_PLUGIN=$WAZUH_REPORT_PLUGIN" >> $GITHUB_OUTPUT
           echo "WAZUH_PLUGINS_CORE=$WAZUH_PLUGINS_CORE" >> $GITHUB_OUTPUT
           echo "WAZUH_PLUGINS_CHECK_UPDATES=$WAZUH_PLUGINS_CHECK_UPDATES" >> $GITHUB_OUTPUT
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_OUTPUT
           echo "FINAL_NAME=$FINAL_NAME" >> $GITHUB_OUTPUT
+          echo "LATEST_NAME=$LATEST_NAME" >> $GITHUB_OUTPUT
           echo "ARCHITECTURE_FLAG=$ARCHITECTURE_FLAG" >> $GITHUB_OUTPUT
 
   validate-job:
@@ -323,7 +322,6 @@ jobs:
         run: |
           cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
           ls -laR ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output
-          echo "PACKAGE NAME: ${{ needs.setup-variables.outputs.PACKAGE_NAME }}"
           echo "FINAL NAME: ${{ needs.setup-variables.outputs.FINAL_NAME }}"
           cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{ inputs.system }}
           bash ./test-packages.sh \

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -354,12 +354,12 @@ jobs:
         run: |
           echo "Uploading package"
           aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
-          if [ ! -z "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
+          if [ -n "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
             aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.LATEST_NAME}}
           fi
           s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}"
           echo "S3 URI: ${s3uri}"
-          if [ ! -z "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
+          if [ -n "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
             s3uri_latest="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.LATEST_NAME}}"
             echo "S3 Latest URI: ${s3uri_latest}"
           fi

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -334,6 +334,13 @@ jobs:
           path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}
           retention-days: 30
 
+      - uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: ${{ needs.setup-variables.outputs.LATEST_NAME }}
+          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}
+          retention-days: 30
+
       - name: Set up AWS CLI
         if: ${{ inputs.upload }}
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -369,5 +369,12 @@ jobs:
         run: |
           echo "Uploading checksum"
           aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
+          if [ -n "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
+            aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.LATEST_NAME}}.sha512
+          fi
           s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512"
           echo "S3 sha512 URI: ${s3uri}"
+          if [ -n "${{ needs.setup-variables.outputs.LATEST_NAME }}" ]; then
+            s3uri_latest="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{needs.setup-variables.outputs.LATEST_NAME}}.sha512"
+            echo "S3 Latest sha512 URI: ${s3uri_latest}"
+          fi


### PR DESCRIPTION
### Description

Starting in `5.0.0` the DevOps repositories automatic checks must work with development packages. For that requirement, a `latest` package must be uploaded to the `packages-dev.internal.wazuh.com` bucket every time a new package is generated.
Currently, packages with the commit in the name are uploaded. We will need the package generation workflows to also upload the packages with `latest` instead of the commit in the name.
Example: if the package name is `wazuh-dashboard_5.0.0-0_amd64_452c31f.deb`, it must also be uploaded as `wazuh-dashboard_5.0.0-0_amd64_latest.deb`.

### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

Closes [Modify the `wazuh-dashboard` package build workflow to upload a `latest` package besides the one with the `commit` · Issue #549 · wazuh/wazuh-dashboard](https://github.com/wazuh/wazuh-dashboard/issues/549)

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff


## Tasks
- [ ] Modify the workflow to also upload the `latest` package to the `packages-dev.internal.wazuh.com` bucket.
- [ ] Test the workflow and provide evidence.
