### PR TITLE
Refine health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 5.0.0
 - Health check service [#811](https://github.com/wazuh/wazuh-dashboard/pull/811) [#866](https://github.com/wazuh/wazuh-dashboard/pull/866)
-- Added Health Check plugin [#870](https://github.com/wazuh/wazuh-dashboard/pull/870)
+- Added Health Check plugin [#870](https://github.com/wazuh/wazuh-dashboard/pull/870) [#946](https://github.com/wazuh/wazuh-dashboard/pull/946)
 
 ### Removed
 

--- a/src/core/server/healthcheck/healthcheck/health_check.ts
+++ b/src/core/server/healthcheck/healthcheck/health_check.ts
@@ -171,6 +171,15 @@ export class HealthCheck extends TaskManager {
     this._coreStartServices = args[0];
     const enabledChecks = this.filterEnabledChecks();
 
+    // Define props to task items
+    [...this.items.values()].forEach((item) => {
+      if (enabledChecks.includes(item.name)) {
+        item._meta.isEnabled = true;
+      } else {
+        item._meta.isEnabled = false;
+      }
+    });
+
     if (!this._enabled) {
       this.logger.info('Disabled. Skip start');
       return;
@@ -183,15 +192,6 @@ export class HealthCheck extends TaskManager {
       this._enabled = false;
       return;
     }
-
-    // Define props to task items
-    [...this.items.values()].forEach((item) => {
-      if (enabledChecks.includes(item.name)) {
-        item._meta.isEnabled = true;
-      } else {
-        item._meta.isEnabled = false;
-      }
-    });
 
     await this.runInitialCheck();
 

--- a/src/core/server/healthcheck/healthcheck/health_check.ts
+++ b/src/core/server/healthcheck/healthcheck/health_check.ts
@@ -181,6 +181,7 @@ export class HealthCheck extends TaskManager {
     } else {
       this.logger.info(`Disabled health check due to no enabled checks.`);
       this._enabled = false;
+      return;
     }
 
     // Define props to task items

--- a/src/plugins/healthcheck/public/components/button_header/health_check_nav_button.tsx
+++ b/src/plugins/healthcheck/public/components/button_header/health_check_nav_button.tsx
@@ -58,12 +58,7 @@ export const HealthCheckNavButton = ({
 
   const isPlacedInLeftNav = coreStart.uiSettings.get('home:useNewHomePage');
 
-  const overallStatusIndicator = (
-    <EuiHealth
-      color={mapTaskStatusToHealthColor(status)}
-      onClick={() => setPopoverOpen((prevState) => !prevState)}
-    />
-  );
+  const overallStatusIndicator = <EuiHealth color={mapTaskStatusToHealthColor(status)} />;
 
   // ToDo: Add aria-label and tooltip when isPlacedInLeftNav is true
   const button = (
@@ -142,13 +137,25 @@ export const HealthCheckNavButton = ({
     </EuiPopover>
   );
 
+  const switchPopover = () => setPopoverOpen((prevState) => !prevState);
+
   return (
     <I18nProvider>
-      {isPlacedInLeftNav ? (
-        popover
-      ) : (
-        <EuiHeaderSectionItemButton size="l">{popover}</EuiHeaderSectionItemButton>
-      )}
+      <div
+        // https://github.com/wazuh/wazuh-dashboard/pull/946#issuecomment-3381930040
+        role="button"
+        tabIndex={0}
+        onClick={switchPopover}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') switchPopover();
+        }}
+      >
+        {isPlacedInLeftNav ? (
+          popover
+        ) : (
+          <EuiHeaderSectionItemButton size="l">{popover}</EuiHeaderSectionItemButton>
+        )}
+      </div>
     </I18nProvider>
   );
 };

--- a/src/plugins/healthcheck/public/components/table/check_flyout.tsx
+++ b/src/plugins/healthcheck/public/components/table/check_flyout.tsx
@@ -70,16 +70,34 @@ export const CheckFlyout = ({ check, formatDate, setIsFlyoutVisible }: CheckFlyo
         <EuiFlexGroup direction="column">
           {error && (
             <>
-              <EuiFlexItem>
-                <EuiText size="m">
-                  <FormattedMessage id="healthcheck.check.details.error" defaultMessage="Error:" />
-                </EuiText>
-                <EuiSpacer size="s" />
-                <EuiCallOut size="s" color={mapTaskStatusToHealthColor(result)}>
-                  <p>{error}</p>
-                </EuiCallOut>
-              </EuiFlexItem>
-              <EuiSpacer />
+              {result === 'red' && (
+                <>
+                  <EuiFlexItem>
+                    <EuiText size="m">
+                      <FormattedMessage id="healthcheck.check.details.error" defaultMessage="Error:" />
+                    </EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiCallOut size="s" color={mapTaskStatusToHealthColor(result)}>
+                      <p>{error}</p>
+                    </EuiCallOut>
+                  </EuiFlexItem>
+                  <EuiSpacer />
+                </>
+              )}
+              {result === 'yellow' && (
+                <>
+                  <EuiFlexItem>
+                    <EuiText size="m">
+                      <FormattedMessage id="healthcheck.check.details.warning" defaultMessage="Warning:" />
+                    </EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiCallOut size="s" color={mapTaskStatusToHealthColor(result)}>
+                      <p>{error}</p>
+                    </EuiCallOut>
+                  </EuiFlexItem>
+                  <EuiSpacer />
+                </>
+              )}
             </>
           )}
           <EuiFlexItem>

--- a/src/plugins/healthcheck/public/components/table/checks_table.tsx
+++ b/src/plugins/healthcheck/public/components/table/checks_table.tsx
@@ -71,10 +71,6 @@ export const ChecksTable: FunctionComponent<ChecksTableProps> = ({ checks }) => 
           value: TASK.RUN_RESULT.RED.value,
           name: TASK.RUN_RESULT.RED.label,
         },
-        {
-          value: TASK.RUN_RESULT.GRAY.value,
-          name: TASK.RUN_RESULT.GRAY.label,
-        },
       ],
     },
     {

--- a/src/plugins/healthcheck/public/components/table/checks_table.tsx
+++ b/src/plugins/healthcheck/public/components/table/checks_table.tsx
@@ -5,7 +5,14 @@
 
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiBasicTable, EuiSearchBar, EuiSearchBarProps } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiSearchBar,
+  EuiSearchBarProps,
+  EuiSwitch,
+  EuiSwitchEvent,
+  EuiToolTip,
+} from '@elastic/eui';
 import { isEqual } from 'lodash';
 import { TaskInfo } from '../../../../../core/common/healthcheck';
 import { CheckFlyout } from './check_flyout';
@@ -18,7 +25,8 @@ interface ChecksTableProps {
   checks: Array<TaskInfo<{ isCritical: boolean; isEnabled: boolean }>>;
 }
 
-const initialQuery = EuiSearchBar.Query.MATCH_ALL;
+const enabledSwitchField = '_meta.isEnabled';
+const initialQuery = EuiSearchBar.Query.parse(`${enabledSwitchField}:true`);
 
 export const ChecksTable: FunctionComponent<ChecksTableProps> = ({ checks }) => {
   const [flyoutVisible, setFlyoutVisible] = useState(false);
@@ -73,17 +81,6 @@ export const ChecksTable: FunctionComponent<ChecksTableProps> = ({ checks }) => 
         },
       ],
     },
-    {
-      type: 'field_value_toggle_group',
-      field: '_meta.isEnabled',
-      items: [
-        { name: i18n.translate('healthcheck.enabled', { defaultMessage: 'Enabled' }), value: true },
-        {
-          name: i18n.translate('healthcheck.disabled', { defaultMessage: 'Disabled' }),
-          value: false,
-        },
-      ],
-    },
   ];
 
   const getCellProps = (item: any, column: any) => {
@@ -95,9 +92,49 @@ export const ChecksTable: FunctionComponent<ChecksTableProps> = ({ checks }) => 
     };
   };
 
