### PR TITLE
Disabled useNewHomePage setting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,16 @@
  */
 
 /**
+ * For new files created by Wazuh Contributors
+ */
+const OSD_WAZUH = `
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+`;
+
+/**
  * For new files created by OpenSearch Contributors
  */
 const OSD_NEW_HEADER = `
@@ -157,7 +167,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            licenses: [OSD_NEW_HEADER, OSD_HEADER],
+            licenses: [OSD_NEW_HEADER, OSD_HEADER, OSD_WAZUH],
           },
         ],
         '@osd/eslint/disallow-license-headers': [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.14.5
 
+### Changed
+
+- Disabled useNewHomePage setting [#1132](https://github.com/wazuh/wazuh-dashboard/pull/1132)
+
 ## Wazuh dashboard v4.14.4 - OpenSearch Dashboards 2.19.4 - Revision 00
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Disabled useNewHomePage setting [#1132](https://github.com/wazuh/wazuh-dashboard/pull/1132)
+- Disabled home:useNewHomePage setting [#1132](https://github.com/wazuh/wazuh-dashboard/pull/1132)
 
 ## Wazuh dashboard v4.14.4 - OpenSearch Dashboards 2.19.4 - Revision 00
 

--- a/src/core/server/ui_settings/ui_settings_config.test.ts
+++ b/src/core/server/ui_settings/ui_settings_config.test.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { applyDeprecations, configDeprecationFactory } from '@osd/config';
+import { config } from './ui_settings_config';
+
+const DEFAULT_CONFIG_PATH = 'uiSettings';
+
+const applyUiSettingsDeprecations = (settings: Record<string, any> = {}) => {
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const deprecationMessages: string[] = [];
+  const wrappedConfig: Record<string, any> = {
+    [DEFAULT_CONFIG_PATH]: settings,
+  };
+
+  const migrated = applyDeprecations(
+    wrappedConfig,
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: DEFAULT_CONFIG_PATH,
+    })),
+    (msg) => deprecationMessages.push(msg)
+  );
+
+  return {
+    messages: deprecationMessages,
+    migrated,
+  };
+};
+
+describe('uiSettings deprecations', () => {
+  it('removes home:useNewHomePage from overrides and keeps other overrides', () => {
+    const { migrated, messages } = applyUiSettingsDeprecations({
+      overrides: {
+        'home:useNewHomePage': true,
+        'theme:version': 'v7',
+      },
+    });
+
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"uiSettings.overrides.home:useNewHomePage\\" is ignored in Wazuh because the new home page is not supported and remains disabled",
+      ]
+    `);
+    expect(migrated.uiSettings.overrides).toEqual({
+      'theme:version': 'v7',
+    });
+  });
+
+  it('does not log anything when home:useNewHomePage is not overridden', () => {
+    const { migrated, messages } = applyUiSettingsDeprecations({
+      overrides: {
+        'theme:darkMode': false,
+      },
+    });
+
+    expect(messages).toEqual([]);
+    expect(migrated.uiSettings.overrides).toEqual({
+      'theme:darkMode': false,
+    });
+  });
+});

