### PR TITLE
Support Revert bump functionality in wazuh-dashboard

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -188,6 +188,11 @@ jobs:
           git checkout HEAD -- VERSION.json 2>/dev/null || true
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
           git checkout HEAD -- package.json 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-dev-image/README.md 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-dev-image/build-multiarch.sh 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile 2>/dev/null || true
+          git checkout HEAD -- src/core/server/healthcheck/healthcheck/config.ts 2>/dev/null || true
+          git checkout HEAD -- src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap 2>/dev/null || true
 
           if git diff --staged --quiet; then
             echo "No references to revert. Skipping commit."

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -37,6 +37,11 @@ on:
         default: false
         required: false
         type: boolean
+      revert:
+        description: 'Set to true to revert the bump changes applied for this issue'
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   bump:
@@ -82,9 +87,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
-          # doesn't have all the necessary permissions
           token: ${{ env.GH_TOKEN }}
+          fetch-depth: 0
 
       - name: Determine branch name
         id: vars
@@ -121,7 +125,13 @@ jobs:
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
-          BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
+          if [[ "${{ inputs.revert }}" == "true" ]]; then
+            BRANCH_NAME="enhancement/wqa${issue_number}-revert-bump-${{ github.ref_name }}"
+            echo "pr_title=Revert bump ${{ github.ref_name }} branch" >> $GITHUB_OUTPUT
+          else
+            BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
+            echo "pr_title=Bump ${{ github.ref_name }} branch" >> $GITHUB_OUTPUT
+          fi
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "script_params=${script_params}" >> $GITHUB_OUTPUT
 
@@ -130,6 +140,7 @@ jobs:
           git checkout -b ${{ steps.vars.outputs.branch_name }}
 
       - name: Make version bump changes
+        if: inputs.revert != true
         run: |
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
@@ -137,27 +148,67 @@ jobs:
       - name: Detect if bump produced changes
         id: bump_changes
         run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
