### PR TITLE
Updates GitHub runner from ubuntu-24.04 to ubuntu-26.04

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -92,7 +92,7 @@ permissions:
 
 jobs:
   setup-variables:
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
     name: Setup variables
     outputs:
       CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
@@ -204,7 +204,7 @@ jobs:
           echo "ARCHITECTURE_FLAG=$ARCHITECTURE_FLAG" >> $GITHUB_OUTPUT
 
   validate-job:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: setup-variables
     name: Validate inputs
     steps:
@@ -336,7 +336,7 @@ jobs:
 
   test-package:
     needs: [setup-variables, build-package]
-    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
     strategy:
       fail-fast: false
     name: Test package
@@ -525,7 +525,7 @@ jobs:
 
   upload-package:
     needs: [setup-variables, test-package]
-    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
     name: Upload package
     steps:
       - name: Set up AWS CLI


### PR DESCRIPTION
### Description

This PR updates the Ubuntu version used into GHA workflows to latest LTS version, 26.04

### Issues Resolved

- https://github.com/wazuh/wazuh/issues/35755