### PR TITLE
Add health check service

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,17 @@ const OSD_NEW_HEADER = `
 `;
 
 /**
+ * For new files created by Wazuh Contributors
+ */
+const OSD_WAZUH = `
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+`;
+
+
+/**
  * For modified and modified files with external open source code
  */
 const OSD_HEADER = `
@@ -157,7 +168,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            licenses: [OSD_NEW_HEADER, OSD_HEADER],
+            licenses: [OSD_NEW_HEADER, OSD_HEADER, OSD_WAZUH],
           },
         ],
         '@osd/eslint/disallow-license-headers': [

--- a/src/core/server/healthcheck/healthcheck/README.md
+++ b/src/core/server/healthcheck/healthcheck/README.md
@@ -1,0 +1,158 @@
+# HealthCheck
+
+The `HealthCheck` provides a mechanism to register and run tasks when the app runs.
+
+This is exposed throught the initialization service of core.
+
+Other plugins can register tasks in the plugin `setup` lifecycle that will be run on the server starts lifecycle.
+
+Optionally the registered tasks could be retrieved to run in API endpoints or getting information about its status.
+
+There are 2 scopes:
+
+- `internal`: run through the internal user
+  - on plugin starts
+  - on demand
+- `user`: run through the logged (requester) user
+  - on demand
+
+The scopes can be used to get a specific context (clients, parameters) that is set in the `scope` property of the task context.
+
+The `internal` scoped tasks keep the same execution data (see [Task execution data](#task-execution-data)), and the `user` scoped task are newly created on demand.
+
+When the app starts, all the registered tasks run for the `internal` scope and should pass to swap the server to the "final" server, else
+accessing to the app will display the `Wazuh dashboard server is not ready yet` view and optionally list the errors in the tasks. This blocks
+set the final server until all the checks are ok.
+
+# HealthCheck tasks
+
+A task can be defined with:
+
+```ts
+interface InitializationTaskDefinition {
+  name: string;
+  run: (ctx: any) => any;
+  order?: number
+  isCritical: boolean
+}
+```
+
+The `name` is used to identify the task and this is rendered in the context logger.
+
+The `order` defines the order to execute the task. Multiple tasks can have the same order and will be executed in parallel. If it is not defined, the task will be executed as last order group.
+
+The `isCritical` defines on any error, the health check should be considered as failed.
+
+The `ctx` is the context of the task execution and includes core services and task context services or dependencies.
+
+For example, in the server log:
+
+```
+server    log   [11:57:39.648] [info][index-pattern-vulnerabilities-states][healthcheck][plugins][wazuhCore] Index pattern with ID [wazuh-states-vulnerabilities-*] does not exist
+
+```
+
+the task name is `index-pattern-vulnerabilities-states`.
+
+## Task name convention
+
+- lowercase
+- kebab case (`word1-word2`)
+- use colon ( `:` ) for tasks related to some entity that have different subentities.
+
+```
+entity_identifier:entity_specific
+```
+
+For example:
+
+```
+index-pattern:alerts
+index-pattern:statistics
+index-pattern:vulnerabilities-states
+```
+
+## Register a task
+
+```ts
+// plugin setup
+setup(){
+
+  // Register a task
+  core.healthcheck.register({
+    name: 'custom-task',
+    run: (ctx) => {
+      console.log('Run from wazuhCore starts' )
+    },
+    order: 1
+    isCritical: false
+  });
+}
+```
+
+## Task execution data
+
+The task has the following data related to the execution:
+
+```ts
+interface InitializationTaskRunData {
+  name: string;
+  status: 'not_started' | 'running' | 'finished';
+  result: 'success' | 'fail';
+  createdAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  duration: number | null; // seconds
+  data: any;
+  error: string | null;
+  _meta: any
+}
+```
+
+## Create a task instance
+
+This is used to create the user scoped tasks.
+
+```ts
+const newTask =
+  core.healthcheck.createNewTaskFromRegisteredTask(
+    'example-task',
+  );
+```
+
+## Context
+
+### Internal
+
+```ts
+interface {
+  services: {
+  },
+  context: {
+    services: {
+      core: CoreStartServices
+    },
+    logger: Logger,
+    scope: 'internal'
+  }
+}
+```
+
+### User
+
+```ts
+TBD
+interface {
+  services: {
+  },
+  context: {
+    services: {
+      core: CoreStartServices
+    },
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest
+    logger: Logger,
+    scope: 'user'
+  }
+}
+```

--- a/src/core/server/healthcheck/healthcheck/config.ts
+++ b/src/core/server/healthcheck/healthcheck/config.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+import { ConfigDeprecationProvider } from 'src/core/server';
+import { ServiceConfigDescriptor } from '../../internal_types';
+
+export type HealthCheckConfigType = TypeOf<typeof configSchema>;
+
+/**
+ * Validation schema for initialization service config.
+ * @public
+ */
+export const configSchema = schema.object({
+  schedule_interval: schema.duration({
+    defaultValue: 15 * 60 * 1000,
+    validate: (value) => {
+      const minValue = 5 * 60 * 1000;
+      const maxValue = 24 * 60 * 60 * 1000;
+      return value.asMilliseconds() < minValue || value.asMilliseconds() > maxValue
+        ? 'Value is not valid. This should be between 5 minutes (5m) and 24 hours (24h)'
+        : undefined;
+    },
+  }),
+  retries_delay: schema.duration({
+    defaultValue: 2.5 * 1000,
+    validate: (value) => {
+      const minValue = 0;
+      const maxValue = 6 * 60 * 60 * 1000;
+      return value.asMilliseconds() < minValue || value.asMilliseconds() > maxValue
+        ? 'Value is not valid. This should be between 0 seconds (0s) and 6 hours (6h)'
+        : undefined;
+    },
+  }),
+  max_retries: schema.number({ defaultValue: 5 }),
+});
+
+const deprecations: ConfigDeprecationProvider = ({ renameFromRoot, renameFromRootWithoutMap }) => [
+  (settings, fromPath, log) => {
+    return settings;
+  },
+];
+
+export const config: ServiceConfigDescriptor<HealthCheckConfigType> = {
+  path: 'healthcheck',
+  schema: configSchema,
+  deprecations,
+};

--- a/src/core/server/healthcheck/healthcheck/health_check.ts
+++ b/src/core/server/healthcheck/healthcheck/health_check.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from 'opensearch-dashboards/server';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { retry, TASK, TaskManager } from '../task';
+import type { TaskRunResult } from '../task';
+import { addRoutes } from './routes';
+import { ScheduledIntervalTask } from './scheduled_task';
+
+export interface HealthCheckStatus {
+  ok: boolean | null;
+  checks: any[] | null;
+  error?: string | null;
+}
+
+export class HealthCheck extends TaskManager implements TaskManager {
+  private items = new Map();
+  status$: BehaviorSubject<HealthCheckStatus> = new BehaviorSubject({
+    ok: null,
+    checks: [],
+    error: null,
+  });
+  private statusSubscriptions: Subscription = new Subscription();
+  private _retryDelay: number = 0;
+  private _maxRetryAttempts: number = 0;
+  private _internalScheduledCheckTime: number = 0;
+  private scheduled?: ScheduledIntervalTask;
+  private _coreStartServices: any;
+  constructor(private readonly logger: Logger, services: any) {
+    super(logger, services);
+  }
+
+  getCheckInfo(taskName: string) {
+    const task = this.get(taskName);
+    return task.getInfo();
+  }
+
+  getChecksInfo(taskNames?: string[]) {
+    const tasks: string[] = taskNames || [...this.items.keys()];
+
+    return tasks.map((taskName) => this.getCheckInfo(taskName));
+  }
+
+  setCheckResult(name: string, result: TaskRunResult) {
+    const task = this.get(name);
+
+    if (task) {
+      task.result = result;
+    }
+  }
+
+  async setup(
+    core: any,
+    config: { retries_delay: number; max_retries: number; schedule_interval: number }
+  ) {
+    this._retryDelay = config.retries_delay.asMilliseconds();
+    this._maxRetryAttempts = config.max_retries;
+    this._internalScheduledCheckTime = config.schedule_interval.asMilliseconds();
+
+    const router = core.http.createRouter('/api/healthcheck');
+    addRoutes(router, { healthcheck: this, logger: this.logger });
+  }
+
+  async runInternal() {
+    return this.run({ services: { core: this._coreStartServices }, scope: 'internal' });
+  }
+
+  async runInitialCheck() {
+    return new Promise<void>((res) => {
+      this.runInternal().catch(() => {});
+
+      this.status$.subscribe(({ ok }) => {
+        if (ok) {
+          res();
+        }
+      });
+    });
+  }
+
+  async start(core: any) {
+    this._coreStartServices = core;
+    this.logger.debug(`Waiting until all checks are ok...`);
+
+    await this.runInitialCheck();
+    this.logger.info(`Checks are ok`);
+
+    this.logger.debug(`Setting scheduled checks`);
+    this.scheduled = new ScheduledIntervalTask(async () => {
+      try {
+        this.logger.debug(`Running scheduled check`);
+        await this.runInternal();
+      } catch (error) {
+        this.logger.error(`Error in scheduled check: ${error.message}`);
+      } finally {
+        this.logger.debug('Scheduled check finished');
+      }
+    }, this._internalScheduledCheckTime);
+    this.scheduled.start();
+    this.logger.info(`Set scheduled checks each ${this._internalScheduledCheckTime}ms`);
+  }
+
+  async stop() {
+    this.logger.debug('Stop starts');
+    this.scheduled?.stop();
+    this.statusSubscriptions.unsubscribe();
+    this.logger.debug('Stop finished');
+  }
+
+  async _run(ctx, taskNames) {
+    let ok: null | boolean = null;
+    let checks: any[] = [];
+    let error = null;
+    try {
+      this.logger.debug('Starting');
+      if (this.items.size === 0) {
+        this.logger.debug('No checks. Skipping');
+        ok = true;
+      } else {
+        this.logger.debug('Running checks');
+
+        checks = await super.run(ctx, taskNames);
+        ok =
+          Array.isArray(checks) &&
+          checks.every(
+            ({ status, result, ..._meta }) =>
+              status === TASK.RUN_STATUS.FINISHED &&
+              (_meta?.isCritical ? result === TASK.RUN_RESULT.SUCCESS : true)
+          );
+      }
+
+      this.logger.debug(`ok: [${ok}]. checks [${checks?.length}]`);
+    } catch (err) {
+      this.logger.error(`There an error: ${err.message}`);
+      ok = false;
+      error = err.message;
+    }
+
+    const data = {
+      ok,
+      checks,
+      error,
+    };
+
+    if (error) {
+      throw error;
+    }
+
+    return data;
+  }
+
+  async run(...args) {
+    return retry(
+      async (...params) => {
+        const data = await this._run(...params);
+        if (data.error) {
+          throw new Error(data.error);
+        }
+        const failedCriticalChecks = data.checks?.filter(
+          ({ status, result, _meta = {} }) =>
+            status === TASK.RUN_STATUS.FINISHED &&
+            result === TASK.RUN_RESULT.FAIL &&
+            _meta?.isCritical
+        );
+        if (failedCriticalChecks?.length) {
+          throw new Error(
+            `Some checks failed: [${failedCriticalChecks.length}/${data.checks.length}]`
+          );
+        }
+        // Emit message through observer
+        this.status$.next(data);
+      },
+      {
+        maxAttempts: this._maxRetryAttempts,
+        delay: this._retryDelay,
+      }
+    )(...args);
+  }
+
+  /**
+   * Subscribe to changes in the health check
+   * @param fn
+   * @returns
+   */
+  subscribe(fn: (params: HealthCheckStatus) => void) {
+    const subscription = this.status$.subscribe(fn);
+    this.statusSubscriptions.add(subscription);
+    return subscription;
+  }
+}

--- a/src/core/server/healthcheck/healthcheck/index.ts
+++ b/src/core/server/healthcheck/healthcheck/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './health_check';
+export * from './config';
+export * from './types';
+export * from './service';

--- a/src/core/server/healthcheck/healthcheck/routes.ts
+++ b/src/core/server/healthcheck/healthcheck/routes.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+
+const getTaskList = (tasksAsString: string) => tasksAsString.split(',');
+
+interface EnhancedLoggerLog {
+  timestamp: string;
+  level: string;
+  message: string;
+}
+
+function enhanceTaskLogger(logger) {
+  const logs: EnhancedLoggerLog[] = [];
+  const enhancedLogger = {
+    getLogs() {
+      return logs;
+    },
+  };
+
+  for (const level of ['debug', 'info', 'warn', 'error']) {
+    enhancedLogger[level] = (message: string) => {
+      logs.push({ timestamp: new Date().toISOString(), level, message });
+      logger[level](message);
+    };
+  }
+
+  return enhancedLogger;
+}
+
+export function addRoutes(router, { healthcheck, logger }) {
+  const validateTaskList = schema.maybe(
+    schema.string({
+      validate(value: string) {
+        const tasks = healthcheck.getAll();
+        const requestTasks = getTaskList(value);
+        const invalidTasks = requestTasks.filter((requestTask) =>
+          tasks.every(({ name }) => requestTask !== name)
+        );
+
+        if (invalidTasks.length > 0) {
+          return `Invalid tasks: ${invalidTasks.join(', ')}`;
+        }
+
+        return;
+      },
+    })
+  );
+
+  // Get the status of internal initialization tasks
+  router.get(
+    {
+      path: '/internal',
+      validate: {
+        tasks: schema.object({
+          tasks: validateTaskList,
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const tasksNames = request.query.tasks ? getTaskList(request.query.tasks) : undefined;
+
+        logger.debug(`Getting initialization tasks related to internal scope`);
+
+        const tasksData = healthcheck.getChecksInfo(tasksNames);
+
+        logger.debug(
+          `Healthcheck tasks related to internal scope: [${[...tasksData]
+            .map(({ name }) => name)
+            .join(', ')}]`
+        );
+
+        return response.ok({
+          body: {
+            message: 'All healthcheck tasks are returned.',
+            tasks: tasksData,
+          },
+        });
+      } catch (error) {
+        return response.internalError({
+          body: {
+            message: `Error getting the internal healthcheck tasks: ${error.message}`,
+          },
+        });
+      }
+    }
+  );
+
+  // Run the internal initialization tasks
+  // TODO: protect with administrator privilegies
+  router.post(
+    {
+      path: '/internal',
+      validate: {
+        query: schema.object({
+          tasks: validateTaskList,
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        logger.debug(`Running healthcheck tasks related to internal scope`);
+        const tasksNames = request.query.tasks ? getTaskList(request.query.tasks) : undefined;
+
+        const results = await initialization.runAsInternal(tasksNames);
+
+        logger.info('Healthcheck tasks related to internal scope were executed');
+
+        return response.ok({
+          body: {
+            message: 'All healthcheck tasks are returned.',
+            tasks: results,
+          },
+        });
+      } catch (error) {
+        return response.internalError({
+          body: {
+            message: `Error running the internal healthcheck tasks: ${error.message}`,
+          },
+        });
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: '/user',
+      validate: {
+        // TODO: restrict to user tasks
+        query: schema.object({
+          tasks: validateTaskList,
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const tasksNames = request.query.tasks ? getTaskList(request.query.tasks) : undefined;
+        const { username } = await context.wazuh_core.dashboardSecurity.getCurrentUser(
+          request,
+          context
+        );
+        const scope = 'user';
+
+        logger.debug(`Getting healthcheck tasks related to user [${username}] scope [${scope}]`);
+
+        const initializationTasks = context.wazuh_core.initialization.get();
+        const indexPatternTasks = initializationTasks
+          .filter(({ name }) => name.startsWith('index-pattern:'))
+          .map(({ name }) =>
+            context.wazuh_core.initialization.createNewTaskFromRegisteredTask(name)
+          );
+        const settingsTasks = initializationTasks
+          .filter(({ name }) => name.startsWith('setting:'))
+          .map(({ name }) =>
+            context.wazuh_core.initialization.createNewTaskFromRegisteredTask(name)
+          );
+        const allUserTasks = [...indexPatternTasks, ...settingsTasks];
+        const tasks = tasksNames
+          ? allUserTasks.filter(({ name }) => tasksNames.includes(name))
+          : allUserTasks;
+
+        logger.debug(
+          `Initialization tasks related to user [${username}] scope [${scope}]: [${tasks
+            .map(({ name }) => name)
+            .join(', ')}]`
+        );
+
+        const taskContext = context.wazuh_core.initialization.createRunContext('user', {
+          core: context.core,
+          request,
+        });
+
+        logger.debug(`Running tasks for user [${username}] scope [${scope}]`);
+
+        const results = await Promise.all(
+          tasks.map(async (task) => {
+            const taskLogger = enhanceTaskLogger(logger);
+
+            try {
+              await task.run({
+                ...taskContext,
+                // TODO: use user selection index patterns
+                logger: taskLogger,
+                ...(task.name.includes('index-pattern:')
+                  ? {
+                      getIndexPatternID: () =>
+                        task.name /* TODO: use request parameters/body/cookies */,
+                    }
+                  : {}),
+              });
+            } catch {
+              /* empty */
+            } finally {
+              // eslint-disable-next-line no-unsafe-finally
+              return {
+                logs: taskLogger.getLogs(),
+                ...task.getInfo(),
+              };
+            }
+          })
+        );
+
+        logger.debug(`All tasks for user [${username}] scope [${scope}] run`);
+
+        const initialMessage = 'All the initialization tasks related to user scope were executed.';
+        const message = [
+          initialMessage,
+          results.some(({ error }) => error) && 'There was some errors.',
+        ]
+          .filter(Boolean)
+          .join(' ');
+
+        return response.ok({
+          body: {
+            message,
+            tasks: results,
+          },
+        });
+      } catch (error) {
+        return response.internalError({
+          body: {
+            message: `Error initializating the tasks: ${error.message}`,
+          },
+        });
+      }
+    }
+  );
+}

--- a/src/core/server/healthcheck/healthcheck/scheduled_task.ts
+++ b/src/core/server/healthcheck/healthcheck/scheduled_task.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export class ScheduledIntervalTask {
+  private _interval: any;
+  public status = 'not_started';
+  constructor(private fn: Function, private time: number) {
+    this.run = this.run.bind(this);
+  }
+  async run() {
+    this.status = 'started';
+    const results = await this.fn();
+    this.status = 'finished';
+    return results;
+  }
+  start() {
+    this._interval = setInterval(this.run, this.time);
+  }
+  stop() {
+    if (this._interval) {
+      clearInterval(this._interval);
+    }
+  }
+}

--- a/src/core/server/healthcheck/healthcheck/service.ts
+++ b/src/core/server/healthcheck/healthcheck/service.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Observable } from 'rxjs';
+import { first } from 'rxjs/operators';
+import { CoreService } from '../../../types';
+import { CoreContext } from '../../core_context';
+import { Logger } from '../../logging';
+import { HealthCheckServiceSetup, HealthCheckServiceStart } from './types';
+import { HealthCheck } from './health_check';
+import { HealthCheckConfigType } from './config';
+
+function createSetup(ctx: HealthCheckService): HealthCheckServiceSetup {
+  return {
+    register: ctx.healthCheck.register.bind(ctx.healthCheck),
+    get: ctx.healthCheck.get.bind(ctx.healthCheck),
+    getAll: ctx.healthCheck.getAll.bind(ctx.healthCheck),
+  };
+}
+
+export class HealthCheckService
+  implements CoreService<HealthCheckServiceSetup, HealthCheckServiceStart> {
+  private readonly logger: Logger;
+  healthCheck: HealthCheck;
+  private readonly config$: Observable<HealthCheckConfigType>;
+
+  constructor(private readonly coreContext: CoreContext) {
+    this.logger = coreContext.logger.get('healthcheck');
+    this.config$ = coreContext.configService.atPath<HealthCheckConfigType>('healthcheck');
+    this.healthCheck = new HealthCheck(this.logger, {});
+  }
+
+  async setup(...params: any[]) {
+    this.logger.debug('Setup starts');
+    const config = await this.config$.pipe(first()).toPromise();
+
+    await this.healthCheck.setup(params[0], config);
+
+    this.logger.debug('Setup finished');
+    return createSetup(this);
+  }
+
+  async start(...params: any[]) {
+    this.logger.debug('Start starts');
+    await this.healthCheck.start(...params);
+
+    this.logger.debug('Start finished');
+    return createSetup(this);
+  }
+
+  stop(): void | Promise<void> {
+    this.logger.debug('Stop starts');
+    this.healthCheck.stop();
+    this.logger.debug('Stop finished');
+  }
+
+  enhanceNotReadyServer(server) {
+    const appName = 'Wazuh dashboard';
+
+    server.route({
+      path: '/{p*}',
+      method: '*',
+      handler: (request, h) => {
+        let initializationTasksErrors;
+        try {
+          initializationTasksErrors = this.healthCheck
+            .getChecksInfo()
+            .filter(({ error }) => error)
+            .map(({ error, name }) => `Check [${name}]: ${error}`);
+          // eslint-disable-next-line no-empty
+        } catch {}
+
+        if (initializationTasksErrors?.length > 0) {
+          const html = `
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <title>${appName} - health check</title>
+              </head>
+              <body>
+                <p>${appName} server is not ready yet</>
+                <p>Health check</p>
+                ${
+                  initializationTasksErrors?.length
+                    ? `
+                      <div>
+                        <div>There are some errors that require to be solved.</div>
+                        <div>
+                          ${(initializationTasksErrors as string[])
+                            .map((error: string) => `<p>${error}</p>`)
+                            .join('\n')}
+                        </div>
+                        <div>For more details, review the app logs.</div>
+                      </div>`
+                    : ''
+                }
+              </body>
+            </html>
+          `;
+          // If server is not ready yet, because plugins or core can perform
+          // long running tasks (build assets, saved objects migrations etc.)
+          // we should let client know that and ask to retry after 30 seconds.
+          // Wazuh
+          return h
+            .response(html)
+            .type('text/html')
+            .code(503)
+            .header('Retry-After', '30')
+            .takeover();
+        }
+        return h.continue;
+      },
+    });
+  }
+}

--- a/src/core/server/healthcheck/healthcheck/types.ts
+++ b/src/core/server/healthcheck/healthcheck/types.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LifecycleService, WazuhCoreServices } from '../types'; // TODO: fix
+import { CoreStart, Logger } from '../../../../../core/server'; // TODO: fix
+
+import { INITIALIZATION_TASK } from './constants';
+import { ITask, TaskDefinition, TaskInfo } from '../task/types';
+
+type RunStatusEnum = typeof INITIALIZATION_TASK['RUN_STATUS'];
+
+export type InitializationTaskRunStatus = RunStatusEnum[keyof RunStatusEnum];
+
+type RunResultEnum = typeof INITIALIZATION_TASK['RUN_RESULT'];
+
+export type InitializationTaskRunResult = RunResultEnum[keyof RunResultEnum];
+
+type ContextEnum = typeof INITIALIZATION_TASK['CONTEXT'];
+
+export type InitializationTaskContext = ContextEnum[keyof ContextEnum];
+
+export interface InitializationTaskDefinition {
+  name: string;
+  run: (ctx: any) => any;
+  // Define the order to execute the task. Multiple task can take the same order and they will be executed in parallel
+  order?: number;
+}
+
+export interface InitializationTaskRunData {
+  name: InitializationTaskDefinition['name'];
+  status: InitializationTaskRunStatus;
+  result: InitializationTaskRunResult;
+  createdAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  duration: number | null; // seconds
+  data: any;
+  error: string | null;
+}
+
+export interface IInitializationTask extends InitializationTaskRunData {
+  run: <Context = any, Result = any>(ctx: Context) => Promise<Result>;
+  getInfo: () => InitializationTaskRunData;
+}
+
+export interface IInitializationService extends LifecycleService<any, any, any, any, any, any> {
+  register: (task: InitializationTaskDefinition) => void;
+  get: (taskName: string) => InitializationTaskRunData;
+  getAll: () => InitializationTaskRunData[];
+  createRunContext: <ContextType = any>(
+    scope: InitializationTaskContext,
+    context: ContextType
+  ) => {
+    scope: InitializationTaskContext;
+  };
+  runAsInternal: <ReturnType = any>(tasks?: string[]) => Promise<ReturnType>;
+}
+
+export interface InitializationTaskRunContext extends WazuhCoreServices {
+  core: CoreStart;
+  logger: Logger;
+  scope: InitializationTaskContext;
+}
+
+// Healcheck
+export interface HealthCheckServiceSetup {
+  register: (task: TaskDefinition) => void;
+  get: (name: string) => ITask;
+  getAll: () => ITask[];
+  subscribe: (fn: () => void) => void;
+}
+
+export type HealthCheckServiceStart = HealthCheckServiceSetup;

--- a/src/core/server/healthcheck/index.ts
+++ b/src/core/server/healthcheck/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './healthcheck';
+export * from './task';

--- a/src/core/server/healthcheck/task/constants.ts
+++ b/src/core/server/healthcheck/task/constants.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const TASK = {
+  RUN_STATUS: {
+    NOT_STARTED: 'not_started',
+    RUNNING: 'running',
+    FINISHED: 'finished',
+  },
+  RUN_RESULT: {
+    NULL: null,
+    SUCCESS: 'success',
+    WARNING: 'warning',
+    FAIL: 'fail',
+  },
+  CONTEXT: {
+    INTERNAL: 'internal',
+    USER: 'user',
+  },
+} as const;

--- a/src/core/server/healthcheck/task/index.ts
+++ b/src/core/server/healthcheck/task/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './constants';
+export * from './task';
+export * from './task_manager';
+// export * from './types'; // TODO: fix export
+export * from './utils';

--- a/src/core/server/healthcheck/task/task.ts
+++ b/src/core/server/healthcheck/task/task.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// import { TASK } from '../healthcheck/constants';
+import { TASK } from './constants';
+import { ITask, TaskDefinition, TaskInfo } from './types';
+
+export class Task implements ITask {
+  public name: string;
+  public order?: number;
+  private readonly runInternal: any;
+  public status: ITask['status'] = TASK.RUN_STATUS.NOT_STARTED;
+  public result: ITask['result'] = TASK.RUN_RESULT.NULL;
+  public data: any = null;
+  public createdAt: ITask['createdAt'] = new Date().toISOString();
+  public startedAt: ITask['startedAt'] = null;
+  public finishedAt: ITask['finishedAt'] = null;
+  public duration: ITask['duration'] = null;
+  public error = null;
+  public _meta: any;
+
+  constructor(task: TaskDefinition) {
+    this.name = task.name;
+    this.runInternal = task.run;
+    this.order = task.order;
+    const { name, run, order, ..._meta } = task;
+    this._meta = _meta;
+  }
+
+  private init() {
+    this.status = TASK.RUN_STATUS.RUNNING;
+    this.result = null;
+    this.data = null;
+    this.startedAt = new Date().toISOString();
+    this.finishedAt = null;
+    this.duration = null;
+    this.error = null;
+  }
+
+  async run(...params: any[]) {
+    if (this.status === TASK.RUN_STATUS.RUNNING) {
+      throw new Error(`Another instance of task ${this.name} is running`);
+    }
+
+    let error;
+
+    try {
+      this.init();
+      this.data = await this.runInternal(...params);
+      this.result = TASK.RUN_RESULT.SUCCESS;
+    } catch (error_) {
+      error = error_;
+      this.result = TASK.RUN_RESULT.FAIL;
+      this.error = error_.message;
+    } finally {
+      this.status = TASK.RUN_STATUS.FINISHED;
+      this.finishedAt = new Date().toISOString();
+
+      const dateStartedAt = new Date(this.startedAt as string);
+      const dateFinishedAt = new Date(this.finishedAt);
+
+      this.duration = ((dateFinishedAt.getTime() - dateStartedAt.getTime()) as number) / 1000;
+    }
+
+    if (error) {
+      throw error;
+    }
+
+    return this.getInfo();
+  }
+
+  getInfo() {
+    return Object.fromEntries(
+      [
+        'name',
+        'status',
+        'result',
+        'data',
+        'createdAt',
+        'startedAt',
+        'finishedAt',
+        'duration',
+        'error',
+        '_meta',
+      ].map((item) => [item, this[item]])
+    ) as TaskInfo;
+  }
+}

--- a/src/core/server/healthcheck/task/task_manager.ts
+++ b/src/core/server/healthcheck/task/task_manager.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from 'opensearch-dashboards/server';
+import { ITask, TaskManager as ITaskManager, TaskDefinition, TaskInfo } from './types';
+import { Task } from './task';
+
+/**
+ * This class manages the initialization tasks and the internal health check.
+ */
+export class TaskManager implements ITaskManager {
+  private readonly items: Map<string, ITask> = new Map();
+
+  constructor(private readonly logger: Logger, private readonly services: any) {}
+
+  async setup() {
+    this.logger.debug('Setup starts');
+    this.logger.debug('Setup finished');
+  }
+
+  async start() {
+    this.logger.debug('Start starts');
+    this.logger.debug('Start finished');
+  }
+
+  async stop() {
+    this.logger.debug('Stop starts');
+    this.logger.debug('Stop finished');
+  }
+
+  register(task: TaskDefinition) {
+    this.logger.debug(`Registering ${task.name}`);
+
+    if (this.items.has(task.name)) {
+      throw new Error(
+        `[${task.name}] was already registered. Ensure the name is unique or remove the duplicated registration of same task.`
+      );
+    }
+
+    this.items.set(task.name, new Task(task));
+    this.logger.debug(`Registered ${task.name}`);
+  }
+
+  get(name: string) {
+    this.logger.debug(`Getting task: [${name}]`);
+
+    if (!this.items.has(name)) {
+      throw new Error(`Task [${name}] not found`);
+    }
+
+    return this.items.get(name) as ITask;
+  }
+
+  getAll() {
+    this.logger.debug('Getting all tasks');
+
+    return [...this.items.values()];
+  }
+
+  createNewTaskFromRegisteredTask(name: string) {
+    const task = this.get(name) as ITask;
+
+    if (!task) {
+      throw new Error(`Task [${name}] is not registered`);
+    }
+
+    return new Task({ ...(task._meta || {}), name, run: task.runInternal, order: task.order });
+  }
+
+  /**
+   * Run tasks in ascending order, executing same-order tasks in parallel.
+   *
+   * @param {Array<{ name: string, run: ()=>any|Promise<any>, order?: number }>} tasks
+   * @returns {Promise<any[]>} results array in execution order
+   */
+  private async runTasksInOrder(tasks: any[], cb) {
+    // 1. Sort by order (undefined → Infinity)
+    const sorted = tasks.slice().sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
+
+    // 2. Group tasks by order
+    const groups = [];
+    for (const task of sorted) {
+      const key = task.order ?? Infinity;
+      const lastGroup = groups[groups.length - 1];
+      if (!lastGroup || lastGroup.order !== key) {
+        groups.push({ order: key, tasks: [task] });
+      } else {
+        lastGroup.tasks.push(task);
+      }
+    }
+
+    // 3. Execute each group in sequence, but tasks in a group in parallel
+    const results = [];
+    for (const { tasks: groupTasks } of groups) {
+      const promises = groupTasks.map((t) => cb(t));
+      const groupResults = await Promise.all(promises);
+      results.push(...groupResults);
+    }
+
+    return results;
+  }
+
+  async run(ctx: any, taskNames?: string[]): Promise<TaskInfo[] | undefined> {
+    try {
+      if (this.items.size > 0) {
+        const allTasks = [...this.items.values()];
+        const tasks = taskNames
+          ? allTasks.filter(({ name }) => taskNames.includes(name))
+          : allTasks;
+
+        return this.runTasksInOrder(tasks, async (item) => {
+          const logger = this.logger.get(item.name);
+
+          try {
+            return await item.run({
+              services: this.services,
+              context: ctx,
+              logger,
+            });
+          } catch (error) {
+            logger.error(`Error running task [${item.name}]: ${error.message}`);
+
+            return item.getInfo();
+          }
+        });
+      } else {
+        this.logger.info('No tasks');
+      }
+    } catch (error) {
+      this.logger.error(`Error running: ${error.message}`);
+    }
+  }
+}

--- a/src/core/server/healthcheck/task/types.ts
+++ b/src/core/server/healthcheck/task/types.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Logger } from '@osd/logging';
+import { TASK } from './constants';
+
+type TaskRunStatusEnum = typeof TASK['RUN_STATUS'];
+
+export type TaskRunStatus = TaskRunStatusEnum[keyof TaskRunStatusEnum];
+
+type TaskRunResultEnum = typeof TASK['RUN_RESULT'];
+
+export type TaskRunResult = TaskRunResultEnum[keyof TaskRunResultEnum];
+
+export interface TaskDefinition {
+  name: string;
+  run: (ctx: any) => any;
+  // Define the order to execute the task. Multiple task can take the same order and they will be executed in parallel
+  order?: number;
+  // Other metafields
+  [key: string]: any;
+}
+export interface TaskInfo<M = null> {
+  name: string;
+  status: TaskRunStatus;
+  result: TaskRunResult;
+  createdAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  duration: number | null; // seconds
+  data: any;
+  error: string | null;
+  _meta: M;
+}
+
+export interface ITask extends TaskInfo {
+  run: <Context = any, Result = any>(ctx: Context) => Promise<Result>;
+  getInfo: () => TaskInfo;
+}
+
+// Task manager
+export interface TaskManager<S> {
+  register: (task: TaskDefinition) => void;
+  get: (name: string) => ITask;
+  getAll: () => ITask[];
+}
+
+export interface TaskManagerRunTaskContext<S, C> {
+  services: S;
+  context: C;
+  logger: Logger;
+}

--- a/src/core/server/healthcheck/task/utils.ts
+++ b/src/core/server/healthcheck/task/utils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Returns a wrapped version of `fn` that retries on rejection.
+ *
+ * @param {Function} fn        The async function to wrap.
+ * @param {Object}   options
+ * @param {number}   options.maxAttempts  Total attempts (default: 3)
+ * @param {number}   options.delay        Delay between attempts in ms (default: 1000)
+ *  * @param {number}   options.delay        Delay between attempts in ms (default: 1000)
+ */
+export function retry<D>(
+  fn: (...args: any[]) => Promise<D>,
+  {
+    maxAttempts,
+    delay,
+  }: {
+    maxAttempts: number;
+    delay: number;
+  }
+) {
+  return async function retryingFn(...args) {
+    let attempt = 0;
+    while (true) {
+      try {
+        return await fn(...args);
+      } catch (err) {
+        attempt++;
+        if (attempt >= maxAttempts) {
+          // Exhausted retries → rethrow last error
+          throw err;
+        }
+        // Wait before next retry
+        await new Promise((res) => setTimeout(res, delay));
+      }
+    }
+  };
+}

--- a/src/core/server/http/http_service.ts
+++ b/src/core/server/http/http_service.ts
@@ -108,7 +108,8 @@ export class HttpService
     const config = await this.config$.pipe(first()).toPromise();
 
     if (this.shouldListen(config)) {
-      await this.runNotReadyServer(config);
+      // Wazuh: inject dependencies
+      await this.runNotReadyServer(config, deps);
     }
 
     const { registerRouter, ...serverContract } = await this.httpServer.setup(config);
@@ -191,28 +192,33 @@ export class HttpService
     await this.httpsRedirectServer.stop();
   }
 
-  private async runNotReadyServer(config: HttpConfig) {
+  // Wazuh: inject dependencies
+  private async runNotReadyServer(config: HttpConfig, deps: any) {
     this.log.debug('starting NotReady server');
     const httpServer = new HttpServer(this.logger, 'NotReady');
     const { server } = await httpServer.setup(config);
     this.notReadyServer = server;
+
+    // Wazuh: decorate server
+    deps.getHealthCheckService().enhanceNotReadyServer(server);
     // use hapi server while OpenSearchDashboardsResponseFactory doesn't allow specifying custom headers
     // https://github.com/elastic/kibana/issues/33779
-    this.notReadyServer.route({
-      path: '/{p*}',
-      method: '*',
-      handler: (req, responseToolkit) => {
-        this.log.debug(`Wazuh dashboard server is not ready yet ${req.method}:${req.url.href}.`);
+    // Wazuh: comment
+    // this.notReadyServer.route({
+    //   path: '/{p*}',
+    //   method: '*',
+    //   handler: (req, responseToolkit) => {
+    //     this.log.debug(`Wazuh dashboard server is not ready yet ${req.method}:${req.url.href}.`);
 
-        // If server is not ready yet, because plugins or core can perform
-        // long running tasks (build assets, saved objects migrations etc.)
-        // we should let client know that and ask to retry after 30 seconds.
-        return responseToolkit
-          .response('Wazuh dashboard server is not ready yet')
-          .code(503)
-          .header('Retry-After', '30');
-      },
-    });
+    //     // If server is not ready yet, because plugins or core can perform
+    //     // long running tasks (build assets, saved objects migrations etc.)
+    //     // we should let client know that and ask to retry after 30 seconds.
+    //     return responseToolkit
+    //       .response('Wazuh dashboard server is not ready yet')
+    //       .code(503)
+    //       .header('Retry-After', '30');
+    //   },
+    // });
     await this.notReadyServer.start();
   }
 }

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -94,6 +94,8 @@ import {
   CoreServicesUsageData,
 } from './core_usage_data';
 import { WorkspaceSetup, WorkspaceStart } from './workspace';
+// Wazuh
+import { HealthCheckServiceSetup, HealthCheckServiceStart } from './healthcheck';
 
 export { CoreUsageData, CoreConfigUsageData, CoreEnvironmentUsageData, CoreServicesUsageData };
 
@@ -497,6 +499,9 @@ export interface CoreSetup<TPluginsStart extends object = object, TStart = unkno
   dynamicConfigService: DynamicConfigServiceSetup;
   /** {@link WorkspaceSetup} */
   workspace: WorkspaceSetup;
+  // Wazuh
+  /** {@link HealthCheckServiceSetup} */
+  healthcheck: HealthCheckServiceSetup;
 }
 
 /**
@@ -540,6 +545,9 @@ export interface CoreStart {
   dynamicConfig: DynamicConfigServiceStart;
   /** {@link WorkspaceStart} */
   workspace: WorkspaceStart;
+  // Wazuh
+  /** {@link HealthCheckServiceStart} */
+  healthcheck: HealthCheckServiceStart;
 }
 
 export {

--- a/src/core/server/internal_types.ts
+++ b/src/core/server/internal_types.ts
@@ -55,6 +55,8 @@ import { CoreUsageDataStart } from './core_usage_data';
 import { InternalSecurityServiceSetup } from './security/types';
 import { CrossCompatibilityServiceStart } from './cross_compatibility';
 import { InternalWorkspaceServiceSetup, InternalWorkspaceServiceStart } from './workspace';
+// Wazuh
+import { HealthCheckServiceSetup, HealthCheckServiceStart } from './healthcheck';
 
 /** @internal */
 export interface InternalCoreSetup {
@@ -74,6 +76,8 @@ export interface InternalCoreSetup {
   security: InternalSecurityServiceSetup;
   dynamicConfig: InternalDynamicConfigServiceSetup;
   workspace: InternalWorkspaceServiceSetup;
+  // Wazuh
+  healthcheck: HealthCheckServiceSetup;
 }
 
 /**
@@ -91,6 +95,8 @@ export interface InternalCoreStart {
   crossCompatibility: CrossCompatibilityServiceStart;
   dynamicConfig: InternalDynamicConfigServiceStart;
   workspace: InternalWorkspaceServiceStart;
+  // Wazuh
+  healthcheck: HealthCheckServiceStart;
 }
 
 /**

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -227,6 +227,8 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>(
       getStartService: deps.dynamicConfig.getStartService,
     },
     workspace: deps.workspace,
+    // Wazuh
+    healthcheck: deps.healthcheck,
   };
 }
 
@@ -284,5 +286,7 @@ export function createPluginStartContext<TPlugin, TPluginDependencies>(
       createStoreFromRequest: deps.dynamicConfig.createStoreFromRequest,
     },
     workspace: deps.workspace,
+    // Wazuh
+    healthcheck: deps.healthcheck,
   };
 }


### PR DESCRIPTION
### Description

This pull request adds the healtch check service.

This exposes a method to register tasks from the plugin setup lifecycle method.

This can block the initialization of the Wazuh dashboard server if there is some critical tasks that failed in the initial check.

### Issues Resolved


## Screenshot


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
