### PR TITLE
Add `--set-as-main` flag support to repository bumper

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -32,6 +32,11 @@ on:
         description: 'Optional identifier for the run'
         required: false
         type: string
+      set_as_main:
+        description: 'Enable main branch mode: bump version values only, keep branch references pointing to main (use only on branch main)'
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   bump:
@@ -88,12 +93,14 @@ jobs:
           STAGE: ${{ inputs.stage }}
           TAG: ${{ inputs.tag }}
           DATE: ${{ inputs.date }}
+          SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
           tag=${{ env.TAG }}
           date=${{ env.DATE }}
+          set_as_main=${{ env.SET_AS_MAIN }}
 
           # Both version and stage provided
           if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
@@ -106,6 +113,11 @@ jobs:
 
           if [[ -n "$date" ]]; then
             script_params+=" --date ${date}"
+          fi
+
+          # Append --set_as_main flag when enabled (keeps branch references pointing to main)
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params="${script_params} --set_as_main"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
@@ -122,7 +134,18 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
+      - name: Detect if bump produced changes
+        id: bump_changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No file changes detected after bump. Skipping commit, PR creation and merge."
+          fi
+
       - name: Commit and push changes
+        if: steps.bump_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
@@ -130,6 +153,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.bump_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -142,6 +166,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.bump_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
@@ -150,6 +175,10 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
-          echo "Bumper scripts logs:"
+          if [[ "${{ steps.bump_changes.outputs.has_changes }}" == "true" ]]; then
+            echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+            echo "PR: Not created (no changes to commit)."
+          fi
+          echo "Bumper script logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -17,6 +17,8 @@ REVISION="00"
 DATE=""
 CURRENT_VERSION=""
 TAG=false
+SET_AS_MAIN=false
+SKIP_URLS="no"
 WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/4_builderpackage_dashboard.yml"
 DOCKERFILE_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile"
 README_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/README.md"
@@ -70,7 +72,7 @@ sed_inplace() {
 
 # Function to show usage
 usage() {
-  echo "Usage: $0 [--version VERSION --stage STAGE | --tag] [--date DATE] [--help]"
+  echo "Usage: $0 [--version VERSION --stage STAGE | --tag] [--date DATE] [--set_as_main] [--help]"
   echo ""
   echo "Parameters:"
   echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
@@ -84,6 +86,9 @@ usage() {
   echo "                      If --stage is not set, it will be stageless(e.g., v4.6.0)"
   echo "                      Otherwise it will be with the provided stage (e.g., v4.6.0-alpha1)"
   echo "                      If this is set, --version and --stage are not required."
+  echo "  --set_as_main       Enable main branch mode: bump version values only, keep branch"
+  echo "                      references pointing to main (alias: --set-as-main)"
+  echo "                      Use only when running on branch main to prepare a new version."
   echo "  --help              Display this help message"
   echo ""
   echo "Examples:"
@@ -92,6 +97,7 @@ usage() {
   echo "  $0 --tag --stage alpha1 --date 2025-04-15"
   echo "  $0 --tag --date 2025-04-15"
   echo "  $0 --tag"
+  echo "  $0 --version 5.0.0 --stage alpha0 --set_as_main"
 }
 
 # --- Core Logic Functions ---
@@ -119,9 +125,13 @@ parse_arguments() {
     --tag)
       TAG=true
       shift
-  ;;
+      ;;
+    --set_as_main|--set-as-main)
+      SET_AS_MAIN=true
+      shift
+      ;;
     *)
-      log "ERROR: Unknown option: $1" # Log error instead of just echo
+      log "ERROR: Unknown option: $1"
       usage
       exit 1
       ;;
@@ -425,15 +435,29 @@ update_build_workflow() {
 
     if grep -qE '\.yml@[^"[:space:]]+' "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
       log "Pattern found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Attempting update..."
-      # If the pattern exists, perform the substitution
-      sed_inplace -E "s/(\.yml@)[^\"[:space:]]+/\1${replacement}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
+      if [[ "$SKIP_URLS" == "yes" ]]; then
+        # set-as-main mode: only update versioned .yml@x.y.z refs, preserve .yml@main
+        sed_inplace -E "s|(\.yml@)${VERSION_PATTERN}|\1${replacement}|g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
+      else
+        # Normal mode: update all .yml@<ref> (versioned and main)
+        sed_inplace -E "s/(\.yml@)[^\"[:space:]]+/\1${replacement}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
+      fi
       modified=true
     else
       log "Pattern not found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Skipping update."
     fi
 
+    # Update default: 'main' branch input defaults only when not in set-as-main mode
+    if [[ "$SKIP_URLS" != "yes" ]]; then
+      if grep -qE "^[[:space:]]*default: 'main'" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
+        log "Branch input defaults found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Attempting update..."
+        sed_inplace -E "s/^([[:space:]]*default: )'main'([[:space:]]*)$/\1'${VERSION}'\2/" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
+        modified=true
+      fi
+    fi
+
     if [[ $modified == true ]]; then
-      log "Successfully updated references to @${replacement} in $(basename "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE")"
+      log "Successfully updated references in $(basename "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE")"
     fi
   fi
 }
@@ -755,6 +779,23 @@ update_deb_changelog() {
   fi
 }
 
+update_branch_reference_defaults() {
+  local branch_files=(
+    "${REPO_PATH}/.github/workflows/5_builderpackage_dashboard_core.yml"
+    "${REPO_PATH}/.github/workflows/5_builderpackage_dev_docker_image.yml"
+  )
+
+  for f in "${branch_files[@]}"; do
+    if [ -f "$f" ]; then
+      log "Updating branch input defaults in $(basename $f)..."
+      sed_inplace -E "s/^([[:space:]]*default: )'main'([[:space:]]*)$/\1'${VERSION}'\2/" "$f"
+      log "Successfully updated branch input defaults in $(basename $f)."
+    else
+      log "WARNING: $(basename $f) not found. Skipping branch defaults update."
+    fi
+  done
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -772,6 +813,14 @@ main() {
   # Parse and validate arguments
   parse_arguments "$@"
   validate_input
+
+  # Determine if main branch references should be preserved
+  if [ "$SET_AS_MAIN" = true ]; then
+    SKIP_URLS="yes"
+    log "Main branch mode enabled: version values will be updated but branch references will remain pointing to main"
+  else
+    SKIP_URLS="no"
+  fi
 
   log "Version: $VERSION"
   log "Stage: $STAGE"
@@ -791,6 +840,9 @@ main() {
   update_root_version_json
   update_package_json
   update_build_workflow
+  if [[ "$SKIP_URLS" != "yes" ]]; then
+    update_branch_reference_defaults
+  fi
   update_base_package_dockerfile
   update_readme_for_base_packages
   update_rendering_service_test_snap


### PR DESCRIPTION
## Description

This PR implements support for the `--set-as-main` flag in the `wazuh-dashboard` repository bumper as part of the two-step version bump flow from `main`. See the parent epic for full context: https://github.com/wazuh/wazuh-qa-automation/issues/6246

## Related issue

Closes https://github.com/wazuh/wazuh-dashboard/issues/1173

### Two-step flow

| Step | Branch | Flag | Behaviour |
|---|---|---|---|
| 1 | `main` | `--set_as_main` | Version values updated; `default: 'main'` and `.yml@main` references preserved |
| 2 | Numbered branch (from main) | _(none)_ | `default: 'main'` → `default: '<version>'`; version values updated; PR created |

### Files changed

#### `tools/repository_bumper.sh`

- Added global variables `SET_AS_MAIN=false` and `SKIP_URLS="no"`.
- Extended `usage()` to document `--set_as_main` (alias `--set-as-main`).
- Extended `parse_arguments()` to accept both `--set_as_main` and `--set-as-main`.
- Set `SKIP_URLS="yes"` in `main()` when `SET_AS_MAIN=true`, with a log message indicating the mode.
- Modified `update_build_workflow()`:
  - In set-as-main mode: replaces only versioned `.yml@x.y.z` refs, preserving `.yml@main`.
  - In normal mode: replaces all `.yml@<ref>` (existing behaviour) **plus** `default: 'main'` branch input defaults in `4_builderpackage_dashboard.yml`.
- Added new function `update_branch_reference_defaults()` targeting the 5.x builder workflows:
  - `.github/workflows/5_builderpackage_dashboard_core.yml` (`CHECKOUT_TO` input)
  - `.github/workflows/5_builderpackage_dev_docker_image.yml` (`branch` input)
  - Called from `main()` only when `SKIP_URLS != "yes"`.

#### `.github/workflows/5_bumper_repository.yml`

- Added `set_as_main` boolean input (`workflow_dispatch`).
- Passed `SET_AS_MAIN: ${{ inputs.set_as_main }}` to the "Determine branch name" step env block.
- Appends `--set_as_main` to `script_params` when the input is `true`.
- Added **no-op handling**: `Detect if bump produced changes` step using `git status --porcelain`; `Commit and push`, `Create pull request`, and `Merge pull request` steps are conditional on `has_changes == 'true'`. `Show logs` reports when no PR was created.

---

## Test plan

### Prerequisites

```bash
cd /path/to/wazuh-dashboard
```

### Scenario 1 — `set_as_main=true` on `main`: version values updated, branch refs unchanged

```bash
bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0 --set_as_main
```

**Expected:**
- `VERSION.json` and `package.json` updated to `5.0.1`.
- `default: 'main'` in `5_builderpackage_dashboard_core.yml`, `5_builderpackage_dev_docker_image.yml`, and `4_builderpackage_dashboard.yml` stays as `'main'`.
- `.yml@x.y.z` versioned refs in `4_builderpackage_dashboard.yml` updated to `5.0.1`.

<details>
<summary>stdout</summary>

```
[2026-03-30 14:16:04] Main branch mode enabled: version values will be updated but branch references will remain pointing to main
[2026-03-30 14:16:04] Version: 5.0.1
[2026-03-30 14:16:04] Stage: alpha0
[2026-03-30 14:16:04] Successfully extracted version using sed: 5.0.0
[2026-03-30 14:16:04] Version check passed: New version (5.0.1) is greater than current version (5.0.0) (Patch increased).
[2026-03-30 14:16:04] Successfully updated /home/asus/wazuh/wazuh-dashboard/VERSION.json with new version: 5.0.1 and stage: alpha0
[2026-03-30 14:16:04] Successfully updated /home/asus/wazuh/wazuh-dashboard/package.json with new version: 5.0.1 and revision: 00
[2026-03-30 14:16:04] Pattern found in 4_builderpackage_dashboard.yml. Attempting update...
[2026-03-30 14:16:04] Successfully updated references in 4_builderpackage_dashboard.yml
[2026-03-30 14:16:04] Repository bump completed successfully.
```

</details>

<details>
<summary>Verification</summary>

```
# VERSION.json → 5.0.1 ✅
$ cat VERSION.json
{ "version": "5.0.1", "stage": "alpha0" }

# default: 'main' preserved in all 5x/4x builder files ✅
$ grep "default: 'main'" \
    .github/workflows/5_builderpackage_dashboard_core.yml \
    .github/workflows/5_builderpackage_dev_docker_image.yml \
    .github/workflows/4_builderpackage_dashboard.yml
5_builderpackage_dashboard_core.yml:        default: 'main'
5_builderpackage_dashboard_core.yml:        default: 'main'
5_builderpackage_dev_docker_image.yml:        default: 'main'
4_builderpackage_dashboard.yml:        default: 'main'
4_builderpackage_dashboard.yml:        default: 'main'
4_builderpackage_dashboard.yml:        default: 'main'
4_builderpackage_dashboard.yml:        default: 'main'

# .yml@ versioned refs updated to 5.0.1 ✅
$ grep "\.yml@" .github/workflows/4_builderpackage_dashboard.yml
    uses: ...4_builderpackage_dashboard_core.yml@5.0.1
    uses: ...4_builderpackage_plugins.yml@5.0.1
    uses: ...4_builderpackage_security_plugin.yml@5.0.1
```

</details>

---

### Scenario 2 — `set_as_main=false` on a branch created from `main`: `main` refs replaced

```bash
bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0
```

**Expected:**
- `VERSION.json` and `package.json` updated to `5.0.1`.
- All `default: 'main'` in `5_builderpackage_dashboard_core.yml`, `5_builderpackage_dev_docker_image.yml`, and `4_builderpackage_dashboard.yml` replaced with `'5.0.1'`.
- `.yml@x.y.z` versioned refs updated to `5.0.1`.

<details>
<summary>stdout</summary>

```
[2026-03-30 14:17:02] Version: 5.0.1
[2026-03-30 14:17:02] Stage: alpha0
[2026-03-30 14:17:02] Successfully updated /home/asus/wazuh/wazuh-dashboard/VERSION.json with new version: 5.0.1 and stage: alpha0
[2026-03-30 14:17:02] Successfully updated references in 4_builderpackage_dashboard.yml
[2026-03-30 14:17:02] Updating branch input defaults in 5_builderpackage_dashboard_core.yml...
[2026-03-30 14:17:02] Successfully updated branch input defaults in 5_builderpackage_dashboard_core.yml.
[2026-03-30 14:17:02] Updating branch input defaults in 5_builderpackage_dev_docker_image.yml...
[2026-03-30 14:17:02] Successfully updated branch input defaults in 5_builderpackage_dev_docker_image.yml.
[2026-03-30 14:17:02] Repository bump completed successfully.
```

</details>

<details>
<summary>Verification</summary>

```
# VERSION.json → 5.0.1 ✅
$ cat VERSION.json
{ "version": "5.0.1", "stage": "alpha0" }

# default: 'main' replaced with '5.0.1' in all builder files ✅
$ grep "default: '5.0.1'" \
    .github/workflows/5_builderpackage_dashboard_core.yml \
    .github/workflows/5_builderpackage_dev_docker_image.yml \
    .github/workflows/4_builderpackage_dashboard.yml
5_builderpackage_dashboard_core.yml:        default: '5.0.1'
5_builderpackage_dashboard_core.yml:        default: '5.0.1'
5_builderpackage_dev_docker_image.yml:        default: '5.0.1'
4_builderpackage_dashboard.yml:        default: '5.0.1'
4_builderpackage_dashboard.yml:        default: '5.0.1'
4_builderpackage_dashboard.yml:        default: '5.0.1'
4_builderpackage_dashboard.yml:        default: '5.0.1'

# .yml@ refs updated ✅
$ grep "\.yml@" .github/workflows/4_builderpackage_dashboard.yml
    uses: ...4_builderpackage_dashboard_core.yml@5.0.1
    uses: ...4_builderpackage_plugins.yml@5.0.1
    uses: ...4_builderpackage_security_plugin.yml@5.0.1

# git diff --stat ✅
 .github/workflows/4_builderpackage_dashboard.yml         | 14 +++--
 .github/workflows/5_builderpackage_dashboard_core.yml    |  4 +-
 .github/workflows/5_builderpackage_dev_docker_image.yml  |  2 +-
 CHANGELOG.md                                             |  6 ++
 VERSION.json                                             |  2 +-
 ...
```

</details>

---

### Scenario 3 — Standard bump on a numbered branch: works as before

Same command as Scenario 2 (no `--set_as_main`). Confirms the existing bump flow is unaffected.

```bash
bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0
```

**Expected:** Same output as Scenario 2. Exit code `0`.

---

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
