### PR TITLE
Hide Forecasting app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Removed
 
 - Removed creation of /usr/lib/.build-id/\* links to prevent conflicts when installing Wazuh Dashboard alongside OpenSearch Dashboards on the same system
-- Hide Forecasting app [#1048](https://github.com/wazuh/wazuh-dashboard/pull/1048)
 
 ### Changed
 


### PR DESCRIPTION
### Description

This PR adds a sed command to hide the forecasting app in the build packages script
#1045 

### Before


<img width="333" height="129" alt="image" src="https://github.com/user-attachments/assets/97205da1-736f-4352-8fb9-37599cd1303e" />


### After 

<img width="576" height="858" alt="Screenshot 2025-12-19 at 11 08 51 AM" src="https://github.com/user-attachments/assets/27941f46-b0dc-4bd0-b708-ca7218296d3f" />

https://github.com/user-attachments/assets/83e26880-8af4-40f5-b3a1-0fc0555366ad

## Test

- Install enviroment using the new wazuh-dashboard package 
  - arm (https://github.com/wazuh/wazuh-dashboard/actions/runs/20348908417)
  - x86 (https://github.com/wazuh/wazuh-dashboard/actions/runs/20376803923)
  - amd (https://github.com/wazuh/wazuh-dashboard/actions/runs/20376914313)
- Go to wazuh dashboard UI
- Check if Forecasting app exists on the sidebar menu

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
