### PR TITLE
Fix apt update error in building deb package with debian:10 Docker base image

### DIFF
--- a/dev-tools/build-packages/deb/docker/amd64/Dockerfile
+++ b/dev-tools/build-packages/deb/docker/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:12
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
### Description

This pull request updates the Docker base version to `debian:12` due to an error with the URL repository used by the `debian:10` versions

### Isses resolved
#826

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
