### PR TITLE
Fix git references in bumping process

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard_core.yml
+++ b/.github/workflows/5_builderpackage_dashboard_core.yml
@@ -16,7 +16,7 @@ on:
       CHECKOUT_TO: # This is the branch to checkout to. Defaults to 'main'
         description: 'The branch/tag/commit to checkout to'
         required: true
-        default: '5.0.0'
+        default: 'v5.0.0-beta2'
         type: string
       ARCHITECTURE:
         description: 'The architecture to build the package for'
@@ -29,7 +29,7 @@ on:
       CHECKOUT_TO: # This is the branch to checkout to. Defaults to 'main'
         description: 'The branch/tag/commit to checkout to'
         required: true
-        default: '5.0.0'
+        default: 'v5.0.0-beta2'
       ARCHITECTURE:
         description: 'The architecture to build the package for'
         required: true

--- a/.github/workflows/5_builderpackage_dev_docker_image.yml
+++ b/.github/workflows/5_builderpackage_dev_docker_image.yml
@@ -18,7 +18,7 @@ on:
       branch:
         description: 'Branch to use for all Wazuh dashboard components'
         required: false
-        default: '5.0.0'
+        default: 'v5.0.0-beta2'
         type: string
       tag:
         description: 'Tag for the Docker image'

--- a/dev-tools/build-packages/base-packages-to-base/README.md
+++ b/dev-tools/build-packages/base-packages-to-base/README.md
@@ -29,15 +29,15 @@ Example:
 
 ```bash
 bash run-docker-compose.sh \
-    --app 5.0.0 \
-    --base 5.0.0 \
-    --security 5.0.0 \
-    --securityAnalytics 5.0.0 \
-    --reporting 5.0.0 \
-    --alerting 5.0.0 \
-    --notifications 5.0.0 \
+    --app v5.0.0-beta2 \
+    --base v5.0.0-beta2 \
+    --security v5.0.0-beta2 \
+    --securityAnalytics v5.0.0-beta2 \
+    --reporting v5.0.0-beta2 \
+    --alerting v5.0.0-beta2 \
+    --notifications v5.0.0-beta2 \
     --arm \
     --node-version 22.22.0
 ```
 
-This example will create a packages folder that inside will have the packages divided by repository of the 5.0.0 branch of each one.
+This example will create a packages folder that inside will have the packages divided by repository of the v5.0.0-beta2 git reference of each one.


### PR DESCRIPTION
### Description

This pull request fixes the git reference in the bumping process pointing to the tag.

### Issues Resolved

#1295

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] Commits are signed per the DCO using --signoff
