### PR TITLE
Set default run_as value as true

### DIFF
--- a/config/opensearch_dashboards.prod.yml
+++ b/config/opensearch_dashboards.prod.yml
@@ -24,4 +24,4 @@ wazuh_core.hosts:
     port: 55000
     username: wazuh-wui
     password: wazuh-wui
-    run_as: false
+    run_as: true


### PR DESCRIPTION
### Description

Set the default `run_as` value to `true` in the `opensearch_dashboards.prod.yml` file.

### Issues Resolved

- **Issue**: https://github.com/wazuh/wazuh-dashboard/issues/1148

### Check List
- [X] Commits are signed per the DCO using --signoff
