### PR TITLE
Improves CI reliability with retry logic and caching

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -269,7 +269,7 @@ jobs:
           # Check the corresponding previous version to be used in the upgrade test
           sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
           sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
-          sudo apt-get update
+          sudo apt-get update || sudo apt-get update
           PREVIOUS=$(apt-cache madison wazuh-dashboard | grep -A 1 "$VERSION" | tail -1 | awk '{print $3}')
           if [ -z "$PREVIOUS" ]; then
             MAJOR_MINOR=$(echo "$VERSION" | cut -d '.' -f 1,2)$(echo ".")
@@ -533,11 +533,10 @@ jobs:
       - name: DEB - Test package upgrade
         if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'deb' }}
         run: |
-          sudo apt-get install debhelper tar curl libcap2-bin #debhelper version 9 or later
-          sudo apt-get install gnupg apt-transport-https
+          sudo apt-get install debhelper tar curl libcap2-bin gnupg apt-transport-https #debhelper version 9 or later
           sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
           sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
-          sudo apt-get update
+          sudo apt-get update || sudo apt-get update
           sudo apt-get -y install wazuh-dashboard=${{needs.setup-variables.outputs.PREVIOUS}}
           sudo  systemctl daemon-reload
           sudo  systemctl enable wazuh-dashboard
@@ -566,7 +565,7 @@ jobs:
         run: |
           git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git
           cd wazuh-automation
-          pip3 install -r deployability/deps/requirements.txt
+          pip3 install --retries 3 -r deployability/deps/requirements.txt
 
       - name: RPM - Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -213,21 +213,20 @@ jobs:
       - name: Get outputs of wazuh-dashboard-plugins
         id: get-plugins
         run: |
-          # TODO: Refactor getting the commit SHA using git ls-remote, use git rev-parse in the plugin build instead. The git ls-remote is causing errors due to matching multiple branches with similar name when using /, e.g. bumper/main
           REPOSITORY=${{ matrix.plugin.repository }}
           REFERENCE="${{ inputs.reference_plugins }}"
           if [ -z "$REFERENCE" ]; then
             echo "No plugin reference provided, using github.ref_name: ${{ github.ref_name }}"
             REFERENCE="${{ github.ref_name }}"
-            SHA=$(git ls-remote $REPOSITORY "refs/heads/$REFERENCE" | cut -f1 | cut -c1-7)
+            SHA=$(git ls-remote $REPOSITORY "$REFERENCE" | cut -f1 | cut -c1-7)
             PACKAGE_NAME=${{matrix.plugin.packageName}}_${{ steps.get-version.outputs.VERSION }}-${{ steps.get-version.outputs.REVISION }}_$(echo $REFERENCE | sed 's/\//-/g').zip
           else
             echo "Using reference: $REFERENCE"
-            SHA=$(git ls-remote $REPOSITORY "refs/heads/$REFERENCE" | cut -f1 | cut -c1-7)
+            SHA=$(git ls-remote $REPOSITORY "$REFERENCE" | cut -f1 | cut -c1-7)
             if [ -z "$SHA" ]; then
               echo "Reference $REFERENCE not found, trying with '${{ github.ref_name }}' branch"
               REFERENCE="${{ github.ref_name }}"
-              SHA=$(git ls-remote $REPOSITORY "refs/heads/$REFERENCE" | cut -f1 | cut -c1-7)
+              SHA=$(git ls-remote $REPOSITORY $REFERENCE | cut -f1 | cut -c1-7)
             fi
             PACKAGE_NAME=${{matrix.plugin.packageName}}_${{ steps.get-version.outputs.VERSION }}-${{ steps.get-version.outputs.REVISION }}_$(echo $REFERENCE | sed 's/\//-/g').zip
           fi

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -213,20 +213,21 @@ jobs:
       - name: Get outputs of wazuh-dashboard-plugins
         id: get-plugins
         run: |
+          # TODO: Refactor getting the commit SHA using git ls-remote, use git rev-parse in the plugin build instead. The git ls-remote is causing errors due to matching multiple branches with similar name when using /, e.g. bumper/main
           REPOSITORY=${{ matrix.plugin.repository }}
           REFERENCE="${{ inputs.reference_plugins }}"
           if [ -z "$REFERENCE" ]; then
             echo "No plugin reference provided, using github.ref_name: ${{ github.ref_name }}"
             REFERENCE="${{ github.ref_name }}"
-            SHA=$(git ls-remote $REPOSITORY "$REFERENCE" | cut -f1 | cut -c1-7)
+            SHA=$(git ls-remote $REPOSITORY "refs/heads/$REFERENCE" | cut -f1 | cut -c1-7)
             PACKAGE_NAME=${{matrix.plugin.packageName}}_${{ steps.get-version.outputs.VERSION }}-${{ steps.get-version.outputs.REVISION }}_$(echo $REFERENCE | sed 's/\//-/g').zip
           else
             echo "Using reference: $REFERENCE"
-            SHA=$(git ls-remote $REPOSITORY "$REFERENCE" | cut -f1 | cut -c1-7)
+            SHA=$(git ls-remote $REPOSITORY "refs/heads/$REFERENCE" | cut -f1 | cut -c1-7)
             if [ -z "$SHA" ]; then
               echo "Reference $REFERENCE not found, trying with '${{ github.ref_name }}' branch"
               REFERENCE="${{ github.ref_name }}"
