### PR TITLE
Hide wazuh dashboards and visualizations listing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,16 +49,6 @@ const OSD_NEW_HEADER = `
 `;
 
 /**
- * For new files created by Wazuh Contributors
- */
-const OSD_WAZUH = `
-/*
- * Copyright Wazuh
- * SPDX-License-Identifier: Apache-2.0
- */
-`;
-
-/**
  * For modified and modified files with external open source code
  */
 const OSD_HEADER = `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed the location of the wazuh-dashboard service to match with the other Wazuh components [#805](https://github.com/wazuh/wazuh-dashboard/issues/805)
 - Changed the default value of `metaFields` and `timepicker:timeDefaults` settings [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
+- Excluded Wazuh dashboards and visualizations listing [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278)
 
 ## Wazuh dashboard v4.14.6 - OpenSearch Dashboards 2.19.5 - Revision 00
 

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
@@ -136,6 +136,7 @@ export const DashboardListing = () => {
       search: search ? `${search}*` : undefined,
       fields: ['title', 'type', 'description', 'updated_at'],
       perPage: listingLimit,
+      filter: 'not dashboard.attributes.description:"*Provided by Wazuh*"', // Wazuh - added filter to exclude dashboards with description containing "Provided by Wazuh"
       page: 1,
       searchFields: ['title^3', 'type', 'description'],
       defaultSearchOperator: 'AND',

--- a/src/plugins/visualizations/public/saved_visualizations/find_list_items.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/find_list_items.ts
@@ -43,7 +43,7 @@ export async function findListItems({
   size,
   savedObjectsClient,
   mapSavedObjectApiHits,
-  filter='', // Wazuh - added filter parameter to findListItems function
+  filter = '', // Wazuh - added filter parameter to findListItems function
 }: {
   search: string;
   size: number;

--- a/src/plugins/visualizations/public/saved_visualizations/find_list_items.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/find_list_items.ts
@@ -43,12 +43,14 @@ export async function findListItems({
   size,
   savedObjectsClient,
   mapSavedObjectApiHits,
+  filter='', // Wazuh - added filter parameter to findListItems function
 }: {
   search: string;
   size: number;
   visTypes: VisTypeAlias[];
   savedObjectsClient: SavedObjectsClientContract;
   mapSavedObjectApiHits: SavedObjectLoader['mapSavedObjectApiHits'];
+  filter?: string; // Wazuh - added filter parameter to findListItems function
 }) {
   const extensions = visTypes
     .map((v) => v.appExtensions?.visualizations)
@@ -65,6 +67,7 @@ export async function findListItems({
     type: searchOption('docTypes', 'visualization'),
     searchFields: searchOption('searchFields', 'title^3', 'description'),
     search: search ? `${search}*` : undefined,
+    filter, // Wazuh - pass filter parameter to savedObjectsClient.find
     perPage: size,
     page: 1,
     defaultSearchOperator: 'AND' as 'AND',

--- a/src/plugins/visualizations/public/saved_visualizations/saved_visualizations.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/saved_visualizations.ts
@@ -87,6 +87,7 @@ export function createSavedVisLoader(
         mapSavedObjectApiHits: this.mapSavedObjectApiHits.bind(this),
         savedObjectsClient,
         visTypes: visualizationTypes.getAliases(),
+        filter: 'not visualization.attributes.description:"*Provided by Wazuh*"', // Wazuh - added filter to exclude visualizations with description containing "Provided by Wazuh"
       });
     }
   }


### PR DESCRIPTION
### Description

This pull request adds a filter in the dashboards and visualize plugins to exclude saved objects provided by Wazuh in the tables.

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8473

## Screenshot

### Visualize

<img width="2751" height="1363" alt="image" src="https://github.com/user-attachments/assets/946b5c0c-39ba-485b-ab70-48f5b89faa6a" />

### Dashboards

<img width="2751" height="1363" alt="image" src="https://github.com/user-attachments/assets/7e911841-8619-4254-9113-86adb12d109f" />

## Testing the changes
- Check that no dashboard or visualization with "Provided by Wazuh" text in the description is listed
- Check that dashboards are rendered in Wazuh modules

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