+  const enabledSwitchChecked = query?.ast?.clauses.some(
+    (clause) => clause.field === enabledSwitchField && clause.value === false
+  );
+  const enabledSwitchLabel = i18n.translate('healthcheck.filter.showDisabled', {
+    defaultMessage: 'Show disabled',
+  });
+
+  const enabledSwitchOnChange = (event: EuiSwitchEvent) => {
+    // Baed on https://github.com/opensearch-project/oui/blob/1.21.0/src/components/search_bar/filters/field_value_toggle_filter.tsx#L71
+    const field = enabledSwitchField;
+    // Invert the value because the switch shows "Show disabled", so checked means isEnabled:false
+    const value = !Boolean(event.target.checked);
+    const operator = undefined;
+    const newQuery = query
+      .addSimpleFieldValue(field, value, true, operator) // Add new value
+      .removeSimpleFieldValue(field, !value); // Remove the opposite and expectec previous value
+
+    setQuery(newQuery);
+  };
+
   return (
     <>
-      <EuiSearchBar defaultQuery={initialQuery} onChange={onChangeQuery} filters={filters} />
+      <EuiSearchBar
+        defaultQuery={initialQuery}
+        query={query}
+        onChange={onChangeQuery}
+        filters={filters}
+        toolsRight={
+          <EuiToolTip
+            content={i18n.translate('healthcheck.filter.showDisabled.tooltip', {
+              defaultMessage: 'Filter by disabled checks',
+            })}
+            position="top"
+          >
+            <EuiSwitch
+              label={enabledSwitchLabel}
+              checked={enabledSwitchChecked}
+              onChange={enabledSwitchOnChange}
+              compressed={true}
+            />
+          </EuiToolTip>
+        }
+      />
       <EuiBasicTable
         columns={tableColumns(openFlyout)}
         items={filteredChecks}

--- a/src/plugins/healthcheck/public/components/table/checks_table.tsx
+++ b/src/plugins/healthcheck/public/components/table/checks_table.tsx
@@ -79,20 +79,6 @@ export const ChecksTable: FunctionComponent<ChecksTableProps> = ({ checks }) => 
     },
     {
       type: 'field_value_toggle_group',
-      field: '_meta.isCritical',
-      items: [
-        {
-          name: i18n.translate('healthcheck.critical', { defaultMessage: 'Critical' }),
-          value: true,
-        },
-        {
-          name: i18n.translate('healthcheck.nonCritical', { defaultMessage: 'Non-critical' }),
-          value: false,
-        },
-      ],
-    },
-    {
-      type: 'field_value_toggle_group',
       field: '_meta.isEnabled',
       items: [
         { name: i18n.translate('healthcheck.enabled', { defaultMessage: 'Enabled' }), value: true },

--- a/src/plugins/healthcheck/public/components/table/columns.tsx
+++ b/src/plugins/healthcheck/public/components/table/columns.tsx
@@ -60,17 +60,4 @@ export const tableColumns = (
     }),
     width: '150px',
   },
