### PR TITLE
Update Dockerfile to use CentOS 8 instead of latest

### DIFF
--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -1,7 +1,5 @@
-FROM centos:latest
-
+FROM centos:8
 RUN mkdir -p /tmp
-FROM centos
 ARG PACKAGE
 RUN cd /etc/yum.repos.d/
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*


### PR DESCRIPTION
### Description

The script used for testing the generated packages used centos:latest. This caused an error when latest was not available, and could cause problems if the latest version changes. 
To avoid that, this PR sets it to a specific version. It also removes a duplicate line specifying the version. This is the same fix applied in #585 for a different branch.

### Issues Resolved

#594


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
