### PR TITLE
Set default index pattern to wazuh-events*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
+- Changed default index pattern settings key from `defaultIndex` to `wazuh-events*` [#1090](https://github.com/wazuh/wazuh-dashboard/issues/1090)
 - Changed the location of the wazuh-dashboard service to match with the other Wazuh components [#805](https://github.com/wazuh/wazuh-dashboard/issues/805)
 - Changed the default value of `metaFields` and `timepicker:timeDefaults` settings [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
 

--- a/src/plugins/data/common/constants.ts
+++ b/src/plugins/data/common/constants.ts
@@ -123,4 +123,5 @@ export const UI_SETTINGS = {
   DATA_WITH_LONG_NUMERALS: 'data:withLongNumerals',
   DATE_FORMAT: 'dateFormat',
   DATE_FORMAT_TIMEZONE: 'dateFormat:tz',
+  WAZUH_EVENTS_INDEX: 'wazuh-events*',
 } as const;

--- a/src/plugins/data/common/data_views/data_views/ensure_default_data_view.test.ts
+++ b/src/plugins/data/common/data_views/data_views/ensure_default_data_view.test.ts
@@ -87,7 +87,7 @@ describe('ensureDefaultDataView', () => {
 
     await ensureDefaultDataView.call(indexPatterns);
     expect(indexPatterns.getIds).toHaveBeenCalled();
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test('should redirect when no patterns available and enhancements disabled', async () => {
@@ -199,7 +199,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test('should handle error in savedObjectsClient.find', async () => {
@@ -260,7 +260,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test("should handle index patterns without throwing error when data sources reference's id is empty", async () => {
@@ -314,7 +314,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -338,7 +338,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -358,7 +358,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test('should not throw error when getDataSource throws error', async () => {

--- a/src/plugins/data/common/data_views/data_views/ensure_default_data_view.test.ts
+++ b/src/plugins/data/common/data_views/data_views/ensure_default_data_view.test.ts
@@ -87,7 +87,7 @@ describe('ensureDefaultDataView', () => {
 
     await ensureDefaultDataView.call(indexPatterns);
     expect(indexPatterns.getIds).toHaveBeenCalled();
-    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
   });
 
   test('should redirect when no patterns available and enhancements disabled', async () => {
@@ -199,7 +199,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
   });
 
   test('should handle error in savedObjectsClient.find', async () => {
@@ -260,7 +260,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
   });
 
   test("should handle index patterns without throwing error when data sources reference's id is empty", async () => {
@@ -314,7 +314,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -338,7 +338,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern2');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -358,7 +358,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
   });
 
   test('should not throw error when getDataSource throws error', async () => {

--- a/src/plugins/data/common/data_views/data_views/ensure_default_data_view.test.ts
+++ b/src/plugins/data/common/data_views/data_views/ensure_default_data_view.test.ts
@@ -87,7 +87,7 @@ describe('ensureDefaultDataView', () => {
 
     await ensureDefaultDataView.call(indexPatterns);
     expect(indexPatterns.getIds).toHaveBeenCalled();
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
   });
 
   test('should redirect when no patterns available and enhancements disabled', async () => {
@@ -199,7 +199,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
   });
 
   test('should handle error in savedObjectsClient.find', async () => {
@@ -260,7 +260,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
   });
 
   test("should handle index patterns without throwing error when data sources reference's id is empty", async () => {
@@ -314,7 +314,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -338,7 +338,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
+    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern2');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -358,7 +358,7 @@ describe('ensureDefaultDataView', () => {
     });
 
     await ensureDefaultDataView.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('wazuh-events*', 'pattern1');
   });
 
   test('should not throw error when getDataSource throws error', async () => {

--- a/src/plugins/data/common/data_views/data_views/ensure_default_data_view.ts
+++ b/src/plugins/data/common/data_views/data_views/ensure_default_data_view.ts
@@ -95,7 +95,7 @@ export const createEnsureDefaultDataView = (
     // If there is any index pattern created, set the first as default
     if (patterns.length >= 1) {
       defaultId = patterns[0];
-      await uiSettings.set('defaultIndex', defaultId);
+      await uiSettings.set('wazuh-events*', defaultId);
     } else {
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       const shouldRedirect = !isEnhancementsEnabled;

--- a/src/plugins/data/common/data_views/data_views/ensure_default_data_view.ts
+++ b/src/plugins/data/common/data_views/data_views/ensure_default_data_view.ts
@@ -95,7 +95,7 @@ export const createEnsureDefaultDataView = (
     // If there is any index pattern created, set the first as default
     if (patterns.length >= 1) {
       defaultId = patterns[0];
-      await uiSettings.set('wazuh-events*', defaultId);
+      await uiSettings.set('defaultIndex', defaultId);
     } else {
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       const shouldRedirect = !isEnhancementsEnabled;

--- a/src/plugins/data/common/data_views/data_views/ensure_default_data_view.ts
+++ b/src/plugins/data/common/data_views/data_views/ensure_default_data_view.ts
@@ -8,6 +8,7 @@ import { DataViewsContract } from './data_views';
 import { DataViewSavedObjectsClientCommon, DataViewUiSettingsCommon } from '../types';
 
 export type EnsureDefaultDataView = () => Promise<unknown | void> | undefined;
+const WAZUH_EVENTS_INDEX = 'wazuh-events*';
 
 export const createEnsureDefaultDataView = (
   uiSettings: DataViewUiSettingsCommon,
@@ -95,7 +96,7 @@ export const createEnsureDefaultDataView = (
     // If there is any index pattern created, set the first as default
     if (patterns.length >= 1) {
       defaultId = patterns[0];
-      await uiSettings.set('defaultIndex', defaultId);
+      await uiSettings.set('defaultIndex', WAZUH_EVENTS_INDEX);
     } else {
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       const shouldRedirect = !isEnhancementsEnabled;

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
@@ -87,7 +87,7 @@ describe('ensureDefaultIndexPattern', () => {
 
     await ensureDefaultIndexPattern.call(indexPatterns);
     expect(indexPatterns.getIds).toHaveBeenCalled();
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test('should redirect when no patterns available and enhancements disabled', async () => {
@@ -199,7 +199,7 @@ describe('ensureDefaultIndexPattern', () => {
     });
 
     await ensureDefaultIndexPattern.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test('should handle error in savedObjectsClient.find', async () => {
@@ -260,7 +260,7 @@ describe('ensureDefaultIndexPattern', () => {
     });
 
     await ensureDefaultIndexPattern.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test("should handle index patterns without throwing error when data sources reference's id is empty", async () => {
@@ -314,7 +314,7 @@ describe('ensureDefaultIndexPattern', () => {
     });
 
     await ensureDefaultIndexPattern.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -338,7 +338,7 @@ describe('ensureDefaultIndexPattern', () => {
     });
 
     await ensureDefaultIndexPattern.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
     uiSettings.set.mockClear();
 
     savedObjectsClient.find.mockImplementation(async (params) => {
@@ -358,7 +358,7 @@ describe('ensureDefaultIndexPattern', () => {
     });
 
     await ensureDefaultIndexPattern.call(indexPatterns);
-    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'wazuh-events*');
   });
 
   test('should not throw error when getDataSource throws error', async () => {

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -33,6 +33,7 @@ import { IndexPatternsContract } from './index_patterns';
 import { SavedObjectsClientCommon, UiSettingsCommon } from '../types';
 
 export type EnsureDefaultIndexPattern = () => Promise<unknown | void> | undefined;
+const WAZUH_EVENTS_INDEX = 'wazuh-events*';
 
 export const createEnsureDefaultIndexPattern = (
   uiSettings: UiSettingsCommon,
@@ -120,7 +121,7 @@ export const createEnsureDefaultIndexPattern = (
     // If there is any index pattern created, set the first as default
     if (patterns.length >= 1) {
       defaultId = patterns[0];
-      await uiSettings.set('defaultIndex', defaultId);
+      await uiSettings.set('defaultIndex', WAZUH_EVENTS_INDEX);
     } else {
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       const shouldRedirect = !isEnhancementsEnabled;

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -202,7 +202,7 @@ export function getUiSettings(
       name: i18n.translate('data.advancedSettings.defaultIndexTitle', {
         defaultMessage: 'Default index',
       }),
-      value: null,
+      value: UI_SETTINGS.WAZUH_EVENTS_INDEX,
       type: 'string',
       description: i18n.translate('data.advancedSettings.defaultIndexText', {
         defaultMessage: 'The index to access if no index is set',


### PR DESCRIPTION
### Description

This PR sets wazuh-events* as the default index pattern in Wazuh Dashboard.

### Issues Resolved

- **Issue:** [#1090](https://github.com/wazuh/wazuh-dashboard/issues/1090)

## Screenshot

Video showing the `wazuh-events*` setting being automatically set as default value.

https://github.com/user-attachments/assets/8d188680-afbf-4ed0-8f91-39ab7ce146a2

## Testing the changes

1. Verify initial default value:
    - Open a fresh instance of Wazuh Dashboard
    - Go to `Dashboard Management -> Advanced Settings`
    - Search for "Default index"
    - Verify the value is `wazuh-events*`

2. Verify reset to default:
    -  Change the "Default index" value to any other pattern
    -  Click the "Reset to default" button
    - Verify it returns to `wazuh-events*`

3. Automated Testing
    - Run the updated test suite:
    ```console
    yarn test:jest --testPathPattern=ensure_default_data_view.test.ts
    yarn test:jest --testPathPattern=ensure_default_index_pattern.test.ts
     ```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
