### PR TITLE
Update CI/CD workflows to use custom Linux runners.(4.14.5)

### DIFF
--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -110,7 +110,7 @@ permissions:
 
 jobs:
   setup-variables:
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     name: Setup variables
     outputs:
       CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
@@ -220,7 +220,7 @@ jobs:
           echo "ARCHITECTURE_FLAG=$ARCHITECTURE_FLAG" >> $GITHUB_OUTPUT
 
   validate-job:
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     needs: setup-variables
     name: Validate inputs
     steps:
@@ -270,7 +270,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Generate packages
     steps:
       - name: Checkout code
@@ -347,7 +347,7 @@ jobs:
 
   test-package:
     needs: [setup-variables, build-package]
-    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     strategy:
       fail-fast: false
     name: Test package
@@ -536,7 +536,7 @@ jobs:
 
   upload-package:
     needs: [setup-variables, test-package]
-    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Upload package
     steps:
       - name: Set up AWS CLI

--- a/.github/workflows/4_builderpackage_dashboard_core.yml
+++ b/.github/workflows/4_builderpackage_dashboard_core.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || 'wz-linux-arm64' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'wz-linux-amd64' || 'wz-linux-arm64' }}
     name: Build
     defaults:
       run:


### PR DESCRIPTION
### Description

Replace GitHub-hosted runners (ubuntu-22.04, ubuntu-24.04, ubuntu-latest, ubuntu-24.04-arm) with the organization's self-hosted runners in the package build workflows.

Changes:

4_builderpackage_dashboard.yml
 — all jobs (setup-variables, validate-job, build-package, test-package, upload-package) now use wz-linux-amd64 for x86 and wz-linux-arm64 for ARM architectures.

4_builderpackage_dashboard_core.yml
 — build job updated accordingly.

### Issues Resolved

- #1129 

## Evidence 

- [Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22411976951)
- [Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22411985587)
- [Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22411993702)
- [Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22412001697)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