+          if [[ "${{ inputs.revert }}" == "true" ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          elif [[ -n "$(git status --porcelain)" ]]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No file changes detected after bump. Skipping commit, PR creation and merge."
           fi
 
-      - name: Commit and push changes
-        if: steps.bump_changes.outputs.has_changes == 'true'
+      - name: Commit changes (Bump)
+        if: inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
+
+      - name: Revert references (Revert)
+        id: revert_step
+        if: inputs.revert == true
+        run: |
+          ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
+
+          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+
+          PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+            echo "Error: The original PR for the bump was not found"
+            echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
+            exit 1
+          fi
+
+          echo "Original PR found: #$PR_NUMBER"
+
+          MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
+
+          git revert -m 1 $MERGE_COMMIT --no-commit
+
+          git checkout HEAD -- VERSION.json 2>/dev/null || true
+          git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
+          git checkout HEAD -- package.json 2>/dev/null || true
+
+          if git diff --staged --quiet; then
+            echo "No references to revert. Skipping commit."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "feat: revert ${{ github.ref_name }} references"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push changes
+        if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        run: |
           git push origin ${{ steps.vars.outputs.branch_name }}
 
       - name: Create pull request
         id: create_pr
-        if: steps.bump_changes.outputs.has_changes == 'true'
+        if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
-            --title "Bump ${{ github.ref_name }} branch" \
+            --title "${{ steps.vars.outputs.pr_title }}" \
             --body "Issue: ${{ inputs.issue-link }}" \
             --base ${{ github.ref_name }} \
             --head ${{ steps.vars.outputs.branch_name }})
@@ -166,12 +217,12 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
-        if: steps.bump_changes.outputs.has_changes == 'true'
+        if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
 
       - name: Show logs
+        if: inputs.revert != true
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
@@ -182,3 +233,16 @@ jobs:
           fi
           echo "Bumper script logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log
+
+      - name: Show revert logs
+        if: inputs.revert == true
+        run: |
+          echo "Revert bump complete."
+          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+          if [[ "${{ steps.revert_step.outputs.has_changes }}" == "true" ]]; then
+            echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+            echo "No references to revert (no PR created)."
+          fi
+          echo "Revert bumper script logs:"
+          cat ${BUMP_LOG_PATH}/repository_bumper*log || true

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -189,6 +189,14 @@ jobs:
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
           git checkout HEAD -- package.json 2>/dev/null || true
 
+          # These files may not have been modified in the bump, so they are avoided on the revert but ignore if they are not in the index
+          git checkout HEAD -- src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-packages/rpm/wazuh-dashboard.spec 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-packages/deb/debian/changelog 2>/dev/null || true
+          git checkout HEAD -- src/core/server/healthcheck/healthcheck/config.ts 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-dev-image/build-multiarch.sh 2>/dev/null || true
+          git checkout HEAD -- dev-tools/build-dev-image/README.md 2>/dev/null || true
+
           if git diff --staged --quiet; then
             echo "No references to revert. Skipping commit."
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -188,11 +188,6 @@ jobs:
           git checkout HEAD -- VERSION.json 2>/dev/null || true
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
           git checkout HEAD -- package.json 2>/dev/null || true
-          git checkout HEAD -- dev-tools/build-dev-image/README.md 2>/dev/null || true
-          git checkout HEAD -- dev-tools/build-dev-image/build-multiarch.sh 2>/dev/null || true
-          git checkout HEAD -- dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile 2>/dev/null || true
-          git checkout HEAD -- src/core/server/healthcheck/healthcheck/config.ts 2>/dev/null || true
-          git checkout HEAD -- src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap 2>/dev/null || true
 
           if git diff --staged --quiet; then
             echo "No references to revert. Skipping commit."

--- a/tools/README.md
+++ b/tools/README.md
@@ -50,10 +50,15 @@ The script performs the following actions:
     - `CHANGELOG.md`:
       - Updates the revision number in the header if an entry for the version already exists.
       - Adds a new entry with the specified version, stage, revision, and detected OpenSearch Dashboards version if no entry exists.
-    - `.github/workflows/build_wazuh_dashboard_with_plugins.yml`: Updates references like `yml@vX.Y.Z` to `yml@v<VERSION>-<STAGE>`.
-    - `dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile`: Updates `_BRANCH=X.Y.Z` and `wazuh-packages-to-base:X.Y.Z` references to use the new `<VERSION>`.
+    - `.github/workflows/5_builderpackage_dashboard_core.yml`: Updates version references from `default: main` to `default: <VERSION>`.
+    - `.github/workflows/5_builderpackage_dev_docker_image.yml`: Updates version references from `default: main` to `default: <VERSION>`.
     - `dev-tools/build-packages/base-packages-to-base/README.md`: Updates version references in example commands (`--app X.Y.Z`, `--base X.Y.Z`, `--security X.Y.Z`) and descriptive text.
     - `src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap`: Updates `"wazuhVersion": "X.Y.Z"` to use the new `<VERSION>`.
+    - `dev-tools/build-packages/rpm/wazuh-dashboard.spec`: Changes the data for existing version entry or add a new entry if not exist for the version.
+    - `dev-tools/build-packages/deb/debian/changelog`: Changes the data for existing version entry or add a new entry if not exist for the version.
+    - `src/core/server/healthcheck/healthcheck/config.ts`: Updates the versioned documentation link from `https://documentation.wazuh.com/<VERSION>` to the new version.
+    - `dev-tools/build-dev-image/build-multiarch.sh`: Updates the default variables `OPENSEARCH_DASHBOARD_VERSION`, `TAG` and `NODE_VERSION` with the new versions.
+    - `dev-tools/build-dev-image/README.md`: Updates the versions related to OpenSearch Dashbaords, NodeJS and Docker image tag in build parameters and descriptive text.
 6.  **Logging:** All actions, errors, and results are logged to the timestamped log file in the `tools` directory.
 
 ## Notes

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -417,93 +417,24 @@ update_changelog() {
   fi
 }
 
-update_base_package_dockerfile() {
-  log "Updating $(basename $DOCKERFILE_FOR_BASE_PACKAGES)..."
-
-  if [ -f "$DOCKERFILE_FOR_BASE_PACKAGES" ]; then
-    local modified=false
-
-    # Update all occurrences of _BRANCH=x.y.z with _BRANCH=$VERSION
-    local branch_pattern_regex="(_BRANCH=)$VERSION_PATTERN"
-    if grep -qE "$branch_pattern_regex" "$DOCKERFILE_FOR_BASE_PACKAGES"; then
-      log "Pattern '$branch_pattern_regex' found in $(basename $DOCKERFILE_FOR_BASE_PACKAGES). Attempting update..."
-      # Perform the substitution
-      sed_inplace -E "s/${branch_pattern_regex}/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES"
-      modified=true
-    else
-      log "Pattern '$branch_pattern_regex' not found in $(basename $DOCKERFILE_FOR_BASE_PACKAGES). Skipping update for this pattern."
-    fi
-
-    # Update all occurrences of wazuh-packages-to-base:x.y.z with wazuh-packages-to-base:$VERSION
-    sed_inplace -E "s/(wazuh-packages-to-base:)$VERSION_PATTERN/\1${VERSION}/g" "$DOCKERFILE_FOR_BASE_PACKAGES" && modified=true
-
-    if [[ $modified == true ]]; then
-      log "Successfully updated $(basename $DOCKERFILE_FOR_BASE_PACKAGES)"
-    fi
-  fi
-}
-
 update_readme_for_base_packages() {
   log "Updating $(basename $README_FOR_BASE_PACKAGES)..."
 
   if [ -f "$README_FOR_BASE_PACKAGES" ]; then
     local modified=false
 
-    # Update all occurrences of --app x.y.z with --app $VERSION
-    # Define the pattern regex
-    local app_pattern_regex="(--app )$VERSION_PATTERN"
+    local pattern_prefixes=("--app " "--base " "--security " "--securityAnalytics " "--reporting " "--alerting " "--notifications " "This example will create a packages folder that inside will have the packages divided by repository of the ")
 
-    # Check if the pattern exists in the file
-    if grep -qE "$app_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
-      log "Pattern '$app_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
-      # If the pattern exists, perform the substitution and set modified to true
-      sed_inplace -E "s/${app_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
-      modified=true
-    else
-      log "Pattern '$app_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
-    fi
-
-    # Update all occurrences of --base x.y.z with --base $VERSION
-    # Define the pattern regex for --base
-    local base_pattern_regex="(--base )$VERSION_PATTERN"
-
-    # Check if the pattern exists in the file
-    if grep -qE "$base_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
-      log "Pattern '$base_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
-      # If the pattern exists, perform the substitution and set modified to true
-      sed_inplace -E "s/${base_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
-      modified=true
-    else
-      log "Pattern '$base_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
-    fi
-
-    # Update all occurrences of --security x.y.z with --security $VERSION
-    # Define the pattern regex for --security
-    local security_pattern_regex="(--security )$VERSION_PATTERN"
-
-    # Check if the pattern exists in the file
-    if grep -qE "$security_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
-      log "Pattern '$security_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
-      # If the pattern exists, perform the substitution and set modified to true
-      sed_inplace -E "s/${security_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
-      modified=true
-    else
-      log "Pattern '$security_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
-    fi
-
-    # Update all occurrences of --security x.y.z with --security $VERSION
-    # Define the pattern regex for the example text
-    local readme_example_pattern_regex="(This example will create a packages folder that inside will have the packages divided by repository of the )$VERSION_PATTERN"
-
-    # Check if the pattern exists in the file
-    if grep -qE "$readme_example_pattern_regex" "$README_FOR_BASE_PACKAGES"; then
-      log "Pattern '$readme_example_pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
-      # If the pattern exists, perform the substitution and set modified to true
-      sed_inplace -E "s/${readme_example_pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
-      modified=true
-    else
-      log "Pattern '$readme_example_pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
-    fi
+    for prefix in "${pattern_prefixes[@]}"; do
+      local pattern_regex="(${prefix})$VERSION_PATTERN"
+      if grep -qE "$pattern_regex" "$README_FOR_BASE_PACKAGES"; then
+        log "Pattern '$pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
+        sed_inplace -E "s/${pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
+        modified=true
+      else
+        log "Pattern '$pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
+      fi
+    done
 
     if [[ $modified == true ]]; then
       log "Successfully updated $(basename $README_FOR_BASE_PACKAGES)"
@@ -797,9 +728,14 @@ main() {
   if [[ "$SKIP_URLS" != "yes" ]]; then
     update_branch_reference_defaults
   fi
+  update_readme_for_base_packages
+  update_rendering_service_test_snap
   update_rpm_changelog
   update_deb_changelog
   update_changelog
+  update_healthcheck_server_not_ready_troubleshooting_link
+  update_build_docker_dev_multiarch
+  update_build_docker_dev_multiarch_readme
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -426,7 +426,7 @@ update_readme_for_base_packages() {
     local pattern_prefixes=("--app " "--base " "--security " "--securityAnalytics " "--reporting " "--alerting " "--notifications " "This example will create a packages folder that inside will have the packages divided by repository of the ")
 
     for prefix in "${pattern_prefixes[@]}"; do
-      local pattern_regex="(${prefix})$VERSION_PATTERN"
+      local pattern_regex="(${prefix})($VERSION_PATTERN|main)"
       if grep -qE "$pattern_regex" "$README_FOR_BASE_PACKAGES"; then
         log "Pattern '$pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
         sed_inplace -E "s/${pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -19,7 +19,6 @@ CURRENT_VERSION=""
 TAG=false
 SET_AS_MAIN=false
 SKIP_URLS="no"
-WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/4_builderpackage_dashboard.yml"
 DOCKERFILE_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/base-packages.Dockerfile"
 README_FOR_BASE_PACKAGES="${REPO_PATH}/dev-tools/build-packages/base-packages-to-base/README.md"
 VERSION_PATTERN="[0-9]+\.[0-9]+\.[0-9]+"
@@ -418,50 +417,6 @@ update_changelog() {
   fi
 }
 
-update_build_workflow() {
-  log "Updating $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE)..."
-
-  if [ -f "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE" ]; then
-    local modified=false
-
-    if [ "$TAG" = true ]; then
-      replacement="v${VERSION}"
-      if [ -n "$STAGE" ]; then
-        replacement+="-${STAGE}"
-      fi
-    else
-      replacement="${VERSION}"
-    fi
-
-    if grep -qE '\.yml@[^"[:space:]]+' "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
-      log "Pattern found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Attempting update..."
-      if [[ "$SKIP_URLS" == "yes" ]]; then
-        # set-as-main mode: only update versioned .yml@x.y.z refs, preserve .yml@main
-        sed_inplace -E "s|(\.yml@)${VERSION_PATTERN}|\1${replacement}|g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
-      else
-        # Normal mode: update all .yml@<ref> (versioned and main)
-        sed_inplace -E "s/(\.yml@)[^\"[:space:]]+/\1${replacement}/g" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
-      fi
-      modified=true
-    else
-      log "Pattern not found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Skipping update."
-    fi
-
-    # Update default: 'main' branch input defaults only when not in set-as-main mode
-    if [[ "$SKIP_URLS" != "yes" ]]; then
-      if grep -qE "^[[:space:]]*default: 'main'" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"; then
-        log "Branch input defaults found in $(basename $WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE). Attempting update..."
-        sed_inplace -E "s/^([[:space:]]*default: )'main'([[:space:]]*)$/\1'${VERSION}'\2/" "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE"
-        modified=true
-      fi
-    fi
-
-    if [[ $modified == true ]]; then
-      log "Successfully updated references in $(basename "$WAZUH_DASHBOARD_PLUGINS_WORKFLOW_FILE")"
-    fi
-  fi
-}
-
 update_base_package_dockerfile() {
   log "Updating $(basename $DOCKERFILE_FOR_BASE_PACKAGES)..."
 
@@ -839,19 +794,12 @@ main() {
 
   update_root_version_json
   update_package_json
-  update_build_workflow
   if [[ "$SKIP_URLS" != "yes" ]]; then
     update_branch_reference_defaults
   fi
-  update_base_package_dockerfile
-  update_readme_for_base_packages
-  update_rendering_service_test_snap
   update_rpm_changelog
   update_deb_changelog
   update_changelog
-  update_healthcheck_server_not_ready_troubleshooting_link
-  update_build_docker_dev_multiarch
-  update_build_docker_dev_multiarch_readme
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"


### PR DESCRIPTION
### Description
Automates the final stage-bump revert flow in both bumper workflows by adding a revert mode that selectively reverts bump reference changes while preserving core version files (e.g. VERSION.json, CHANGELOG.md), and skips PR creation when no effective revert changes remain.

### Issues Resolved
- **Closes**: https://github.com/wazuh/wazuh-dashboard/issues/1202

### Evidence

1. Trigger the workflow on a branch with `revert=false` normal bump script runs, references, and version values updated → PR created correctly: https://github.com/Ripdiegozz/wazuh-dashboard/actions/runs/25010590576

2. Merge the previous PR and trigger the workflow on the same branch with `revert=true` and `issue-link` pointing to the previous execution's issue, script bypassed, `gh` cli finds the PR, git reverts the commit, core version files are preserved → new Revert PR created: https://github.com/Ripdiegozz/wazuh-dashboard/actions/runs/25010732264

3. Verify that triggering `revert=true` when only `VERSION.json` was updated in the original bump results in a clean exit (no empty PR created):
    - Bumper only changes `VERSION.json`: https://github.com/Ripdiegozz/wazuh-dashboard/actions/runs/25011792523
    - `revert=true` results in a clean exit: https://github.com/Ripdiegozz/wazuh-dashboard/actions/runs/25012934914

### Check List
- [X] Commits are signed per the DCO using --signoff