### PR TITLE
Fix tooltip text for no cached mapping field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed a style issue with the empty button texts are cut off in v7 theme of OpenSearch Dashboards 2.19.0 upgrade [#423](https://github.com/wazuh/wazuh-dashboard/issues/423)
 - Fixed horizontal scrolling in the v7 theme of the Discover plugin to improve accessibility when many columns exceed the viewport width, ensuring easier navigation [#7330](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7330)
+- Fixed tooltip text for no cached mapping field, because the change of the Management application to Dashboard management [#614](https://github.com/wazuh/wazuh-dashboard/pull/614)
 
 ## Wazuh dashboard v4.11.2 - OpenSearch Dashboards 2.16.0 - Revision 02
 

--- a/src/plugins/discover/public/application/components/table/table_row_icon_no_mapping.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_icon_no_mapping.tsx
@@ -40,7 +40,7 @@ export function DocViewTableRowIconNoMapping() {
     'discover.docViews.table.noCachedMappingForThisFieldTooltip',
     {
       defaultMessage:
-        'No cached mapping for this field. Refresh field list from the Management > Index Patterns page',
+        'No cached mapping for this field. Refresh field list from the Dashboards Management > Index Patterns page',
     }
   );
   return (


### PR DESCRIPTION
### Description

Update tooltip text for no cached mapping field, because the change of the Management application to Dashboard management

### Issues Resolved

- #610 

### Screenshot

<img width="661" alt="image" src="https://github.com/user-attachments/assets/5f2266e0-f6a0-4a8e-a1f6-1a79b200fabf" />

### Test

- Navigate to `Dev tools`
- Create a document in some index
- Navigate to `Dashboards Management > Index Patterns`
- Create an index 
- Navigate to `Dev tools`
- Create another document with a new field
- Navigate to `Discover`
- Inspect the document with a new field and check tooltip

> To create the document use the example of opensearch
> https://opensearch.org/docs/latest/api-reference/document-apis/index-document/#example-post-request

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
