### PR TITLE
Update Dockerfile to use CentOS 8 instead of latest

### DIFF
--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -1,7 +1,5 @@
-FROM centos:latest
-
+FROM centos:8
 RUN mkdir -p /tmp
-FROM centos
 ARG PACKAGE
 RUN cd /etc/yum.repos.d/
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*


### PR DESCRIPTION
### Description

The script used for testing the generated packages used centos:latest. This caused an error when latest was not available, and could cause problems if the latest version changes. 
To avoid that, this PR sets it to a specific version. It also removes a duplicate line specifying the version. 

### Issues Resolved

#584

### Evidence

<details>

```bash
bash ./test-packages.sh -p wazuh-dashboard-4.11.1-1.rpm
[+] Building 52.0s (13/13) FINISHED                                         docker:default
 => [internal] load build definition from Dockerfile                                  0.0s
 => => transferring dockerfile: 366B                                                  0.0s
 => [internal] load metadata for docker.io/library/centos:8                           0.0s
 => [internal] load .dockerignore                                                     0.0s
 => => transferring context: 2B                                                       0.0s
 => CACHED [1/8] FROM docker.io/library/centos:8                                      0.0s
 => [internal] load build context                                                     0.0s
 => => transferring context: 53B                                                      0.0s
 => [2/8] RUN mkdir -p /tmp                                                           0.3s
 => [3/8] RUN cd /etc/yum.repos.d/                                                    0.5s
 => [4/8] RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*           0.6s
 => [5/8] RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.cento  0.6s
 => [6/8] RUN yum update -y                                                          27.4s
 => [7/8] COPY wazuh-dashboard-4.11.1-1.rpm /tmp/wazuh.rpm                            0.3s
 => [8/8] RUN yum install /tmp/wazuh.rpm -y                                          13.8s
 => exporting to image                                                                8.4s
 => => exporting layers                                                               8.4s
 => => writing image sha256:2c8dc034715691f032743c501c1ee606b65ebf0ae0cd1cbb8e79eeff  0.0s
 => => naming to docker.io/library/wazuh-dashboard                                    0.0s
32e376a09afc40919e211b6cb1c979ff67360f3265f1bc48e67197f66cb9d6dd
metadata version is correct: 4.11.1-1
metadata package is correct: wazuh-dashboard
/etc/wazuh-dashboard/opensearch_dashboards.yml exist and is owned by wazuh-dashboard
/usr/share/wazuh-dashboard exist and is owned by wazuh-dashboard
Successfully copied 2.56kB to wazuh-dashboard:/tmp/opensearch_dashboards.yml

opensearch_dashboards.yml is the same as the one in the package
wazuh-dashboard
Untagged: wazuh-dashboard:latest
Deleted: sha256:2c8dc034715691f032743c501c1ee606b65ebf0ae0cd1cbb8e79eeffe207d89b
```

</details>

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