-  {
-    field: 'error',
-    name: i18n.translate('healthcheck.statusPage.statusTable.columns.errorHeader', {
-      defaultMessage: 'Error',
-    }),
-    truncateText: true,
-    render: (error: string) => {
-      if (!error) {
-        return '-';
-      }
-      return <span className="eui-textTruncate">{error}</span>;
-    },
-  },
 ];


### PR DESCRIPTION
### Description

This pull request refines the health check.

- Remove Critical, Non-Critical and Gray filters
- Skip start if there are no enabled checks
- Rename Error to Warning in the check details for yellow checks
- Add Error callout to red checks in check details
- Remove Error column of check list table

List of checks
- Remove Grey, Critical and Non-critical filters
- Remove Error column

<img width="1179" height="819" alt="Image" src="https://github.com/user-attachments/assets/ebbb4cd3-9031-4321-a7e2-91b55ddd993c" />

Enabling the switch this will display the `disabled` checks:

<img width="1177" height="576" alt="Image" src="https://github.com/user-attachments/assets/69fe3b26-dc38-4f7c-858a-87d558b9509b" />

<img width="360" height="113" alt="Image" src="https://github.com/user-attachments/assets/03cd944b-974e-47d8-9214-9a78b87e8a4c" />

- Replace Error to Warning for yellow checks
<img width="485" height="626" alt="Image" src="https://github.com/user-attachments/assets/6f46627d-00e7-4a7a-8c3a-82566f883a0e" />

### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7744

## Testing the changes

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Ensure the critical, non-critical and gray filters were removed | :black_circle: | :black_circle: | :black_circle: |
| For yellow hecks, the check details should displays Warning instead of Error | :black_circle: | :black_circle: | :black_circle: |
| The checks list should not display the Error column | :black_circle: | :black_circle: | :black_circle: |
| The enabled/disabled fitler was changed to a switch that should work as expected combining filters | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Ensure the critical, non-critical and gray filters were removed</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: For yellow hecks, the check details should displays Warning instead of Error</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: The checks list should not display the Error column</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: The enabled/disabled fitler was changed to a switch that should as expected combining filters</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
