### PR TITLE
Reorder the entries in the changelog for deb packages.

### DIFF
--- a/dev-tools/build-packages/deb/debian/changelog
+++ b/dev-tools/build-packages/deb/debian/changelog
@@ -1,14 +1,14 @@
-wazuh-dashboard (4.14.5-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-14-5.html
-
- -- Wazuh, Inc <info@wazuh.com>  Sat, 11 Apr 2026 12:00:00 +0000
-
 wazuh-dashboard (5.0.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 12 Mar 2026 12:00:00 +0000
+
+wazuh-dashboard (4.14.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-14-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Sat, 11 Apr 2026 12:00:00 +0000
 
 wazuh-dashboard (4.14.4-RELEASE) stable; urgency=low
 


### PR DESCRIPTION
### Description

The order of versions in the changelog of deb packages is changed so that the newest version comes first.

### Issues Resolved

- #1124 

### Evidence

- [Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22310187511)
- [Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22310177984)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
