### PR TITLE
Update composite names - Allocator 4.14.3

### DIFF
--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -431,7 +431,6 @@ jobs:
         run: |
           git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git
           cd wazuh-automation
-          git checkout change/2807-change-allocator-composite-names-2
           pip3 install -r deployability/deps/requirements.txt
 
       - name: RPM - Configure AWS credentials


### PR DESCRIPTION
> [!CAUTION]
> Code review only; the merge will be done at the same time as the other teams.

### Description

the Allocator's composite names naming was changed to the following:

- linux-centos-9-amd64 -> centos_stream-9-amd64
- linux-centos-8-arm64 -> centos_stream-8-arm64

## Testing the changes

https://github.com/wazuh/wazuh-dashboard/actions/runs/20133619576

https://github.com/wazuh/wazuh-dashboard/actions/runs/20133636208

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
