### PR TITLE
Update GitHub Actions workflows to use custom `wz-linux` runners. (Main)

### DIFF
--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -110,7 +110,7 @@ permissions:
 
 jobs:
   setup-variables:
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: wz-linux-amd64
     name: Setup variables
     outputs:
       CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
@@ -226,7 +226,7 @@ jobs:
           echo "ARCHITECTURE_FLAG=$ARCHITECTURE_FLAG" >> $GITHUB_OUTPUT
 
   validate-job:
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     needs: setup-variables
     name: Validate inputs
     steps:
@@ -276,7 +276,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Generate packages
     steps:
       - name: Checkout code
@@ -353,7 +353,7 @@ jobs:
 
   test-package:
     needs: [setup-variables, build-package]
-    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     strategy:
       fail-fast: false
     name: Test package
@@ -542,7 +542,7 @@ jobs:
 
   upload-package:
     needs: [setup-variables, test-package]
-    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Upload package
     steps:
       - name: Set up AWS CLI

--- a/.github/workflows/4_builderpackage_dashboard_core.yml
+++ b/.github/workflows/4_builderpackage_dashboard_core.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || 'wz-linux-arm64' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'wz-linux-amd64' || 'wz-linux-arm64' }}
     name: Build
     defaults:
       run:

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -100,7 +100,7 @@ permissions:
 
 jobs:
   validate-job:
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     name: Validate inputs
     steps:
       - name: Validate inputs
@@ -127,7 +127,7 @@ jobs:
   #   - If need to add more plugins from the wazuh-dashboard-plugins repo, outputSHA can be omitted because it will be retrieved from the main plugin
   # - Add them to the outputs section (NAME_PLUGIN_... and WAZUH_..._SHA)
   get-outputs-plugins:
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: get-outputs-plugins
     needs: [validate-job]
     outputs:
@@ -226,7 +226,7 @@ jobs:
           fi
 
   setup-variables:
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     needs: [validate-job, get-outputs-plugins]
     name: Setup variables
     outputs:
@@ -357,7 +357,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, get-outputs-plugins, build-dashboard, build-plugins]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Generate packages
     steps:
       - name: Checkout code
@@ -448,7 +448,7 @@ jobs:
 
   test-package:
     needs: [setup-variables, build-package]
-    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     strategy:
       fail-fast: false
     name: Test package
@@ -637,7 +637,7 @@ jobs:
 
   upload-package:
     needs: [setup-variables, test-package]
-    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Upload package
     steps:
       - name: Set up AWS CLI

--- a/.github/workflows/5_builderpackage_dashboard_core.yml
+++ b/.github/workflows/5_builderpackage_dashboard_core.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || 'wz-linux-arm64' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'wz-linux-amd64' || 'wz-linux-arm64' }}
     name: Build
     defaults:
       run:

--- a/.github/workflows/5_builderpackage_dashboard_plugins.yml
+++ b/.github/workflows/5_builderpackage_dashboard_plugins.yml
@@ -32,11 +32,10 @@ on:
         description: 'Path to the plugins folder ( only for wazuh-dashboard-plugins repo )'
         required: false
 
-
 jobs:
   build-plugins:
     name: Build Plugin ${{ inputs.name }}
-    runs-on: ubuntu-latest
+    runs-on: wz-linux-amd64
     env:
       PLUGIN_REF: ${{ inputs.reference_plugins }}
     steps:

--- a/.github/workflows/6_builderpackage_dashboard.yml
+++ b/.github/workflows/6_builderpackage_dashboard.yml
@@ -127,7 +127,7 @@ jobs:
     #   - Final package name based on system, architecture and stage.
     #   - Architecture flags.
     #   - Version, revision and commit SHA information.
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     name: Setup variables
     outputs:
       CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
@@ -235,7 +235,7 @@ jobs:
   validate-job:
     # 1. Validates valid combinations of system and architecture.
     # 2. Sets up AWS CLI for future uploads if needed.
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     needs: setup-variables
     name: Validate job
     steps:
@@ -296,7 +296,7 @@ jobs:
     # 7. Finally, upload the resulting package as an artifact.
     needs:
       [setup-variables, build-main-plugins, build-base, build-security-plugin, build-report-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
     name: Generate packages
     steps:
       - name: Checkout code

--- a/.github/workflows/6_builderpackage_dashboard_core.yml
+++ b/.github/workflows/6_builderpackage_dashboard_core.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-24.04' || 'wz-linux-arm64' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'wz-linux-amd64' || 'wz-linux-arm64' }}
     name: Build
     defaults:
       run:


### PR DESCRIPTION
### Description

Migrate package build workflows from GitHub-hosted runners to the organization's self-hosted Wazuh runners.
## Changes
Replace GitHub-hosted runners (`ubuntu-latest`, `ubuntu-22.04`, `ubuntu-24.04`, `ubuntu-24.04-arm`) with self-hosted runners across all package build workflows:
- 4_builderpackage_dashboard.yml / 4_builderpackage_dashboard_core.yml
- 5_builderpackage_dashboard.yml / 5_builderpackage_dashboard_core.yml / 5_builderpackage_dashboard_plugins.yml
- 6_builderpackage_dashboard.yml / 6_builderpackage_dashboard_core.yml


| Architecture | Before | After |
|---|---|---|
| `amd64` / `x86_64` | `ubuntu-latest`, `ubuntu-22.04`, `ubuntu-24.04` | `wz-linux-amd64` |
| `arm64` / `aarch64` | `ubuntu-24.04-arm` | `wz-linux-arm64` |

### Issues Resolved

- #1129 

## Evidence 

- [Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22409902669)
- [Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22409914151)
- [Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22409916784)
- [Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/22409926201)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
