### PR TITLE
Remove configuration files from installation directory

### DIFF
--- a/dev-tools/build-packages/deb/deb-builder.sh
+++ b/dev-tools/build-packages/deb/deb-builder.sh
@@ -60,7 +60,8 @@ log "Extracting base tar.gz..."
 tar -zxf "${out_dir}/wazuh-dashboard-$version-$revision-linux-$architecture.tar.gz"
 log "Preparing the package..."
 jq '.wazuh.revision="'${revision}'"' package.json > pkgtmp.json && mv pkgtmp.json package.json
-cp "${config_path}"/* .
+mkdir -p etc/services
+cp "${config_path}"/* etc/services
 jq '.version="'${version}'"' VERSION.json > VERSION.tmp && mv VERSION.tmp VERSION.json
 jq '.commit="'${commit_sha}'"' VERSION.json > VERSION.tmp && mv VERSION.tmp VERSION.json
 cd "${tmp_dir}"

--- a/dev-tools/build-packages/deb/debian/rules
+++ b/dev-tools/build-packages/deb/debian/rules
@@ -73,9 +73,8 @@ override_dh_install:
 
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/config
 
-	cp $(TARGET_DIR)$(INSTALLATION_DIR)/wazuh-dashboard.service $(TARGET_DIR)/usr/lib/systemd/system/wazuh-dashboard.service
-	cp $(TARGET_DIR)$(INSTALLATION_DIR)/wazuh-dashboard $(TARGET_DIR)/usr/lib/systemd/system/$(NAME)
-	cp $(TARGET_DIR)$(INSTALLATION_DIR)/default $(TARGET_DIR)/etc/default/$(NAME)
+	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard* $(TARGET_DIR)/usr/lib/systemd/system/
+	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/default $(TARGET_DIR)/etc/default/$(NAME)
 
 	rm -rf $(TARGET_DIR)$(INSTALLATION_DIR)/etc
 

--- a/dev-tools/build-packages/deb/debian/rules
+++ b/dev-tools/build-packages/deb/debian/rules
@@ -73,7 +73,8 @@ override_dh_install:
 
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/config
 
-	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard* $(TARGET_DIR)/usr/lib/systemd/system/
+	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard.service $(TARGET_DIR)/usr/lib/systemd/system/wazuh-dashboard.service
+  cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard $(TARGET_DIR)/usr/lib/systemd/system/$(NAME)
 	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/default $(TARGET_DIR)/etc/default/$(NAME)
 
 	rm -rf $(TARGET_DIR)$(INSTALLATION_DIR)/etc

--- a/dev-tools/build-packages/deb/debian/rules
+++ b/dev-tools/build-packages/deb/debian/rules
@@ -74,7 +74,7 @@ override_dh_install:
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/config
 
 	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard.service $(TARGET_DIR)/usr/lib/systemd/system/wazuh-dashboard.service
-  cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard $(TARGET_DIR)/usr/lib/systemd/system/$(NAME)
+	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/wazuh-dashboard $(TARGET_DIR)/usr/lib/systemd/system/$(NAME)
 	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/services/default $(TARGET_DIR)/etc/default/$(NAME)
 
 	rm -rf $(TARGET_DIR)$(INSTALLATION_DIR)/etc

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -256,6 +256,7 @@ rm -fr %{buildroot}
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/src/legacy/ui/ui_render/bootstrap"
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/src/legacy/ui/apm"
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/src/docs"
+%dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/src/translations"
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/node_modules"
 %attr(-, %{USER}, %{GROUP}) "%{INSTALL_DIR}/node_modules/*"
 %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/node_modules/.yarn-integrity"


### PR DESCRIPTION
### Description

This pull request removes the configuration files from the installation directory on .deb packages.

Side changes:
- Define permission for `src/translations` directory on .rpm packages

### Issues Resolved

#1288



## Testing the changes

[Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26175273041)
[Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26175274798)
[Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26175269174)
[Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26175271356)

- [ ] [deb] Verify that the configuration files are not present in the /usr/share/wazuh-dashboard folder
- [ ] [rpm] Verify that the “translations” folder has the “wazuh-dashboard” user and group

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
