### PR TITLE
 Refactor Allocator instance/composite names and add custom AWS tagging for better resource management

### DIFF
--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -451,10 +451,14 @@ jobs:
         if: ${{ inputs.system == 'rpm' }}
         run: |
           if [ "${{ inputs.architecture }}" = "x86_64" ]; then
-            python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name centos_stream-9-amd64 --instance-name "centos_9_amd_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard
+            INSTANCE_NAME="centos_9_amd_large_aws"
+            COMPOSITE_NAME="centos_stream-9-amd64"
           else
-            python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name centos_stream-8-arm64 --instance-name "centos_8_arm_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard
+            INSTANCE_NAME="centos_8_arm_large_aws"
+            COMPOSITE_NAME="centos_stream-8-arm64"
           fi
+          CUSTOM_TAGS="Name:${INSTANCE_NAME},Team:dashboard,Organization:xdrsiem,CreatedBy:github-actions,FixedResource:false,Sensitive:false,Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
+          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard --custom-tags "${CUSTOM_TAGS}"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -457,8 +457,7 @@ jobs:
             INSTANCE_NAME="centos_8_arm_large_aws"
             COMPOSITE_NAME="centos_stream-8-arm64"
           fi
-          CUSTOM_TAGS="Name:${INSTANCE_NAME},Team:dashboard,Organization:xdrsiem,CreatedBy:github-actions,FixedResource:false,Sensitive:false,Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard --custom-tags "${CUSTOM_TAGS}"
+          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -579,10 +579,14 @@ jobs:
         if: ${{ inputs.system == 'rpm' }}
         run: |
           if [ "${{ inputs.architecture }}" = "x86_64" ]; then
-            python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name centos_stream-9-amd64 --instance-name "centos_9_amd_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard
+            INSTANCE_NAME="centos_9_amd_large_aws"
+            COMPOSITE_NAME="centos_stream-9-amd64"
           else
-            python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name centos_stream-8-arm64 --instance-name "centos_8_arm_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard
+            INSTANCE_NAME="centos_8_arm_large_aws"
+            COMPOSITE_NAME="centos_stream-8-arm64"
           fi
+          CUSTOM_TAGS="Name:${INSTANCE_NAME},Team:dashboard,Organization:xdrsiem,CreatedBy:github-actions,FixedResource:false,Sensitive:false,Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
+          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard --custom-tags "${CUSTOM_TAGS}"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -585,8 +585,7 @@ jobs:
             INSTANCE_NAME="centos_8_arm_large_aws"
             COMPOSITE_NAME="centos_stream-8-arm64"
           fi
-          CUSTOM_TAGS="Name:${INSTANCE_NAME},Team:dashboard,Organization:xdrsiem,CreatedBy:github-actions,FixedResource:false,Sensitive:false,Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard --custom-tags "${CUSTOM_TAGS}"
+          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -434,10 +434,14 @@ jobs:
         if: ${{ inputs.system == 'rpm' }}
         run: |
           if [ "${{ inputs.architecture }}" = "x86_64" ]; then
-            python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name centos_stream-9-amd64 --instance-name "centos_9_amd_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard
+            INSTANCE_NAME="centos_9_amd_large_aws"
+            COMPOSITE_NAME="centos_stream-9-amd64"
           else
-            python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name centos_stream-8-arm64 --instance-name "centos_8_arm_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard
+            INSTANCE_NAME="centos_8_arm_large_aws"
+            COMPOSITE_NAME="centos_stream-8-arm64"
           fi
+          CUSTOM_TAGS="Name:${INSTANCE_NAME},Team:dashboard,Organization:xdrsiem,CreatedBy:github-actions,FixedResource:false,Sensitive:false,Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
+          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard --custom-tags "${CUSTOM_TAGS}"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -440,8 +440,7 @@ jobs:
             INSTANCE_NAME="centos_8_arm_large_aws"
             COMPOSITE_NAME="centos_stream-8-arm64"
           fi
-          CUSTOM_TAGS="Name:${INSTANCE_NAME},Team:dashboard,Organization:xdrsiem,CreatedBy:github-actions,FixedResource:false,Sensitive:false,Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --working-dir /tmp/dashboard --custom-tags "${CUSTOM_TAGS}"
+          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')


### PR DESCRIPTION
### Description

Allocator EC2 provisioning in dashboard package-builder workflows now sets **mandatory AWS tags at creation time** via `--custom-tags`, aligned with the XDR SIEM tagging standard. Shell logic selects `INSTANCE_NAME` / `COMPOSITE_NAME` by architecture once, builds a comma-separated tag string (including optional `ExecutionId`, `Stage`, `Product`, `Purpose`), and passes it to `wazuh-automation` allocation `main.py`.
**Affected workflows:** `4_builderpackage_dashboard.yml`, `5_builderpackage_dashboard.yml`, `build_wazuh_dashboard_with_plugins.yml` (RPM smoke-test path only).

## Testing the changes

1. Merge when `wazuh-automation` on the cloned branch supports `--custom-tags`.
2. Run a workflow with **`system: rpm`** (AMD and optionally ARM).
3. In AWS Console (or CLI), confirm theAllocator-created instance has tags including:  
   **Name**, **Team**, **Organization**, **CreatedBy**, **FixedResource**, **Sensitive**, plus intended optionals (**Product**, **Purpose**, **ExecutionId**, **Stage**).



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff