### PR TITLE
Center health check indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 5.0.0
-- Health check service [#811](https://github.com/wazuh/wazuh-dashboard/pull/811) [#866](https://github.com/wazuh/wazuh-dashboard/pull/866) [#961](https://github.com/wazuh/wazuh-dashboard/pull/961) [#1031](https://github.com/wazuh/wazuh-dashboard/pull/1031)
+- Health check service [#811](https://github.com/wazuh/wazuh-dashboard/pull/811) [#866](https://github.com/wazuh/wazuh-dashboard/pull/866) [#961](https://github.com/wazuh/wazuh-dashboard/pull/961) [#1031](https://github.com/wazuh/wazuh-dashboard/pull/1031) [#1179](https://github.com/wazuh/wazuh-dashboard/pull/1179)
 - Added Health Check plugin [#870](https://github.com/wazuh/wazuh-dashboard/pull/870) [#946](https://github.com/wazuh/wazuh-dashboard/pull/946)
 - Added manager host configuration for the default configuration file [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
 - Set v9 theme as default [#1092](https://github.com/wazuh/wazuh-dashboard/pull/1092)

--- a/src/plugins/healthcheck/public/components/button_header/health_check_nav_button.tsx
+++ b/src/plugins/healthcheck/public/components/button_header/health_check_nav_button.tsx
@@ -9,7 +9,7 @@ import {
   EuiButtonEmpty,
   EuiContextMenuPanel,
   EuiHeaderSectionItemButton,
-  EuiHealth,
+  EuiIcon,
   EuiPopover,
   EuiToolTip,
   EuiText,
@@ -58,7 +58,19 @@ export const HealthCheckNavButton = ({
 
   const isPlacedInLeftNav = coreStart.uiSettings.get('home:useNewHomePage');
 
-  const overallStatusIndicator = <EuiHealth color={mapTaskStatusToHealthColor(status)} />;
+  const overallStatusIndicator = (
+    <EuiIcon
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginLeft: '1.5px',
+      }}
+      type="dot"
+      color={mapTaskStatusToHealthColor(status)}
+      aria-hidden
+    />
+  );
 
   // ToDo: Add aria-label and tooltip when isPlacedInLeftNav is true
   const button = (

--- a/src/plugins/healthcheck/public/components/button_header/health_check_nav_button.tsx
+++ b/src/plugins/healthcheck/public/components/button_header/health_check_nav_button.tsx
@@ -64,7 +64,6 @@ export const HealthCheckNavButton = ({
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        marginLeft: '1.5px',
       }}
       type="dot"
       color={mapTaskStatusToHealthColor(status)}
@@ -144,6 +143,7 @@ export const HealthCheckNavButton = ({
         setPopoverOpen(false);
       }}
       panelPaddingSize="m"
+      panelStyle={{ marginLeft: '-1px' }}
     >
       {contextMenuPanel}
     </EuiPopover>


### PR DESCRIPTION
### Description

Centers health check indicator.

-Changed EuiHealth component to EuiIcon, due to EuiHealth expecting a label that was causing extra padding.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8261

## Screenshot

<img width="836" height="544" alt="image" src="https://github.com/user-attachments/assets/83b2ba1d-856c-4970-b6e3-7224ecd19cd2" />


## Testing the changes

- Verify navbar health check status indicator is centered. 

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
