### PR TITLE
Change default OSD configuration and create certs folder

### DIFF
--- a/config/opensearch_dashboards.prod.yml
+++ b/config/opensearch_dashboards.prod.yml
@@ -1,15 +1,14 @@
 server.host: 0.0.0.0
 server.port: 443
-
-opensearch.hosts: https://localhost:9200
+opensearch.hosts: https://127.0.0.1:9200
+opensearch.ssl.verificationMode: certificate
+#opensearch.username:
+#opensearch.password:
 opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
-
 server.ssl.enabled: true
 server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
-opensearch.ssl.verificationMode: certificate
-
 uiSettings.overrides.defaultRoute: /app/home

--- a/dev-tools/build-packages/base/base-builder.sh
+++ b/dev-tools/build-packages/base/base-builder.sh
@@ -143,6 +143,7 @@ log
 
 cp -f $config_path/opensearch_dashboards.prod.yml config/opensearch_dashboards.yml
 cp -f $config_path/node.options.prod config/node.options
+mkdir config/certs
 
 log
 log "Fixing shebangs"

--- a/dev-tools/build-packages/deb/debian/postinst
+++ b/dev-tools/build-packages/deb/debian/postinst
@@ -23,6 +23,7 @@ configure)
   chmod 750 "${TARGET_DIR}""${CONFIG_DIR}"
   chown -R "${NAME}":"${NAME}" "${TARGET_DIR}""${CONFIG_DIR}"
   chmod 750 "${TARGET_DIR}""${INSTALLATION_DIR}"
+  chmod 500 "${TARGET_DIR}""${CONFIG_DIR}"/certs
   chown -R "${NAME}":"${NAME}" "${TARGET_DIR}""${INSTALLATION_DIR}"
   setcap 'cap_net_bind_service=+ep' "${INSTALLATION_DIR}"/node/bin/node
   setcap 'cap_net_bind_service=+ep' "${INSTALLATION_DIR}"/node/fallback/bin/node

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -196,6 +196,7 @@ rm -fr %{buildroot}
 %files
 %defattr(-,%{USER},%{GROUP})
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}
+%dir %attr(500, %{USER}, %{GROUP}) %{CONFIG_DIR}/certs
 
 %attr(0750, %{USER}, %{GROUP}) "/etc/default/wazuh-dashboard"
 %config(noreplace) %attr(0640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch_dashboards.yml"


### PR DESCRIPTION
### Description

This PR changes the default opensearch_dashboards.yml configuration.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/577


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
