### PR TITLE
Add Wazuh repository before testing upgrade in smoke tests

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -139,9 +139,9 @@ jobs:
           CURRENT_DIR=$(pwd -P)
           VERSION=$(jq -r '.version' VERSION.json)
           # Check the corresponding previous version to be used in the upgrade test
-          curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
-          echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
-          apt-get update
+          sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
+          sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
+          sudo apt-get update
           PREVIOUS=$(apt-cache madison wazuh-dashboard | grep -A 1 "$VERSION" | tail -1 | awk '{print $3}')
           if [ -z "$PREVIOUS" ]; then
             MAJOR_MINOR=$(echo "$VERSION" | cut -d '.' -f 1,2)

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -139,6 +139,9 @@ jobs:
           CURRENT_DIR=$(pwd -P)
           VERSION=$(jq -r '.version' VERSION.json)
           # Check the corresponding previous version to be used in the upgrade test
+          curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
+          echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+          apt-get update
           PREVIOUS=$(apt-cache madison wazuh-dashboard | grep -A 1 "$VERSION" | tail -1 | awk '{print $3}')
           if [ -z "$PREVIOUS" ]; then
             MAJOR_MINOR=$(echo "$VERSION" | cut -d '.' -f 1,2)

--- a/src/core/public/chrome/ui/header/__snapshots__/header_help_menu.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header_help_menu.test.tsx.snap
@@ -1812,7 +1812,7 @@ exports[`Header help menu hides survey link 1`] = `
                       >
                         <a
                           class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
-                          href="https://documentation.wazuh.com/4.12/"
+                          href="https://documentation.wazuh.com/4.13/"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
@@ -2028,14 +2028,14 @@ exports[`Header help menu hides survey link 1`] = `
                         >
                           <EuiButtonEmpty
                             flush="left"
-                            href="https://documentation.wazuh.com/4.12/"
+                            href="https://documentation.wazuh.com/4.13/"
                             iconType="/ui/logos/icon_light.svg"
                             size="xs"
                             target="_blank"
                           >
                             <a
                               className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
-                              href="https://documentation.wazuh.com/4.12/"
+                              href="https://documentation.wazuh.com/4.13/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
@@ -4042,7 +4042,7 @@ exports[`Header help menu renders survey link 1`] = `
                       >
                         <a
                           class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
-                          href="https://documentation.wazuh.com/4.12/"
+                          href="https://documentation.wazuh.com/4.13/"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
@@ -4283,14 +4283,14 @@ exports[`Header help menu renders survey link 1`] = `
                         >
                           <EuiButtonEmpty
                             flush="left"
-                            href="https://documentation.wazuh.com/4.12/"
+                            href="https://documentation.wazuh.com/4.13/"
                             iconType="/ui/logos/icon_light.svg"
                             size="xs"
                             target="_blank"
                           >
                             <a
                               className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
-                              href="https://documentation.wazuh.com/4.12/"
+                              href="https://documentation.wazuh.com/4.13/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >


### PR DESCRIPTION
### Description

This PR fixes a bug on which the upgrade smoke test will always fail due to a missing Wazuh repository to infer the previous Wazuh version. 

### Issues Resolved

#642 

### Evidence

- https://github.com/wazuh/wazuh-dashboard/actions/runs/14903536637
- https://github.com/wazuh/wazuh-dashboard/actions/runs/14903541980
- https://github.com/wazuh/wazuh-dashboard/actions/runs/14903550830
- https://github.com/wazuh/wazuh-dashboard/actions/runs/14887693359

![image](https://github.com/user-attachments/assets/ebe0ea3c-d5f4-454a-9d93-77537ddaeb94)
![image](https://github.com/user-attachments/assets/f4ad3d57-bfee-4e48-9bcf-1e3b05e86cc8)
![image](https://github.com/user-attachments/assets/262a8690-9f4a-4911-b567-ccd456171fdf)
![image](https://github.com/user-attachments/assets/a860e919-f167-4f97-9b3b-654f1375734b)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
