### PR TITLE
Fix bug in repository bumper script

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -223,7 +223,7 @@ compare_versions_and_set_revision() {
         local current_revision_int=$((10#$current_revision_val))
         local new_revision_int=$((current_revision_int + 1))
         # Format back to two digits with leading zero
-        if [ -n "$STAGE" ]; then
+        if [ -n "$STAGE" ] && [ "$STAGE" != "$CURRENT_STAGE" ]; then
           REVISION=$(printf "%02d" "$new_revision_int")
           log "Current revision: $current_revision_val. New revision set to: $REVISION"
         else

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -207,25 +207,28 @@ compare_versions_and_set_revision() {
       else
         # Versions are identical (Major, Minor, Patch are equal)
         log "New version ($VERSION) is identical to current version ($CURRENT_VERSION)."
+        log "Attempting to extract current revision from $PACKAGE_JSON using sed (Note: This is fragile)"
+        local current_revision_val=$(sed -n 's/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
+        # Check if sed successfully extracted a revision
+        if [ -z "$current_revision_val" ]; then
+          log "ERROR: Failed to extract 'revision' from $PACKAGE_JSON using sed. Check file format or key presence."
+          exit 1 # Exit if sed fails
+        fi
+        log "Successfully extracted revision using sed: $current_revision_val"
+        if [ -z "$current_revision_val" ] || [ "$current_revision_val" == "null" ]; then
+          log "ERROR: Could not read current revision from $PACKAGE_JSON"
+          exit 1
+        fi
+        # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
+        local current_revision_int=$((10#$current_revision_val))
+        local new_revision_int=$((current_revision_int + 1))
+        # Format back to two digits with leading zero
         if [ -n "$STAGE" ]; then
-          log "Attempting to extract current revision from $PACKAGE_JSON using sed (Note: This is fragile)"
-          local current_revision_val=$(sed -n 's/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
-          # Check if sed successfully extracted a revision
-          if [ -z "$current_revision_val" ]; then
-            log "ERROR: Failed to extract 'revision' from $PACKAGE_JSON using sed. Check file format or key presence."
-            exit 1 # Exit if sed fails
-          fi
-          log "Successfully extracted revision using sed: $current_revision_val"
-          if [ -z "$current_revision_val" ] || [ "$current_revision_val" == "null" ]; then
-            log "ERROR: Could not read current revision from $PACKAGE_JSON"
-            exit 1
-          fi
-          # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
-          local current_revision_int=$((10#$current_revision_val))
-          local new_revision_int=$((current_revision_int + 1))
-          # Format back to two digits with leading zero
           REVISION=$(printf "%02d" "$new_revision_int")
           log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        else
+          REVISION=$(printf "%02d" "$current_revision_int")
+          log "Current revision: $current_revision_val."
         fi
       fi
     fi


### PR DESCRIPTION
### Description

This PR fixes a bump on which the repository bumper script increases the revision when `--tag` is used without any other parameters.

### Issues Resolved

#716 


## Test
> [!NOTE]
> All tests were performed in order, one after another

<details> 
<summary>`--tag` changing the version should set the revision to 00</summary>

`./repository_bumper.sh --version 4.14.0 --tag`
![image](https://github.com/user-attachments/assets/8b46fe11-18a8-4be7-8853-50c876400ab1)
![image](https://github.com/user-attachments/assets/7f57cdfd-d736-44c1-a4d4-d07817cb5220)


</details> 

<details> 
<summary>`--tag` changing the stage should increase the revision</summary>

`./repository_bumper.sh --stage alpha1 --tag`

![image](https://github.com/user-attachments/assets/342e12ed-39e5-4eb8-a365-0b9abcd8e272)
![image](https://github.com/user-attachments/assets/727b4f7e-b5b7-47e3-8f76-568525dddb80)

</details> 

<details> 
<summary>`--tag` without any other parameter should not change the revision</summary>

`./repository_bumper.sh --tag`

![image](https://github.com/user-attachments/assets/5219d14d-2822-4baf-a4b5-0347f22921e8)
![image](https://github.com/user-attachments/assets/1acf0820-fb2e-49a0-95b4-9a40301cc861)

</details> 

<details> 
<summary>`--tag` changing the version and stage should set the revision to 00</summary>

`./repository_bumper.sh --version 4.15.0 --stage beta1 --tag`

![image](https://github.com/user-attachments/assets/27590d9b-5876-453a-ad56-0b0487e8367e)
![image](https://github.com/user-attachments/assets/b7f180c6-d91d-4c25-b5c4-2953ef3546ad)

</details> 

<details> 
<summary>`--tag` keeping the same stage and version should not modify the revision</summary>
`./repository_bumper.sh --version 4.15.0 --stage beta1 --tag`

![image](https://github.com/user-attachments/assets/c245a4c2-9d8a-4a35-a8fd-fc621e64983b)

</details> 

<details> 
<summary>Changing the version without `--tag` should set the revision to 00</summary>

`./repository_bumper.sh --version 4.16.0 --stage beta1`

![image](https://github.com/user-attachments/assets/61a43f5b-e3c0-47b1-b5b6-39414bfa248b)
![image](https://github.com/user-attachments/assets/2a05bc71-4b58-4951-bee6-8756b17abe65)

</details> 

<details> 
<summary>Changing the stage without `--tag` should increase the revision number</summary>

`./repository_bumper.sh --version 4.16.0 --stage beta2`

![image](https://github.com/user-attachments/assets/76aa43a6-738e-46fd-a117-84c64d0570aa)

</details> 

<details> 
<summary>Changing version and stage without `--tag` should set the revision to 00</summary>
`./repository_bumper.sh --version 4.16.1 --stage alpha1`

![image](https://github.com/user-attachments/assets/392c716a-b8d7-4f2c-bfef-f130b18a6a99)

</details> 


<details> 
<summary>Keeping the same stage and version without `--tag` should not change the revision</summary>
`./repository_bumper.sh --version 4.16.1 --stage alpha1`

![image](https://github.com/user-attachments/assets/cf1b628f-c5b3-4b77-8d74-fc8f7a933ba9)

</details> 


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
