### PR TITLE
Avoid rendering Wazuh saved objects description

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,16 @@
  */
 
 /**
+ * For new files created by Wazuh Contributors
+ */
+const OSD_WAZUH = `
+/*
+ * Copyright Wazuh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+`;
+
+/**
  * For new files created by OpenSearch Contributors
  */
 const OSD_NEW_HEADER = `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed the location of the wazuh-dashboard service to match with the other Wazuh components [#805](https://github.com/wazuh/wazuh-dashboard/issues/805)
 - Changed the default value of `metaFields` and `timepicker:timeDefaults` settings [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
-- Excluded Wazuh dashboards and visualizations listing [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278)
+- Excluded Wazuh dashboards and visualizations listing [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278) [#1279](https://github.com/wazuh/wazuh-dashboard/pull/1279)
 
 ## Wazuh dashboard v4.14.6 - OpenSearch Dashboards 2.19.5 - Revision 00
 

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -119,7 +119,7 @@ function getViewDescription(embeddable: IEmbeddable | EmbeddableWithDescription)
   if ('getDescription' in embeddable) {
     const description = embeddable.getDescription();
 
-    if (description) {
+    if (description && !description.includes('Provided by Wazuh.')) {
       return description;
     }
   }

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -119,6 +119,7 @@ function getViewDescription(embeddable: IEmbeddable | EmbeddableWithDescription)
   if ('getDescription' in embeddable) {
     const description = embeddable.getDescription();
 
+    // Wazuh - added check to exclude descriptions containing "Provided by Wazuh" in visualization card titles
     if (description && !description.includes('Provided by Wazuh.')) {
       return description;
     }


### PR DESCRIPTION
### Description

This pull request avoids rendering Wazuh custom description in visualization card titles.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8473

## Screenshot

<img width="2274" height="1576" alt="image" src="https://github.com/user-attachments/assets/81b0e6f7-916f-453a-b8d9-4cda8edf1054" />


## Testing the changes

- Render Threat hunting dashboard and check that there are no tooltips in the card titles.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
