### PR TITLE
Add spacer between the Health check search bar and the table

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,16 +29,6 @@
  */
 
 /**
- * For new files created by Wazuh Contributors
- */
-const OSD_WAZUH = `
-/*
- * Copyright Wazuh
- * SPDX-License-Identifier: Apache-2.0
- */
-`;
-
-/**
  * For new files created by OpenSearch Contributors
  */
 const OSD_NEW_HEADER = `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added manager host configuration for the default configuration file [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
 - Set v9 theme as default [#1092](https://github.com/wazuh/wazuh-dashboard/pull/1092)
 
+### Fixed
+
+- Fixed health check padding styles [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276)
+
 ### Removed
 
 - Removed creation of /usr/lib/.build-id/\* links to prevent conflicts when installing Wazuh Dashboard alongside OpenSearch Dashboards on the same system

--- a/src/plugins/healthcheck/public/components/table/checks_table.tsx
+++ b/src/plugins/healthcheck/public/components/table/checks_table.tsx
@@ -12,7 +12,7 @@ import {
   EuiSwitch,
   EuiSwitchEvent,
   EuiToolTip,
-  EuiSpacer
+  EuiSpacer,
 } from '@elastic/eui';
 import { isEqual } from 'lodash';
 import { TaskInfo } from '../../../../../core/common/healthcheck';

--- a/src/plugins/healthcheck/public/components/table/checks_table.tsx
+++ b/src/plugins/healthcheck/public/components/table/checks_table.tsx
@@ -12,6 +12,7 @@ import {
   EuiSwitch,
   EuiSwitchEvent,
   EuiToolTip,
+  EuiSpacer
 } from '@elastic/eui';
 import { isEqual } from 'lodash';
 import { TaskInfo } from '../../../../../core/common/healthcheck';
@@ -133,6 +134,7 @@ export const ChecksTable: FunctionComponent<ChecksTableProps> = ({ checks }) => 
           </EuiToolTip>
         }
       />
+      <EuiSpacer size="s" />
       <EuiBasicTable
         columns={tableColumns(openFlyout)}
         items={filteredChecks}


### PR DESCRIPTION
### Description

Add a spacer between the Health check search bar and the table, because there's almost no separation between them.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/1277#top

## Screenshot

<img width="1790" height="538" alt="Screenshot 2026-05-15 at 12 01 37 PM" src="https://github.com/user-attachments/assets/a7c244d7-b500-4961-95c1-af580d552b68" />

## Testing the changes

- Go to Dashboard management > Health Check, and verify the spacer is applied

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
