### PR TITLE
Fix apt update error in building deb package with debian:10 Docker base image

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -227,7 +227,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.13.0-rc1
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.13.0
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -237,7 +237,7 @@ jobs:
     name: Build plugins
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.13.0-rc1
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.13.0
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
@@ -246,7 +246,7 @@ jobs:
     name: Build security plugin
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.13.0-rc1
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.13.0
     with:
       reference: ${{ inputs.reference_security_plugins }}
 

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -227,7 +227,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@4.13.0
+    uses: wazuh/wazuh-dashboard/.github/workflows/build_base.yml@v4.13.0-rc1
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -237,7 +237,7 @@ jobs:
     name: Build plugins
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/manual-build.yml@v4.13.0-rc1
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
@@ -246,7 +246,7 @@ jobs:
     name: Build security plugin
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@4.13.0
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml@v4.13.0-rc1
     with:
       reference: ${{ inputs.reference_security_plugins }}
 

--- a/dev-tools/build-packages/deb/Docker/Dockerfile
+++ b/dev-tools/build-packages/deb/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:12
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### Description

This pull request updates the Docker base version to `debian:12` due to an error with the URL repository used by the `debian:10` versions

### Isses resolved
#794

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