--- a/src/core/server/ui_settings/ui_settings_config.test.ts
+++ b/src/core/server/ui_settings/ui_settings_config.test.ts
@@ -66,7 +66,7 @@ describe('uiSettings deprecations', () => {
 
     expect(messages).toMatchInlineSnapshot(`
       Array [
-        "\\"uiSettings.overrides.home:useNewHomePage\\" is ignored in Wazuh because the new home page is not supported and remains disabled",
+        "\\"uiSettings.overrides.home:useNewHomePage\\" is ignored because the new home page is not supported and remains disabled",
       ]
     `);
     expect(migrated.uiSettings.overrides).toEqual({

--- a/src/core/server/ui_settings/ui_settings_config.test.ts
+++ b/src/core/server/ui_settings/ui_settings_config.test.ts
@@ -1,31 +1,6 @@
 /*
+ * Copyright Wazuh
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
  */
 
 import { applyDeprecations, configDeprecationFactory } from '@osd/config';

--- a/src/core/server/ui_settings/ui_settings_config.ts
+++ b/src/core/server/ui_settings/ui_settings_config.ts
@@ -49,7 +49,7 @@ const ignoreUseNewHomePageOverride: ConfigDeprecation = (settings, fromPath, log
 
   unset(settings, settingPath);
   log(
-    `"${settingPath}" is ignored in Wazuh because the new home page is not supported and remains disabled`
+    `"${settingPath}" is ignored because the new home page is not supported and remains disabled`
   );
   return settings;
 };

--- a/src/plugins/home/server/ui_settings.test.ts
+++ b/src/plugins/home/server/ui_settings.test.ts
@@ -16,19 +16,17 @@ describe('home settings', () => {
   const getValidationFn = (setting: UiSettingsParams) => (value: any) =>
     setting.schema.validate(value);
 
-  // Wazuh: Skip test because it is not used in Wazuh for now
-  describe.skip('home:useNewHomePage', () => {
+  describe('home:useNewHomePage', () => {
     const validate = getValidationFn(uiSettings['home:useNewHomePage']);
 
-    it('should only accept boolean values', () => {
-      expect(() => validate(true)).not.toThrow();
+    it('should only accept false', () => {
+      // Wazuh safeguard: this must stay hard-disabled until new home issues are fixed.
+      // If the feature is re-enabled, this test should be updated alongside ui_settings.ts
+      // and ui_settings_config.ts.
       expect(() => validate(false)).not.toThrow();
-      expect(() => validate('foo')).toThrowErrorMatchingInlineSnapshot(
-        `"expected value of type [boolean] but got [string]"`
-      );
-      expect(() => validate(12)).toThrowErrorMatchingInlineSnapshot(
-        `"expected value of type [boolean] but got [number]"`
-      );
+      expect(() => validate(true)).toThrow();
+      expect(() => validate('foo')).toThrow();
+      expect(() => validate(12)).toThrow();
     });
   });
 

--- a/src/plugins/home/server/ui_settings.ts
+++ b/src/plugins/home/server/ui_settings.ts
@@ -16,9 +16,8 @@ import { UiSettingsParams } from 'opensearch-dashboards/server';
 import { UiSettingScope } from '../../../core/server';
 import { SEARCH_WORKSPACE_DISMISS_GET_STARTED, USE_NEW_HOME_PAGE } from '../common/constants';
 
-// Wazuh: Remove the new home page configuration for now because it is not ready yet.
-// To add it again it must be exported
-// export const uiSettings: Record<string, UiSettingsParams> = {
+// Wazuh: keep the setting registered to avoid runtime errors in consumers that call
+// `uiSettings.get('home:useNewHomePage')`, but force it to remain disabled.
 export const uiSettings: Record<string, UiSettingsParams> = {
   [USE_NEW_HOME_PAGE]: {
     name: i18n.translate('home.ui_settings.useNewHomePage.label', {
@@ -28,7 +27,12 @@ export const uiSettings: Record<string, UiSettingsParams> = {
     description: i18n.translate('home.ui_settings.useNewHomePage.description', {
       defaultMessage: 'Try the new home page',
     }),
-    schema: schema.boolean(),
+    // Keep this setting hard-disabled while the new home/menu flow is unstable.
+    // To re-enable it in the future, switch back to schema.boolean(), remove readonly,
+    // and remove the ignoreUseNewHomePageOverride deprecation in ui_settings_config.ts.
+    // literal(false) also ignores stale persisted values set to true.
+    schema: schema.literal(false),
+    readonly: true,
     requiresPageReload: true,
   },
 };


### PR DESCRIPTION
### Description

This PR changes:
- Hard-disabled home:useNewHomePage at source
In ui_settings.ts, the setting stays registered but it is now forced to false with schema.literal(false) and marked readonly: true.

- Ignored YAML overrides for that setting
In ui_settings_config.ts, a deprecation handler removes uiSettings.overrides."home:useNewHomePage" during config processing, so even if someone sets it in opensearch_dashboards.yml, startup does not fail and the feature remains disabled.

### Issues Resolved

#1125 

## Screenshot

<img width="1512" height="448" alt="Screenshot 2026-02-26 at 4 25 54 PM" src="https://github.com/user-attachments/assets/22e01ada-96a9-4be5-96e3-2c4b254e062b" />


## Testing the changes

1. UI check: setting is not visible

Open Management -> OpenSearch Dashboards -> Settings, search for home and Use New Home Page.
Expected result: home:useNewHomePage does not appear in Advanced Settings.

2. Dev Tools check: force persisted value to true

Run this in Dev Tools to find the config document:

```http
POST .kibana/_update/config:2.19.4?refresh=true
{
  "doc": {
    "config": {
      "home:useNewHomePage": true
    }
  }
}

GET .kibana*/_search?expand_wildcards=all&ignore_unavailable=true
{
  "query": {
    "ids": {
      "values": ["config:2.19.4"]
    }
  }
}
```

<img width="1512" height="827" alt="Screenshot 2026-02-26 at 4 40 04 PM" src="https://github.com/user-attachments/assets/c843b237-5af6-4134-b05c-75ee4fad5eff" />


Expected result: dashboard still works, setting still not shown in UI, feature remains effectively disabled.

3. opensearch_dashboards.yml override check: service still starts and override is ignored
For security mode in this repo, edit opensearch_dashboards.dev.security.yml:

```yml
...
uiSettings:
  overrides:
    "home:useNewHomePage": true
...
```

Restart and start dashboard:

```bash
./docker/dev.sh down security
./docker/dev.sh up security
```

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
