### PR TITLE
Add data source enabled setting and change Observability category order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 4.14.0
-- Added Observability and Anomaly Detection plugins to default installation [#843](https://github.com/wazuh/wazuh-dashboard/pull/843) [#905](https://github.com/wazuh/wazuh-dashboard/pull/905)
+- Added Observability and Anomaly Detection plugins to default installation [#843](https://github.com/wazuh/wazuh-dashboard/pull/843) [#905](https://github.com/wazuh/wazuh-dashboard/pull/905) [#909](https://github.com/wazuh/wazuh-dashboard/pull/909)
 - Added ML Commons plugin to default installation [#875](https://github.com/wazuh/wazuh-dashboard/pull/875)
 - Added Assistant Dashboards plugin to default installation [#821](https://github.com/wazuh/wazuh-dashboard/pull/821)
 

--- a/config/opensearch_dashboards.prod.yml
+++ b/config/opensearch_dashboards.prod.yml
@@ -17,3 +17,4 @@ opensearch_security.cookie.ttl: 900000
 opensearch_security.session.ttl: 900000
 opensearch_security.session.keepalive: true
 assistant.chat.enabled: true
+data_source.enabled: true

--- a/dev-tools/build-packages/base/base-builder.sh
+++ b/dev-tools/build-packages/base/base-builder.sh
@@ -145,7 +145,7 @@ sed -i -e "s|defaultMessage:\"Management\"|${category_label_indexer_management}|
 assistant_dashboard_whitelabeling
 
 # Add category icon to Observability plugin and change order in the main menu
-sed -i 's|const OBSERVABILITY_APP_CATEGORIES=Object\.freeze({observability:{id:"observability",label:external_osdSharedDeps_OsdI18n_\["i18n"\]\.translate("core\.ui\.observabilityNavList\.label",{defaultMessage:"Observability"}),order:shared\["Jb"\]}});|const OBSERVABILITY_APP_CATEGORIES=Object.freeze({observability:{id:"observability",euiIconType:"searchProfilerApp",label:external_osdSharedDeps_OsdI18n_["i18n"].translate("core.ui.observabilityNavList.label",{defaultMessage:"Observability"}),order:550}});|' ./plugins/observabilityDashboards/target/public/observabilityDashboards.plugin.js
+sed -i 's|const OBSERVABILITY_APP_CATEGORIES=Object\.freeze({observability:{id:"observability",label:external_osdSharedDeps_OsdI18n_\["i18n"\]\.translate("core\.ui\.observabilityNavList\.label",{defaultMessage:"Observability"}),order:shared\["Jb"\]}});|const OBSERVABILITY_APP_CATEGORIES=Object.freeze({observability:{id:"observability",euiIconType:"searchProfilerApp",label:external_osdSharedDeps_OsdI18n_["i18n"].translate("core.ui.observabilityNavList.label",{defaultMessage:"Observability"}),order:150}});|' ./plugins/observabilityDashboards/target/public/observabilityDashboards.plugin.js
 
 
 log


### PR DESCRIPTION
### Description

This PR changes the Observability menu category order and enables by default the setting `data_source: true` in the `opensearch_dashboards.yml` file.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7674


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
