### PR TITLE
Repository bumper script development

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+# Ignore repository bumper log files
+repository_bumper_*.log

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,60 @@
+# Repository Bumper Script
+
+This script automates the process of updating the version, stage, and revision number across various files within the Wazuh Dashboard repository. It uses standard shell commands (`sed`, `awk`, `grep`, etc.) for modifications.
+
+## Purpose
+
+The primary goal of this script is to ensure consistency when releasing a new version or build stage (alpha, beta, rc) of the Wazuh Dashboard. It modifies key files to reflect the new version information, reducing the chance of manual errors.
+
+## Usage
+
+To run the script, navigate to the `tools` directory and execute it with the required parameters:
+
+```bash
+./repository_bumper.sh --version <VERSION> --stage <STAGE>
+```
+
+**Parameters:**
+
+*   `--version VERSION`: Specify the target version in `x.y.z` format (e.g., `4.9.0`). **Required**.
+*   `--stage STAGE`: Specify the build stage (e.g., `alpha0`, `beta1`, `rc2`, `stable`). **Required**.
+*   `--help`: Display the help message.
+
+**Example:**
+
+```bash
+./repository_bumper.sh --version 4.9.0 --stage beta1
+```
+
+## Process
+
+The script performs the following actions:
+
+1.  **Initialization:** Sets up paths, date/time, and the log file (`repository_bumper_YYYY-MM-DD_HH-MM-SS-ms.log`).
+2.  **Argument Parsing & Validation:** Reads the `--version` and `--stage` arguments and validates their format.
+3.  **Pre-update Checks:**
+    *   Reads the current `version`, `stage` from `VERSION.json`.
+    *   Reads the current `revision` from `package.json` (within the `"wazuh"` object).
+4.  **Version Comparison & Revision Determination:**
+    *   Compares the provided `--version` with the current version read from `VERSION.json`.
+    *   **Error Handling:** Prevents setting a lower version number.
+    *   **Revision Logic:**
+        *   If the new version (Major, Minor, or Patch) is *higher* than the current version, the `revision` is reset to `00`.
+        *   If the new version is *identical* to the current version, the existing `revision` (from `package.json`) is incremented (e.g., `00` -> `01`, `01` -> `02`).
+5.  **File Modifications:** Updates the version, stage, and/or revision in the following files using `sed`:
+    *   `VERSION.json`: Updates `version` and `stage`.
+    *   `package.json`: Updates `version` and `revision` within the `"wazuh"` object.
+    *   `CHANGELOG.md`:
+        *   Updates the revision number in the header if an entry for the version already exists.
+        *   Adds a new entry with the specified version, stage, revision, and detected OpenSearch Dashboards version if no entry exists.
+    *   `.github/workflows/build_wazuh_dashboard_with_plugins.yml`: Updates references like `yml@vX.Y.Z` to `yml@v<VERSION>-<STAGE>`.
+    *   `dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile`: Updates `_BRANCH=X.Y.Z` and `wazuh-packages-to-base:X.Y.Z` references to use the new `<VERSION>`.
+    *   `dev-tools/build-packages/base-packages-to-base/README.md`: Updates version references in example commands (`--app X.Y.Z`, `--base X.Y.Z`, `--security X.Y.Z`) and descriptive text.
+    *   `src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap`: Updates `"wazuhVersion": "X.Y.Z"` to use the new `<VERSION>`.
+6.  **Logging:** All actions, errors, and results are logged to the timestamped log file in the `tools` directory.
+
+## Notes
+
+*   The script relies heavily on `sed` with specific patterns. Changes to the structure of the target files might break the script.
+*   Ensure you are inside the git repository root when running the script, although it determines the root path automatically.
+*   Review the generated log file after execution to confirm all steps completed successfully.

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -344,10 +344,11 @@ update_build_workflow() {
     local modified=false
     # Update all occurrences of yml@x.y.z with yml@$VERSION-$STAGE
     # Check if the pattern exists in the file first
-    if grep -qE "(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
+    local workflow_version_pattern="(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?"
+    if grep -qE "$workflow_version_pattern" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
       log "Pattern found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Attempting update..."
       # If the pattern exists, perform the substitution
-      sed -i -E "s/(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
+      sed -i -E "s/${workflow_version_pattern}/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
       modified=true
     else
       log "Pattern not found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Skipping update."

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -393,16 +393,60 @@ update_readme_for_base_packages() {
     local modified=false
 
     # Update all occurrences of --app x.y.z with --app $VERSION
-    sed -i -E "s/(--app )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    # Define the pattern regex
+    local app_pattern_regex="(--app )$VERSION_PATTERN"
+
+    # Check if the pattern exists in the file
+    if grep -qE "$app_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
+      log "Pattern '$app_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
+      # If the pattern exists, perform the substitution and set modified to true
+      sed -i -E "s/${app_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
+      modified=true
+    else
+      log "Pattern '$app_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
+    fi
 
     # Update all occurrences of --base x.y.z with --base $VERSION
-    sed -i -E "s/(--base )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    # Define the pattern regex for --base
+    local base_pattern_regex="(--base )$VERSION_PATTERN"
+
+    # Check if the pattern exists in the file
+    if grep -qE "$base_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
+      log "Pattern '$base_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
+      # If the pattern exists, perform the substitution and set modified to true
+      sed -i -E "s/${base_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
+      modified=true
+    else
+      log "Pattern '$base_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
+    fi
 
     # Update all occurrences of --security x.y.z with --security $VERSION
-    sed -i -E "s/(--security )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    # Define the pattern regex for --security
+    local security_pattern_regex="(--security )$VERSION_PATTERN"
+
+    # Check if the pattern exists in the file
+    if grep -qE "$security_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
+      log "Pattern '$security_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
+      # If the pattern exists, perform the substitution and set modified to true
+      sed -i -E "s/${security_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
+      modified=true
+    else
+      log "Pattern '$security_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
+    fi
 
     # Update all occurrences of --security x.y.z with --security $VERSION
-    sed -i -E "s/(This example will create a packages folder that inside will have the packages divided by repository of the )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    # Define the pattern regex for the example text
+    local readme_example_pattern_regex="(This example will create a packages folder that inside will have the packages divided by repository of the )$VERSION_PATTERN"
+
+    # Check if the pattern exists in the file
+    if grep -qE "$readme_example_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
+      log "Pattern '$readme_example_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
+      # If the pattern exists, perform the substitution and set modified to true
+      sed -i -E "s/${readme_example_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
+      modified=true
+    else
+      log "Pattern '$readme_example_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
+    fi
 
     if [[ $modified == true ]]; then
       log "Successfully updated $(basename $README_FOR_BASE_PACKAGES)"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -454,6 +454,30 @@ update_readme_for_base_packages() {
   fi
 }
 
+update_rendering_service_test_snap() {
+  local rendering_service_test_snap="${REPO_PATH}/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap"
+
+  if [ -f "$rendering_service_test_snap" ]; then
+    log "Updating rendering service test snapshot..."
+
+    # Update all occurrences of ("wazuhVersion": "x.y.z",) with ("wazuhVersion": "$VERSION",)
+    # Define the pattern regex
+    local pattern_regex="(\"wazuhVersion\": \")$VERSION_PATTERN"
+    # Check if the pattern exists in the file
+    if grep -qE "$pattern_regex" "$rendering_service_test_snap"; then
+      log "Pattern '$pattern_regex' found in $(basename $rendering_service_test_snap). Attempting update..."
+      # If the pattern exists, perform the substitution
+      sed -i -E "s/${pattern_regex}/\1${VERSION}/g" "$rendering_service_test_snap"
+      log "Successfully updated rendering service test snapshot."
+    else
+      log "Pattern '$pattern_regex' not found in $(basename $rendering_service_test_snap). Skipping update for this pattern."
+    fi
+
+  else
+    log "ERROR: Rendering service test snapshot not found at $rendering_service_test_snap" >&2
+  fi
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -489,6 +513,7 @@ main() {
   update_build_workflow
   update_base_package_dockerfile
   update_readme_for_base_packages
+  update_rendering_service_test_snap
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -18,6 +18,7 @@ CURRENT_VERSION=""
 WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/build_wazuh_dashboard_with_plugins.yml"
 DOCKERFILE_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile"
 README_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/README.md"
+VERSION_PATTERN="[0-9]+\.[0-9]+\.[0-9]+"
 
 # --- Helper Functions ---
 
@@ -81,7 +82,7 @@ validate_input() {
     usage
     exit 1
   fi
-  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if ! [[ $VERSION =~ ^$VERSION_PATTERN$ ]]; then
     log "ERROR: Version must be in the format x.y.z (e.g., 4.6.0)"
     exit 1
   fi
@@ -342,7 +343,7 @@ update_build_workflow() {
   if [ -f "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" ]; then
     local modified=false
     # Update all occurrences of yml@x.y.z with yml@$VERSION-$STAGE
-    sed -i -E "s/(\.yml@)v?[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" && modified=true
+    sed -i -E "s/(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" && modified=true
 
     if [[ $modified == true ]]; then
       log "Successfully updated yml@v${VERSION}-${STAGE} in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE)"
@@ -357,10 +358,10 @@ update_base_package_dockerfile() {
     local modified=false
 
     # Update all occurrences of _BRANCH=x.y.z with _BRANCH=$VERSION
-    sed -i -E "s/(_BRANCH=)[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
+    sed -i -E "s/(_BRANCH=)$VERSION_PATTERN/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
 
     # Update all occurrences of wazuh-packages-to-base:x.y.z with wazuh-packages-to-base:$VERSION
-    sed -i -E "s/(wazuh-packages-to-base:)[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
+    sed -i -E "s/(wazuh-packages-to-base:)$VERSION_PATTERN/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
 
     if [[ $modified == true ]]; then
       log "Successfully updated $(basename $DOCKERFILE_FOR_BASE_PACKAGES)"
@@ -375,16 +376,16 @@ update_readme_for_base_packages() {
     local modified=false
 
     # Update all occurrences of --app x.y.z with --app $VERSION
-    sed -i -E "s/(--app )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    sed -i -E "s/(--app )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
 
     # Update all occurrences of --base x.y.z with --base $VERSION
-    sed -i -E "s/(--base )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    sed -i -E "s/(--base )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
 
     # Update all occurrences of --security x.y.z with --security $VERSION
-    sed -i -E "s/(--security )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    sed -i -E "s/(--security )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
 
     # Update all occurrences of --security x.y.z with --security $VERSION
-    sed -i -E "s/(This example will create a packages folder that inside will have the packages divided by repository of the )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+    sed -i -E "s/(This example will create a packages folder that inside will have the packages divided by repository of the )$VERSION_PATTERN/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
 
     if [[ $modified == true ]]; then
       log "Successfully updated $(basename $README_FOR_BASE_PACKAGES)"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -367,7 +367,15 @@ update_base_package_dockerfile() {
     local modified=false
 
     # Update all occurrences of _BRANCH=x.y.z with _BRANCH=$VERSION
-    sed -i -E "s/(_BRANCH=)$VERSION_PATTERN/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
+    local branch_pattern_regex="(_BRANCH=)$VERSION_PATTERN"
+    if grep -qE "$branch_pattern_regex" "$DOCKERFILE_FOR_BASE_PACKAGES"; then
+      log "Pattern '$branch_pattern_regex' found in $(basename $DOCKERFILE_FOR_BASE_PACKAGES). Attempting update..."
+      # Perform the substitution
+      sed -i -E "s/${branch_pattern_regex}/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES"
+      modified=true
+    else
+      log "Pattern '$branch_pattern_regex' not found in $(basename $DOCKERFILE_FOR_BASE_PACKAGES). Skipping update for this pattern."
+    fi
 
     # Update all occurrences of wazuh-packages-to-base:x.y.z with wazuh-packages-to-base:$VERSION
     sed -i -E "s/(wazuh-packages-to-base:)$VERSION_PATTERN/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -15,7 +15,7 @@ PACKAGE_JSON="${REPO_PATH}/package.json"
 VERSION=""
 REVISION="00"
 CURRENT_VERSION=""
-BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/build_wazuh_dashboard_with_plugins.yml"
+WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/build_wazuh_dashboard_with_plugins.yml"
 
 # --- Helper Functions ---
 
@@ -335,15 +335,15 @@ update_changelog() {
 }
 
 update_build_workflow() {
-  log "Updating $(basename $BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE)..."
+  log "Updating $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE)..."
 
-  if [ -f "$BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE" ]; then
+  if [ -f "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" ]; then
     local modified=false
     # Update all occurrences of yml@x.y.z with yml@$VERSION-$STAGE
-    sed -i -E "s/(\.yml@)v?[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE" && modified=true
+    sed -i -E "s/(\.yml@)v?[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" && modified=true
 
     if [[ $modified == true ]]; then
-      log "Successfully updated yml@v${VERSION}-${STAGE} in $(basename $BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE)"
+      log "Successfully updated yml@v${VERSION}-${STAGE} in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE)"
     fi
   fi
 }

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -343,7 +343,15 @@ update_build_workflow() {
   if [ -f "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" ]; then
     local modified=false
     # Update all occurrences of yml@x.y.z with yml@$VERSION-$STAGE
-    sed -i -E "s/(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" && modified=true
+    # Check if the pattern exists in the file first
+    if grep -qE "(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
+      log "Pattern found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Attempting update..."
+      # If the pattern exists, perform the substitution
+      sed -i -E "s/(\.yml@)v?$VERSION_PATTERN(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
+      modified=true
+    else
+      log "Pattern not found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Skipping update."
+    fi
 
     if [[ $modified == true ]]; then
       log "Successfully updated yml@v${VERSION}-${STAGE} in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE)"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -16,6 +16,7 @@ VERSION=""
 REVISION="00"
 CURRENT_VERSION=""
 WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/build_wazuh_dashboard_with_plugins.yml"
+DOCKERFILE_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile"
 
 # --- Helper Functions ---
 
@@ -348,6 +349,24 @@ update_build_workflow() {
   fi
 }
 
+update_base_package_dockerfile() {
+  log "Updating $(basename $DOCKERFILE_FOR_BASE_PACKAGES)..."
+
+  if [ -f "$DOCKERFILE_FOR_BASE_PACKAGES" ]; then
+    local modified=false
+
+    # Update all occurrences of _BRANCH=x.y.z with _BRANCH=$VERSION
+    sed -i -E "s/(_BRANCH=)[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
+
+    # Update all occurrences of wazuh-packages-to-base:x.y.z with wazuh-packages-to-base:$VERSION
+    sed -i -E "s/(wazuh-packages-to-base:)[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated $(basename $DOCKERFILE_FOR_BASE_PACKAGES)"
+    fi
+  fi
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -381,6 +400,7 @@ main() {
   update_package_json
   update_changelog
   update_build_workflow
+  update_base_package_dockerfile
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -15,6 +15,7 @@ PACKAGE_JSON="${REPO_PATH}/package.json"
 VERSION=""
 REVISION="00"
 CURRENT_VERSION=""
+BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/build_wazuh_dashboard_with_plugins.yml"
 
 # --- Helper Functions ---
 
@@ -333,6 +334,20 @@ update_changelog() {
   fi
 }
 
+update_build_workflow() {
+  log "Updating $(basename $BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE)..."
+
+  if [ -f "$BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE" ]; then
+    local modified=false
+    # Update all occurrences of yml@x.y.z with yml@$VERSION-$STAGE
+    sed -i -E "s/(\.yml@)v?[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?/\1v${VERSION}-${STAGE}/g" "$BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE" && modified=true
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated yml@v${VERSION}-${STAGE} in $(basename $BUILD_DASHBOARD_WITH_PLUGINS_WORKFLOW_FILE)"
+    fi
+  fi
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -365,6 +380,7 @@ main() {
   update_root_version_json
   update_package_json
   update_changelog
+  update_build_workflow
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -509,7 +509,6 @@ main() {
 
   update_root_version_json
   update_package_json
-  update_changelog
   update_build_workflow
   update_base_package_dockerfile
   update_readme_for_base_packages

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -1,0 +1,375 @@
+#!/bin/bash
+#
+# Wazuh Security Dashboards Plugin repository bumper (Pure Shell Version)
+# This script automates version and stage bumping across the repository using only shell commands.
+
+set -e
+
+# --- Global Variables ---
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
+DATE_TIME=$(date "+%Y-%m-%d_%H-%M-%S-%3N")
+LOG_FILE="${SCRIPT_PATH}/repository_bumper_${DATE_TIME}.log"
+VERSION_FILE="${REPO_PATH}/VERSION.json"
+PACKAGE_JSON="${REPO_PATH}/package.json"
+VERSION=""
+REVISION="00"
+CURRENT_VERSION=""
+
+# --- Helper Functions ---
+
+# Function to log messages
+log() {
+  local message="$1"
+  local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+  echo "[${timestamp}] ${message}" | tee -a "$LOG_FILE"
+}
+
+# Function to show usage
+usage() {
+  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo ""
+  echo "Parameters:"
+  echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
+  echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
+  echo "  --help              Display this help message"
+  echo ""
+  echo "Example:"
+  echo "  $0 --version 4.6.0 --stage alpha0"
+  echo "  $0 --version 4.6.0 --stage beta1"
+}
+
+# --- Core Logic Functions ---
+
+parse_arguments() {
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "ERROR: Unknown option: $1" # Log error instead of just echo
+      usage
+      exit 1
+      ;;
+    esac
+  done
+}
+
+# Function to validate input parameters
+validate_input() {
+  if [ -z "$VERSION" ]; then
+    log "ERROR: Version parameter is required"
+    usage
+    exit 1
+  fi
+  if [ -z "$STAGE" ]; then
+    log "ERROR: Stage parameter is required"
+    usage
+    exit 1
+  fi
+  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log "ERROR: Version must be in the format x.y.z (e.g., 4.6.0)"
+    exit 1
+  fi
+  if ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
+    log "ERROR: Stage must be alphanumeric (e.g., alpha0, beta1, rc2)"
+    exit 1
+  fi
+}
+
+# Function to perform pre-update checks and gather initial data
+pre_update_checks() {
+  if [ ! -f "$VERSION_FILE" ]; then
+    log "ERROR: Root VERSION.json not found at $VERSION_FILE"
+    exit 1
+  fi
+
+  # Attempt to extract version from VERSION.json using sed
+  log "Attempting to extract current version from $VERSION_FILE using sed..."
+  CURRENT_VERSION=$(sed -n 's/^\s*"version"\s*:\s*"\([^"]*\)".*$/\1/p' "$VERSION_FILE" | head -n 1) # head -n 1 ensures only the first match is taken
+
+  # Check if sed successfully extracted a version
+  if [ -z "$CURRENT_VERSION" ]; then
+    log "ERROR: Failed to extract 'version' from $VERSION_FILE using sed. Check file format or key presence."
+    exit 1 # Exit if sed fails
+  fi
+  log "Successfully extracted version using sed: $CURRENT_VERSION"
+
+  if [ "$CURRENT_VERSION" == "null" ]; then # Check specifically for "null" string if sed might output that
+    log "ERROR: Could not read current version from $VERSION_FILE (value was 'null')"
+    exit 1
+  fi
+  log "Current version detected in VERSION.json: $CURRENT_VERSION"
+
+  # Attempt to extract stage from VERSION.json using sed
+  log "Attempting to extract current stage from $VERSION_FILE using sed..."
+  CURRENT_STAGE=$(sed -n 's/^\s*"stage"\s*:\s*"\([^"]*\)".*$/\1/p' "$VERSION_FILE" | head -n 1) # head -n 1 ensures only the first match is taken
+
+  # Check if sed successfully extracted a stage
+  if [ -z "$CURRENT_STAGE" ]; then
+    log "ERROR: Failed to extract 'stage' from $VERSION_FILE using sed. Check file format or key presence."
+    exit 1 # Exit if sed fails
+  fi
+  log "Successfully extracted stage using sed: $CURRENT_STAGE"
+
+  if [ "$CURRENT_STAGE" == "null" ]; then # Check specifically for "null" string if sed might output that
+    log "ERROR: Could not read current stage from $VERSION_FILE (value was 'null')"
+    exit 1
+  fi
+  log "Current stage detected in VERSION.json: $CURRENT_STAGE"
+
+  # Attempt to extract current revision from package.json using sed
+  log "Attempting to extract current revision from $PACKAGE_JSON using sed..."
+  CURRENT_REVISION=$(sed -n '/"wazuh": {/,/}/ s/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
+
+  if [ -z "$CURRENT_REVISION" ]; then
+    log "ERROR: Failed to extract 'revision' from $PACKAGE_JSON using sed. Check file format or key presence."
+    exit 1
+  fi
+  log "Successfully extracted revision using sed: $CURRENT_REVISION"
+
+  if [ "$CURRENT_REVISION" == "null" ]; then
+    log "ERROR: Could not read current revision from $PACKAGE_JSON (value was 'null')"
+    exit 1
+  fi
+  log "Current revision detected in package.json: $CURRENT_REVISION"
+
+  log "Default revision set to: $REVISION" # Log default revision here
+}
+
+# Function to compare versions and determine revision
+compare_versions_and_set_revision() {
+  log "Comparing new version ($VERSION) with current version ($CURRENT_VERSION)..."
+
+  # Split versions into parts using '.' as delimiter
+  IFS='.' read -r -a NEW_VERSION_PARTS <<<"$VERSION"
+  IFS='.' read -r -a CURRENT_VERSION_PARTS <<<"$CURRENT_VERSION"
+
+  # Ensure both versions have 3 parts (Major.Minor.Patch)
+  if [ ${#NEW_VERSION_PARTS[@]} -ne 3 ] || [ ${#CURRENT_VERSION_PARTS[@]} -ne 3 ]; then
+    log "ERROR: Invalid version format detected during comparison. Both versions must be x.y.z."
+    exit 1
+  fi
+
+  # Compare Major version
+  if ((${NEW_VERSION_PARTS[0]} < ${CURRENT_VERSION_PARTS[0]})); then
+    log "ERROR: New major version (${NEW_VERSION_PARTS[0]}) cannot be lower than current major version (${CURRENT_VERSION_PARTS[0]})."
+    exit 1
+  elif ((${NEW_VERSION_PARTS[0]} > ${CURRENT_VERSION_PARTS[0]})); then
+    log "Version check passed: New version ($VERSION) is greater than current version ($CURRENT_VERSION) (Major increased)."
+    REVISION="00" # Reset revision on major increase
+  else
+    # Major versions are equal, compare Minor version
+    if ((${NEW_VERSION_PARTS[1]} < ${CURRENT_VERSION_PARTS[1]})); then
+      log "ERROR: New minor version (${NEW_VERSION_PARTS[1]}) cannot be lower than current minor version (${CURRENT_VERSION_PARTS[1]}) when major versions are the same."
+      exit 1
+    elif ((${NEW_VERSION_PARTS[1]} > ${CURRENT_VERSION_PARTS[1]})); then
+      log "Version check passed: New version ($VERSION) is greater than current version ($CURRENT_VERSION) (Minor increased)."
+      REVISION="00" # Reset revision on minor increase
+    else
+      # Major and Minor versions are equal, compare Patch version
+      if ((${NEW_VERSION_PARTS[2]} < ${CURRENT_VERSION_PARTS[2]})); then
+        log "ERROR: New patch version (${NEW_VERSION_PARTS[2]}) cannot be lower than current patch version (${CURRENT_VERSION_PARTS[2]}) when major and minor versions are the same."
+        exit 1
+      elif ((${NEW_VERSION_PARTS[2]} > ${CURRENT_VERSION_PARTS[2]})); then
+        log "Version check passed: New version ($VERSION) is greater than current version ($CURRENT_VERSION) (Patch increased)."
+        REVISION="00" # Reset revision on patch increase
+      else
+        # Versions are identical (Major, Minor, Patch are equal)
+        log "New version ($VERSION) is identical to current version ($CURRENT_VERSION). Incrementing revision."
+        log "Attempting to extract current revision from $PACKAGE_JSON using sed (Note: This is fragile)"
+        local current_revision_val=$(sed -n 's/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
+        # Check if sed successfully extracted a revision
+        if [ -z "$current_revision_val" ]; then
+          log "ERROR: Failed to extract 'revision' from $PACKAGE_JSON using sed. Check file format or key presence."
+          exit 1 # Exit if sed fails
+        fi
+        log "Successfully extracted revision using sed: $current_revision_val"
+        if [ -z "$current_revision_val" ] || [ "$current_revision_val" == "null" ]; then
+          log "ERROR: Could not read current revision from $PACKAGE_JSON"
+          exit 1
+        fi
+        # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
+        local current_revision_int=$((10#$current_revision_val))
+        local new_revision_int=$((current_revision_int + 1))
+        # Format back to two digits with leading zero
+        REVISION=$(printf "%02d" "$new_revision_int")
+        log "Current revision: $current_revision_val. New revision set to: $REVISION"
+      fi
+    fi
+  fi
+  log "Final revision determined: $REVISION"
+}
+
+# Function to update VERSION.json
+update_root_version_json() {
+  if [ -f "$VERSION_FILE" ]; then
+    log "Processing $VERSION_FILE"
+    # Update version and revision in VERSION.json
+    local modified=false
+
+    # Update version in VERSION.json
+    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+      sed -i "s/^\s*\"version\"\s*:\s*\"[^\"]*\"/  \"version\": \"$VERSION\"/" "$VERSION_FILE"
+      modified=true
+    fi
+
+    # Update stage in VERSION.json
+    if [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
+      sed -i "s/^\s*\"stage\"\s*:\s*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
+      modified=true
+    fi
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated $VERSION_FILE with new version: $VERSION and stage: $STAGE"
+    fi
+  else
+    log "WARNING: $VERSION_FILE not found. Skipping update."
+  fi
+}
+
+update_package_json() {
+  if [ -f "$PACKAGE_JSON" ]; then
+    log "Processing $PACKAGE_JSON"
+    local modified=false
+    # Update version and revision in package.json
+    # "wazuh": {
+    #   "version": "4.13.0",
+    #   "revision": "00"
+    # },
+    # Update version and revision in package.json using the structure above
+    # Use sed with address range to target lines within the "wazuh": { ... } block
+    # Update version in package.json
+    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+      log "Attempting to update version to $VERSION within 'wazuh' object in $PACKAGE_JSON"
+      # Note: This sed command assumes a specific formatting and might be fragile.
+      # It looks for the block starting with a line containing "wazuh": { and ending with the next line containing only }
+      # Within that block, it replaces the value on the line starting with "version":
+      sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"version\"\s*:\s*\)\"[^\"]*\"/\1\"$VERSION\"/" "$PACKAGE_JSON"
+      modified=true
+    fi
+
+    # Update revision in package.json
+    if [[ "$CURRENT_REVISION" != "$REVISION" ]]; then
+      log "Attempting to update revision to $REVISION within 'wazuh' object in $PACKAGE_JSON"
+      # Similar sed command for the revision line within the same block
+      sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"revision\"\s*:\s*\)\"[^\"]*\"/\1\"$REVISION\"/" "$PACKAGE_JSON"
+      modified=true
+    fi
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated $PACKAGE_JSON with new version: $VERSION and revision: $REVISION"
+    fi
+  else
+    log "WARNING: $PACKAGE_JSON not found. Skipping update."
+  fi
+}
+
+# Function to update CHANGELOG.md
+update_changelog() {
+  log "Updating CHANGELOG.md..."
+  local changelog_file="${REPO_PATH}/CHANGELOG.md"
+
+  # Extract OpenSearch Dashboards version from package.json
+  # Attempt to extract OpenSearch Dashboards version using sed (WARNING: Fragile!)
+  # This assumes "pluginPlatform": { ... "version": "x.y.z" ... } structure
+  # It looks for the block starting with "pluginPlatform": { and ending with }
+  # Within that block, it finds the line starting with "version": "..." and extracts the value.
+  # This is significantly less reliable than using jq.
+  log "Attempting to extract .version from $VERSION_FILE using sed (Note: This is fragile)"
+  # Extract OpenSearch Dashboards version from package.json (first occurrence of "version")
+  OPENSEARCH_VERSION=$(sed -n 's/^\s*"version"\s*:\s*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
+  if [ -z "$OPENSEARCH_VERSION" ] || [ "$OPENSEARCH_VERSION" == "null" ]; then
+    log "ERROR: Could not extract pluginPlatform.version from $PACKAGE_JSON for changelog"
+    exit 1
+  fi
+  log "Detected OpenSearch Dashboards version for changelog: $OPENSEARCH_VERSION"
+
+  # Construct the new changelog entry
+  # Note: Using printf for better handling of newlines and potential special characters
+  # Use the calculated REVISION variable here
+  # Prepare the header to search for
+  local changelog_header="## Wazuh dashboard v${VERSION} - OpenSearch Dashboards ${OPENSEARCH_VERSION} - Revision "
+  local changelog_header_regex="^${changelog_header}[0-9]+"
+
+  # Check if an entry for this version and OpenSearch version already exists
+  if grep -qE "$changelog_header_regex" "$changelog_file"; then
+    log "Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only."
+    # Use sed to update only the revision number in the header
+    sed -i -E "s|(${changelog_header_regex})|${changelog_header}${REVISION}|" "$changelog_file" &&
+      log "CHANGELOG.md revision updated successfully." || {
+      log "ERROR: Failed to update revision in $changelog_file"
+      exit 1
+    }
+  else
+    log "No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry."
+    local new_entry
+    new_entry=$(printf "${changelog_header}%s\n\n### Added\n\n- Support for Wazuh %s\n" "$REVISION" "$VERSION")
+
+    # Use awk to insert the new entry after the title and description (lines 1-4)
+    awk -v entry="$new_entry" '
+    NR == 1 { print; next } # Print line 1 (# Change Log)
+    NR == 2 { print; next } # Print line 2 (blank)
+    NR == 3 { print; next } # Print line 3 (description)
+    NR == 4 { print; printf "%s\n\n", entry; next } # Print line 4 (blank) and insert entry
+    { print } # Print the rest of the lines starting from line 5
+    ' "$changelog_file" >temp_changelog && mv temp_changelog "$changelog_file" || {
+      log "ERROR: Failed to update $changelog_file"
+      rm -f temp_changelog # Clean up temp file on error
+      exit 1
+    }
+    log "CHANGELOG.md updated successfully."
+  fi
+}
+
+# --- Main Execution ---
+main() {
+  # Initialize log file
+  touch "$LOG_FILE"
+  log "Starting repository bump process"
+
+  # Check if inside a git repository early
+  if [ -z "$REPO_PATH" ]; then
+    # Use log function for consistency, redirect initial error to stderr
+    log "ERROR: Failed to determine repository root. Ensure you are inside the git repository." >&2
+    exit 1
+  fi
+  log "Repository path: $REPO_PATH"
+
+  # Parse and validate arguments
+  parse_arguments "$@"
+  validate_input
+  log "Version: $VERSION"
+  log "Stage: $STAGE"
+
+  # Perform pre-update checks
+  pre_update_checks
+
+  # Compare versions and determine revision
+  compare_versions_and_set_revision
+
+  # Start file modifications
+  log "Starting file modifications..."
+
+  update_root_version_json
+  update_package_json
+  update_changelog
+
+  log "File modifications completed."
+  log "Repository bump completed successfully. Log file: $LOG_FILE"
+  exit 0
+}
+
+# Execute main function with all script arguments
+main "$@"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -17,6 +17,7 @@ REVISION="00"
 CURRENT_VERSION=""
 WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/build_wazuh_dashboard_with_plugins.yml"
 DOCKERFILE_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile"
+README_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/README.md"
 
 # --- Helper Functions ---
 
@@ -367,6 +368,30 @@ update_base_package_dockerfile() {
   fi
 }
 
+update_readme_for_base_packages() {
+  log "Updating $(basename $README_FOR_BASE_PACKAGES)..."
+
+  if [ -f "$README_FOR_BASE_PACKAGES" ]; then
+    local modified=false
+
+    # Update all occurrences of --app x.y.z with --app $VERSION
+    sed -i -E "s/(--app )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+
+    # Update all occurrences of --base x.y.z with --base $VERSION
+    sed -i -E "s/(--base )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+
+    # Update all occurrences of --security x.y.z with --security $VERSION
+    sed -i -E "s/(--security )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+
+    # Update all occurrences of --security x.y.z with --security $VERSION
+    sed -i -E "s/(This example will create a packages folder that inside will have the packages divided by repository of the )[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES" && modified=true
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated $(basename $README_FOR_BASE_PACKAGES)"
+    fi
+  fi
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -401,6 +426,7 @@ main() {
   update_changelog
   update_build_workflow
   update_base_package_dockerfile
+  update_readme_for_base_packages
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"


### PR DESCRIPTION
### Description

We need to develop new functionality to automatically bump the version and stage of the repository.

The objective of this issue is to eliminate the need for manually changing repository details related to the version, stage, and other related data.

<details><summary>Requirements and restrictions</summary>

#### Script

- [x] Each repository bumper should be developed using a Unix shell script (.sh).
- [x] The repository bumper script should log its actions to a log file named `repository_bumper_{date_time}.log`, where `date_time` is the timestamp when the script is executed. For example: `repository_bumper_2025-04-04_18-47-04-670.log`.
- [x] The log file will be located in the same path as the script.
- [x] The repository bumper should report each file that is modified.
- [x] The repository bumper should be located in a `tools` directory at the root of the repository.
- [x] The repository bumper must accept the following parameters:
  - [x] `version`: string (e.g., x.y.z, such as 4.12.0)
  - [x] `stage`: string (e.g., textnumber, such as alpha0)

- The repository bumper may accept additional parameters depending on the specific repository, such as:
  - `date`: string (e.g., yyyy-mm-dd, such as 2025-04-13)
- Any other parameters required for the bump procedure, which are not listed here, should be communicated to the @wazuh/devel-xdrsiem-qa-leaders team.

</details>

Introduces a shell script to automate version and stage updates across the repository. Includes validation, logging and JSON/YAML updates. Adds a .gitignore entry to exclude generated log files.

### Issues Resolved

[Repository bumper script development · Issue #620 · wazuh/wazuh-dashboard](https://github.com/wazuh/wazuh-dashboard/issues/620)

## Changelog
- skip

### Evidence

<details><summary>The repository bumper should be located in a `tools` directory at the root of the repository.</summary>
<p>

![image](https://github.com/user-attachments/assets/ff8cef41-c297-45a5-b3a2-51d3d3108cf3)

</p>
</details> 

<details><summary>Version parameter is required</summary>
<p>

![image](https://github.com/user-attachments/assets/2196f541-882a-468e-ad30-61f44d4c22b5)

</p>
</details> 

<details><summary>Stage parameter is required</summary>
<p>

![image](https://github.com/user-attachments/assets/ad1b0512-af88-419f-851c-2ee21c74546f)

</p>
</details> 

<details><summary>Version must be in the format x.y.z (e.g., 4.6.0)</summary>
<p>

![image](https://github.com/user-attachments/assets/19c7c446-c2b2-4c9a-b901-3bbac39e2b75)

</p>
</details> 

<details><summary>Stage must be alphanumeric (e.g., alpha0, beta1, rc2)</summary>
<p>

![image](https://github.com/user-attachments/assets/e5af7912-1f52-4290-b3c2-6b96c8b77eb2)

</p>
</details> 

<details><summary>New major version (2) cannot be lower than current major version (4).</summary>
<p>

![image](https://github.com/user-attachments/assets/a5cea13b-20d9-4ccf-9826-fcfe3ada7cf4)

</p>
</details> 

<details><summary>New minor version (12) cannot be lower than current minor version (13) when major versions are the same.</summary>
<p>

![image](https://github.com/user-attachments/assets/91dd2467-3e16-4482-99ed-5aad8f413726)

</p>
</details> 

<details><summary>New patch version (0) cannot be lower than current patch version (1) when major and minor versions are the same.</summary>
<p>

![image](https://github.com/user-attachments/assets/60c752a3-b399-4a4c-89bb-0b5514588084)

</p>
</details> 

<details><summary>The repository bumper script should log its actions to a log file named `repository_bumper_{date_time}.log`, where `date_time` is the timestamp when the script is executed. For example: `repository_bumper_2025-04-04_18-47-04-670.log` and the log file will be located in the same path as the script.</summary>
<p>

![image](https://github.com/user-attachments/assets/8efa630c-78b8-43af-8bd6-b32ab73a1309)

</p>
</details> 

<details><summary>When keeping the same version, only the revision should be modified. The repository bumper should report each file that is modified.</summary>
<p>

```console
./repository_bumper.sh --version 4.13.0 --stage alpha1
```

![image](https://github.com/user-attachments/assets/5319710e-1fc5-4bcc-9c78-ddcd1530c58a)

```diff
diff --git a/.github/workflows/build_wazuh_dashboard_with_plugins.yml b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
index b5c9352320..55511c4248 100644
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -206,7 +206,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.13.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.13.0-alpha1
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -214,14 +214,14 @@ jobs:
   build-main-plugins:
     needs: [validate-job]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.13.0-alpha1
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-job]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.13.0-alpha1
     with:
       reference: ${{ inputs.reference_security_plugins }}
 
diff --git a/CHANGELOG.md b/CHANGELOG.md
index a1d806aadc..e6e5d36be4 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh dashboard v4.13.0 - OpenSearch Dashboards 2.19.1 - Revision 00
+## Wazuh dashboard v4.13.0 - OpenSearch Dashboards 2.19.1 - Revision 01
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 4d32c49e25..3747a847fb 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.13.0",
-  "stage": "alpha0"
+  "stage": "alpha1"
 }
diff --git a/dev-tools/build-packages/base-packages-to-base/README.md b/dev-tools/build-packages/base-packages-to-base/README.md
index e5c8290bdc..6ffdba0f6a 100644
--- a/dev-tools/build-packages/base-packages-to-base/README.md
+++ b/dev-tools/build-packages/base-packages-to-base/README.md
@@ -27,11 +27,11 @@ Example:
 
 ```bash
 bash run-docker-compose.sh \
-    --app 4.12.1 \
-    --base 4.12.1 \
-    --security 4.12.1 \
+    --app 4.13.0 \
+    --base 4.13.0 \
+    --security 4.13.0 \
     --arm \
     --node-version 18.19.0
 \```
 
-This example will create a packages folder that inside will have the packages divided by repository of the 4.12.1 branch of each one.
+This example will create a packages folder that inside will have the packages divided by repository of the 4.13.0 branch of each one.
diff --git a/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile b/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
index 3011fd4386..639692a154 100644
--- a/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
+++ b/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
@@ -1,11 +1,11 @@
 # Usage:
 # docker build \
 #         --build-arg NODE_VERSION=18.19.0 \
-#         --build-arg WAZUH_DASHBOARD_BRANCH=4.12.1 \
-#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.12.1 \
-#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.12.1 \
+#         --build-arg WAZUH_DASHBOARD_BRANCH=4.13.0 \
+#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.13.0 \
+#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.13.0 \
 #         --build-arg ARCHITECTURE=arm \
-#         -t wazuh-packages-to-base:4.12.1 \
+#         -t wazuh-packages-to-base:4.13.0 \
 #         -f base-packages.Dockerfile .
 
 ARG NODE_VERSION=18.19.0
diff --git a/package.json b/package.json
index 7f2f8a311f..74bd98f051 100644
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "wazuh": {
     "version": "4.13.0",
-    "revision": "00"
+    "revision": "01"
   },
   "homepage": "https://opensearch.org",
   "bugs": {
``` 
</p>
</details> 

<details><summary>When you keep the version but change the Stage, only the revision should be modified in corresponding files and the Stage in VERSION.json.</summary>
<p>

```console
./repository_bumper.sh --version 4.13.0 --stage alpha1
``` 

![image](https://github.com/user-attachments/assets/1e5e8a63-93c3-4476-a272-5c1d56537c6d)

```diff
diff --git a/.github/workflows/build_wazuh_dashboard_with_plugins.yml b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
index b5c9352320..55511c4248 100644
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -206,7 +206,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.13.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.13.0-alpha1
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -214,14 +214,14 @@ jobs:
   build-main-plugins:
     needs: [validate-job]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.13.0-alpha1
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-job]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.13.0-alpha1
     with:
       reference: ${{ inputs.reference_security_plugins }}
 
diff --git a/CHANGELOG.md b/CHANGELOG.md
index a1d806aadc..e6e5d36be4 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh dashboard v4.13.0 - OpenSearch Dashboards 2.19.1 - Revision 00
+## Wazuh dashboard v4.13.0 - OpenSearch Dashboards 2.19.1 - Revision 01
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 4d32c49e25..3747a847fb 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.13.0",
-  "stage": "alpha0"
+  "stage": "alpha1"
 }
diff --git a/dev-tools/build-packages/base-packages-to-base/README.md b/dev-tools/build-packages/base-packages-to-base/README.md
index e5c8290bdc..6ffdba0f6a 100644
--- a/dev-tools/build-packages/base-packages-to-base/README.md
+++ b/dev-tools/build-packages/base-packages-to-base/README.md
@@ -27,11 +27,11 @@ Example:
 
 ```bash
 bash run-docker-compose.sh \
-    --app 4.12.1 \
-    --base 4.12.1 \
-    --security 4.12.1 \
+    --app 4.13.0 \
+    --base 4.13.0 \
+    --security 4.13.0 \
     --arm \
     --node-version 18.19.0
 \```
 
-This example will create a packages folder that inside will have the packages divided by repository of the 4.12.1 branch of each one.
+This example will create a packages folder that inside will have the packages divided by repository of the 4.13.0 branch of each one.
diff --git a/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile b/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
index 3011fd4386..639692a154 100644
--- a/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
+++ b/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
@@ -1,11 +1,11 @@
 # Usage:
 # docker build \
 #         --build-arg NODE_VERSION=18.19.0 \
-#         --build-arg WAZUH_DASHBOARD_BRANCH=4.12.1 \
-#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.12.1 \
-#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.12.1 \
+#         --build-arg WAZUH_DASHBOARD_BRANCH=4.13.0 \
+#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.13.0 \
+#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.13.0 \
 #         --build-arg ARCHITECTURE=arm \
-#         -t wazuh-packages-to-base:4.12.1 \
+#         -t wazuh-packages-to-base:4.13.0 \
 #         -f base-packages.Dockerfile .
 
 ARG NODE_VERSION=18.19.0
diff --git a/package.json b/package.json
index 7f2f8a311f..74bd98f051 100644
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "wazuh": {
     "version": "4.13.0",
-    "revision": "00"
+    "revision": "01"
   },
   "homepage": "https://opensearch.org",
   "bugs": {
``` 

</p>
</details> 

<details><summary>When changing the version, specifically the patch version, only the corresponding files should be updated and the revision should be set to zero. And a new entry should be added to the CHANGELOG, with the new version and the revision set to zero.</summary>
<p>

```console
./repository_bumper.sh --version 4.13.1 --stage alpha0
``` 

![image](https://github.com/user-attachments/assets/4a6817ce-f442-49e0-bea2-fa6980a8e6af)

```diff
diff --git a/.github/workflows/build_wazuh_dashboard_with_plugins.yml b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
index b5c9352320..56cde64ad1 100644
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -206,7 +206,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.13.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.13.1-alpha0
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -214,14 +214,14 @@ jobs:
   build-main-plugins:
     needs: [validate-job]
     name: Build plugins
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.13.1-alpha0
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
   build-security-plugin:
     needs: [validate-job]
     name: Build security plugin
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.13.1-alpha0
     with:
       reference: ${{ inputs.reference_security_plugins }}
 
diff --git a/CHANGELOG.md b/CHANGELOG.md
index a1d806aadc..90479d33ef 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh dashboard v4.13.1 - OpenSearch Dashboards 2.19.1 - Revision 00
+
+### Added
+
+- Support for Wazuh 4.13.1
+
 ## Wazuh dashboard v4.13.0 - OpenSearch Dashboards 2.19.1 - Revision 00
 
 ### Added
diff --git a/VERSION.json b/VERSION.json
index 4d32c49e25..bd93ea6873 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.13.0",
+  "version": "4.13.1",
   "stage": "alpha0"
 }
diff --git a/dev-tools/build-packages/base-packages-to-base/README.md b/dev-tools/build-packages/base-packages-to-base/README.md
index e5c8290bdc..2879e956c3 100644
--- a/dev-tools/build-packages/base-packages-to-base/README.md
+++ b/dev-tools/build-packages/base-packages-to-base/README.md
@@ -27,11 +27,11 @@ Example:
 
 ```bash
 bash run-docker-compose.sh \
-    --app 4.12.1 \
-    --base 4.12.1 \
-    --security 4.12.1 \
+    --app 4.13.1 \
+    --base 4.13.1 \
+    --security 4.13.1 \
     --arm \
     --node-version 18.19.0
 \```
 
-This example will create a packages folder that inside will have the packages divided by repository of the 4.12.1 branch of each one.
+This example will create a packages folder that inside will have the packages divided by repository of the 4.13.1 branch of each one.
diff --git a/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile b/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
index 3011fd4386..2f6fc188db 100644
--- a/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
+++ b/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile
@@ -1,11 +1,11 @@
 # Usage:
 # docker build \
 #         --build-arg NODE_VERSION=18.19.0 \
-#         --build-arg WAZUH_DASHBOARD_BRANCH=4.12.1 \
-#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.12.1 \
-#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.12.1 \
+#         --build-arg WAZUH_DASHBOARD_BRANCH=4.13.1 \
+#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.13.1 \
+#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.13.1 \
 #         --build-arg ARCHITECTURE=arm \
-#         -t wazuh-packages-to-base:4.12.1 \
+#         -t wazuh-packages-to-base:4.13.1 \
 #         -f base-packages.Dockerfile .
 
 ARG NODE_VERSION=18.19.0
diff --git a/package.json b/package.json
index 7f2f8a311f..ef8727f54c 100644
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "sha": "6cb7fec4e154faa0a4a3fee4b33dfef91b9870d9"
   },
   "wazuh": {
-    "version": "4.13.0",
+    "version": "4.13.1",
     "revision": "00"
   },
   "homepage": "https://opensearch.org",
diff --git a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
index 8ea635ea38..0a21320f34 100644
--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -51,7 +51,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
 
@@ -106,7 +106,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
 
@@ -161,7 +161,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
 
@@ -220,7 +220,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
 
@@ -275,7 +275,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
 
@@ -326,7 +326,7 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
 
@@ -381,6 +381,6 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "4.13.0",
+  "wazuhVersion": "4.13.1",
 }
 `;
``` 

</p>
</details> 

### Test

For this testing section, you should follow the steps outlined in the evidence.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

- [ ] Add README.md
