### PR TITLE
Add restart always directive to dashboard build configuration

### DIFF
--- a/dev-tools/build-packages/config/wazuh-dashboard.service
+++ b/dev-tools/build-packages/config/wazuh-dashboard.service
@@ -9,6 +9,7 @@ EnvironmentFile=-/etc/default/wazuh-dashboard
 EnvironmentFile=-/etc/sysconfig/wazuh-dashboard
 ExecStart=/usr/share/wazuh-dashboard/bin/opensearch-dashboards
 WorkingDirectory=/usr/share/wazuh-dashboard
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

This PR adds `Restart=always` directive to the Wazuh dashboard service
 
### Issues Resolved

#918

## Testing the changes

Install a Wazuh stack and verify that it works. Stop the wazuh dashboard and reduce the limit of circuit breaker for Indexer

```
curl -XPUT -k -u admin:admin "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
    "persistent" : {
      "indices.breaker.total.limit" : "20%"
    }
  }
'
```

After that, try to start dashboard and verify that it automatically restart on crashes. Once that is verified, raise again the limit 

```
curl -XPUT -k -u admin:admin "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
    "persistent" : {
      "indices.breaker.total.limit" : "90%"
    }
  }
'
```

and verify that it's possible to access the dashboard.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
