### PR TITLE
Add GIT_REF to Build plugin job

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard_plugins.yml
+++ b/.github/workflows/5_builderpackage_dashboard_plugins.yml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Build Plugin
         working-directory: plugins/${{ inputs.name }}
+        env:
+          GIT_REF: ${{ env.PLUGIN_REF }}
         run: |
           set -o pipefail
           OPENSEARCH_DASHBOARDS_VERSION=${{ inputs.version_opensearch }} yarn build 2>&1 | tee build.log


### PR DESCRIPTION
### Description

This pull request add the GIT_REF to Build plugin job.

Related change:
- https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/244

### Issues Resolved
#1266 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