-              SHA=$(git ls-remote $REPOSITORY $REFERENCE | cut -f1 | cut -c1-7)
+              SHA=$(git ls-remote $REPOSITORY "refs/heads/$REFERENCE" | cut -f1 | cut -c1-7)
             fi
             PACKAGE_NAME=${{matrix.plugin.packageName}}_${{ steps.get-version.outputs.VERSION }}-${{ steps.get-version.outputs.REVISION }}_$(echo $REFERENCE | sed 's/\//-/g').zip
           fi

--- a/.github/workflows/5_builderpackage_dashboard_core.yml
+++ b/.github/workflows/5_builderpackage_dashboard_core.yml
@@ -89,7 +89,7 @@ jobs:
           echo "ARTIFACT_BUILD_NAME=wazuh-dashboard_${{ env.WZD_VERSION }}-${{ env.WZD_REVISION }}_${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'x64' || 'arm64' }}.${{ matrix.DISTRIBUTION }}" >> $GITHUB_ENV
 
       - name: Run bootstrap
-        run: yarn osd bootstrap
+        run: yarn osd bootstrap || yarn osd bootstrap
 
       - name: Build
         run: yarn build-platform --${{(inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'linux' || 'linux-arm'}} --skip-os-packages --release

--- a/.github/workflows/5_builderpackage_dashboard_plugins.yml
+++ b/.github/workflows/5_builderpackage_dashboard_plugins.yml
@@ -51,7 +51,20 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Yarn
-        run: npm install -g yarn@^1.22.10
+        run: |
+          npm install -g yarn@1.22.10
+          yarn config set network-timeout 1000000 -g
+
+      - name: Configure Yarn Cache
+        run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
+
+      - name: Initialize Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.YARN_CACHE_LOCATION }}
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-
 
       - name: Check if plugin reference exists or use github.ref_name
         run: |
@@ -92,7 +105,7 @@ jobs:
       - name: Bootstrap with Plugins
         env:
           GIT_REF: ${{ env.PLUGIN_REF }}
-        run: yarn osd bootstrap --single-version=loose
+        run: yarn osd bootstrap --single-version=loose || yarn osd bootstrap --single-version=loose
 
       - name: Build Plugin
         working-directory: plugins/${{ inputs.name }}

--- a/dev-tools/build-packages/build-packages.sh
+++ b/dev-tools/build-packages/build-packages.sh
@@ -78,7 +78,9 @@ get_packages(){
     log "Downloading ${package_name}"
 
     if [[ $package_url =~ $valid_url ]]; then
-      if ! run_with_retry curl --output "packages/${package_var}.zip" --silent --show-error --fail "${package_url}"; then
+      if ! run_with_retry curl --output "packages/${package_var}.zip" --silent --show-error --fail \
+          --retry "${RETRY_MAX_ATTEMPTS}" --retry-delay "${RETRY_DELAY_SECONDS}" --retry-connrefused \
+          "${package_url}"; then
         echo "Failed to download ${package_name} after ${RETRY_MAX_ATTEMPTS} attempts: ${package_url}"
         clean 1
       fi
@@ -91,8 +93,6 @@ get_packages(){
   done
   cd ..
 }
-
-source ../utils/retry-operation.sh
 
 build_tar() {
   log


### PR DESCRIPTION
## Summary

Improves the reliability of the `5_builderpackage_dashboard` workflow group by reducing dependency installation failures caused by transient network errors, non-deterministic package versions, and missing caching.

## Changes

### `5_builderpackage_dashboard_plugins.yml`

- **Fix Yarn version:** pinned `yarn@^1.22.10` (semver range) to `yarn@1.22.10` (exact version) to ensure deterministic builds across runs.
- **Add network timeout:** set `yarn config set network-timeout 1000000 -g` to give Yarn sufficient time to recover from transient registry errors (e.g. `502 Bad Gateway`) before aborting.
- **Add Yarn cache:** added `Configure Yarn Cache` and `Initialize Yarn Cache` steps using `actions/cache@v4`, consistent with `5_builderpackage_dashboard_core.yml`. On cache hit, packages are restored locally and the npm registry is never contacted, eliminating the root cause of flaky bootstrap failures.
- **Add bootstrap retry:** `yarn osd bootstrap --single-version=loose || yarn osd bootstrap --single-version=loose` — if a transient registry error occurs on a cache miss, the second attempt benefits from partially cached packages.

### `5_builderpackage_dashboard_core.yml`

- **Add bootstrap retry:** `yarn osd bootstrap || yarn osd bootstrap` for the same reason as above.

### `5_builderpackage_dashboard.yml`

- **Retry `apt-get update`** in `setup-variables` and `DEB - Test package upgrade` steps: `sudo apt-get update || sudo apt-get update` to handle transient APT mirror failures.
- **Consolidate `apt-get install`** in `DEB - Test package upgrade`: merged two separate `apt-get install` calls into one to reduce the number of network operations.
- **Add pip retry:** `pip3 install --retries 3` in `RPM - Clone automation repo` to handle transient PyPI failures when installing `deployability` dependencies.
- WORKAROUND: add a fix to reduce the branch matching in the git ls-remote commands