### PR TITLE
Fix duplicated configuration files issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.13.0
 
+### Fixed
+
+- Fixed a problem that caused configuration files to be duplicated [#790](https://github.com/wazuh/wazuh-dashboard/issues/790)
+
 ## Wazuh dashboard v4.12.1 - OpenSearch Dashboards 2.19.1 - Revision 00
 
 ### Added

--- a/dev-tools/build-packages/deb/debian/rules
+++ b/dev-tools/build-packages/deb/debian/rules
@@ -67,8 +67,8 @@ override_dh_install:
 	mkdir -p $(TARGET_DIR)/etc/systemd/system
 	mkdir -p $(TARGET_DIR)/etc/default
 
-	cp wazuh-dashboard-base/config/node.options $(TARGET_DIR)$(CONFIG_DIR)
-	cp wazuh-dashboard-base/config/opensearch_dashboards.yml $(TARGET_DIR)$(CONFIG_DIR)
+	mv wazuh-dashboard-base/config/node.options $(TARGET_DIR)$(CONFIG_DIR)
+	mv wazuh-dashboard-base/config/opensearch_dashboards.yml $(TARGET_DIR)$(CONFIG_DIR)
 	mv wazuh-dashboard-base/* $(TARGET_DIR)$(INSTALLATION_DIR)
 
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/config

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -66,8 +66,8 @@ mkdir -p %{buildroot}/etc/systemd/system
 mkdir -p %{buildroot}%{_initrddir}
 mkdir -p %{buildroot}/etc/default
 
-cp wazuh-dashboard-base/config/node.options %{buildroot}%{CONFIG_DIR}
-cp wazuh-dashboard-base/config/opensearch_dashboards.yml %{buildroot}%{CONFIG_DIR}
+mv wazuh-dashboard-base/config/node.options %{buildroot}%{CONFIG_DIR}
+mv wazuh-dashboard-base/config/opensearch_dashboards.yml %{buildroot}%{CONFIG_DIR}
 cp wazuh-dashboard-base/VERSION.json %{buildroot}%{INSTALL_DIR}
 
 mv wazuh-dashboard-base/* %{buildroot}%{INSTALL_DIR}
@@ -205,8 +205,6 @@ rm -fr %{buildroot}
 
 %config(noreplace) %attr(0750, %{USER}, %{GROUP}) "/etc/default/wazuh-dashboard"
 %config(noreplace) %attr(0640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch_dashboards.yml"
-%config(noreplace) %attr(0640, %{USER}, %{GROUP}) "%{INSTALL_DIR}/config/opensearch_dashboards.yml"
-%config(noreplace) %attr(0640, %{USER}, %{GROUP}) "%{INSTALL_DIR}/config/node.options"
 
 %attr(440, %{USER}, %{GROUP}) %{INSTALL_DIR}/VERSION.json
 %dir %attr(750, %{USER}, %{GROUP}) %{INSTALL_DIR}


### PR DESCRIPTION
### Description

This PR fixes a problem on which the configuration files `node.options` and `opensearch_dashboards.yml` were duplicated on Wazuh installations. 

### Issues Resolved

#789 

## Evidence

**deb**
```console
root@vagrant:/home/vagrant# ls -l /usr/share/wazuh-dashboard/config/
total 0
root@vagrant:/home/vagrant# ls -l /etc/wazuh-dashboard/
total 12
-rw-r----- 1 wazuh-dashboard wazuh-dashboard 312 May  5  2023 node.options
-rw-r--r-- 1 wazuh-dashboard wazuh-dashboard 226 Jul 10 17:18 opensearch_dashboards.keystore
-rw-r----- 1 wazuh-dashboard wazuh-dashboard 634 May  5  2023 opensearch_dashboards.yml
```

**rpm**
```console
[root@rhel9 vagrant]# ls -l /usr/share/wazuh-dashboard/config/
total 0
[root@rhel9 vagrant]# ls -l /etc/wazuh-dashboard/
total 12
dr-x------. 2 wazuh-dashboard wazuh-dashboard  83 Jul 10 18:24 certs
-rw-r-----. 1 wazuh-dashboard wazuh-dashboard 312 Jul 10 15:37 node.options
-rw-r--r--. 1 wazuh-dashboard wazuh-dashboard 254 Jul 10 18:25 opensearch_dashboards.keystore
-rw-r-----. 1 wazuh-dashboard wazuh-dashboard 714 Jul 10 18:24 opensearch_dashboards.yml
```
## Testing the changes

Generate packages on this branch, install them and verify that everything works as expected, and the configuration files are only in `/etc/wazuh-dashboard` and not in `/usr/share/wazuh-dashboard`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
