### PR TITLE
Development - AWS XDR+SIEM Refactor Tier 2 - Dashboard - packages-dev.internal.wazuh.com bucket migration

### DIFF
--- a/.github/workflows/6_builderpackage_dashboard.yml
+++ b/.github/workflows/6_builderpackage_dashboard.yml
@@ -389,14 +389,14 @@ jobs:
         if: ${{ inputs.upload }}
         run: |
           echo "Uploading package"
-          aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/6.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/6.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}"
+          aws s3 cp  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}} s3://xdrsiem-packages-dev-internal/development/wazuh/6.x/main/packages/
+          s3uri="s3://xdrsiem-packages-dev-internal/development/wazuh/6.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}"
           echo "S3 URI: ${s3uri}"
 
       - name: Upload SHA512
         if: ${{ inputs.checksum }}
         run: |
           echo "Uploading checksum"
-          aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/6.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/6.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512"
+          aws s3 cp ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/6.x/main/packages/
+          s3uri="s3://xdrsiem-packages-dev-internal/development/wazuh/6.x/main/packages/${{needs.setup-variables.outputs.FINAL_NAME}}.sha512"
           echo "S3 sha512 URI: ${s3uri}"

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -544,14 +544,14 @@ jobs:
       - name: Upload package
         run: |
           echo "Uploading package"
-          aws s3 cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}"
+          aws s3 cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}} s3://xdrsiem-packages-dev-internal/development/wazuh/4.x/main/packages/
+          s3uri="s3://xdrsiem-packages-dev-internal/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}"
           echo "S3 URI: ${s3uri}"
 
       - name: Upload SHA512
         if: ${{ inputs.checksum }}
         run: |
           echo "Uploading checksum"
-          aws s3 cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
-          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512"
+          aws s3 cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/4.x/main/packages/
+          s3uri="s3://xdrsiem-packages-dev-internal/development/wazuh/4.x/main/packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512"
           echo "S3 sha512 URI: ${s3uri}"


### PR DESCRIPTION
### Description

As stated in #2520, the `packages-dev.internal.wazuh.com` is being migrated to a new bucket under the `xdrsiem-pre` account. The name of the new bucket will be `xdrsiem-packages-dev-internal`. We need to perform the required changes to migrate to the new buckets.

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- The workflow to build Wazuh Dashboard packages passes.
- The workflow to build Wazuh Dashboard packages uploads the packages to the `xdrsiem-packages-dev-internal` bucket.

GHA: https://github.com/wazuh/wazuh-dashboard/actions/runs/15999034220 ✅

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
