### PR TITLE
Update of the changelog for rpm packages

### DIFF
--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -411,7 +411,7 @@ rm -fr %{buildroot}
 %attr(644, root, root) "/etc/systemd/system/wazuh-dashboard.service"
 
 %changelog
-* Thu Sep 25 2025 support <info@wazuh.com> - 4.14.1
+* Thu Nov 12 2025 support <info@wazuh.com> - 4.14.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-1.html
 * Wed Oct 22 2025 support <info@wazuh.com> - 4.14.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-0.html


### PR DESCRIPTION
### Description

The changelog for rpm packages is fixed because it must have the date in order.

### Issues Resolved

- #976 

## Testing the changes

- GH run:

[Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/18882974791)
[Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/18882982168)
[Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/18882987285)
[Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/18882993070)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
