### PR TITLE
Fix tag references on bump when --tag is provided

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -429,7 +429,7 @@ update_readme_for_base_packages() {
       local pattern_regex="(${prefix})($VERSION_PATTERN|main)"
       if grep -qE "$pattern_regex" "$README_FOR_BASE_PACKAGES"; then
         log "Pattern '$pattern_regex' found in $(basename $README_FOR_BASE_PACKAGES). Attempting update..."
-        sed_inplace -E "s/${pattern_regex}/\1${VERSION}/g" "$README_FOR_BASE_PACKAGES"
+        sed_inplace -E "s/${pattern_regex}/\1${GIT_REF_REPLACEMENT}/g" "$README_FOR_BASE_PACKAGES"
         modified=true
       else
         log "Pattern '$pattern_regex' not found in $(basename $README_FOR_BASE_PACKAGES). Skipping update for this pattern."
@@ -674,12 +674,26 @@ update_branch_reference_defaults() {
   for f in "${branch_files[@]}"; do
     if [ -f "$f" ]; then
       log "Updating branch input defaults in $(basename $f)..."
-      sed_inplace -E "s/^([[:space:]]*default: )'main'([[:space:]]*)$/\1'${VERSION}'\2/" "$f"
+      sed_inplace -E "s/^([[:space:]]*default: )'main'([[:space:]]*)$/\1'${GIT_REF_REPLACEMENT}'\2/" "$f"
       log "Successfully updated branch input defaults in $(basename $f)."
     else
       log "WARNING: $(basename $f) not found. Skipping branch defaults update."
     fi
   done
+}
+
+get_git_ref_replacement(){
+  local replacement
+  if [ "$TAG" = true ]; then
+    replacement="v${VERSION}"
+    if [ -n "$STAGE" ]; then
+      replacement+="-${STAGE}"
+    fi
+  else
+    replacement="${VERSION}"
+  fi
+
+  GIT_REF_REPLACEMENT="$replacement"
 }
 
 # --- Main Execution ---
@@ -719,6 +733,8 @@ main() {
   fi
 
   compare_versions_and_set_revision
+
+  get_git_ref_replacement
 
   # Start file modifications
   log "Starting file modifications..."


### PR DESCRIPTION
### Description

This pull request fixes the git references in some files on bump when --tag is provided.

### Issues Resolved

#1295

### Test

1. Run
```
./repository_bumper.sh --tag --stage beta3
```
2. Check the references to main should be changed to the tag reference

Run:
```
git --no-pager diff
```

Output:
```diff
diff --git a/.github/workflows/5_builderpackage_dashboard_core.yml b/.github/workflows/5_builderpackage_dashboard_core.yml
index 8ef8f80ed1..774e01dfa3 100644
--- a/.github/workflows/5_builderpackage_dashboard_core.yml
+++ b/.github/workflows/5_builderpackage_dashboard_core.yml
@@ -16,7 +16,7 @@ on:
       CHECKOUT_TO: # This is the branch to checkout to. Defaults to 'main'
         description: 'The branch/tag/commit to checkout to'
         required: true
-        default: 'main'
+        default: 'v5.0.0-beta3'
         type: string
       ARCHITECTURE:
         description: 'The architecture to build the package for'
@@ -29,7 +29,7 @@ on:
       CHECKOUT_TO: # This is the branch to checkout to. Defaults to 'main'
         description: 'The branch/tag/commit to checkout to'
         required: true
-        default: 'main'
+        default: 'v5.0.0-beta3'
       ARCHITECTURE:
         description: 'The architecture to build the package for'
         required: true
diff --git a/.github/workflows/5_builderpackage_dev_docker_image.yml b/.github/workflows/5_builderpackage_dev_docker_image.yml
index 1b3aa286d4..1f470eacf7 100644
--- a/.github/workflows/5_builderpackage_dev_docker_image.yml
+++ b/.github/workflows/5_builderpackage_dev_docker_image.yml
@@ -18,7 +18,7 @@ on:
       branch:
         description: 'Branch to use for all Wazuh dashboard components'
         required: false
-        default: 'main'
+        default: 'v5.0.0-beta3'
         type: string
       tag:
         description: 'Tag for the Docker image'
diff --git a/CHANGELOG.md b/CHANGELOG.md
index fbdc3b71a1..52c8e1bba2 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 02
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 0533024ce6..a57868ae74 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta2"
+  "stage": "beta3"
 }
diff --git a/dev-tools/build-packages/base-packages-to-base/README.md b/dev-tools/build-packages/base-packages-to-base/README.md
index 20e49c197b..368bd6b281 100644
--- a/dev-tools/build-packages/base-packages-to-base/README.md
+++ b/dev-tools/build-packages/base-packages-to-base/README.md
@@ -29,15 +29,15 @@ Example:
 
 ```bash
 bash run-docker-compose.sh \
-    --app main \
-    --base main \
-    --security main \
-    --securityAnalytics main \
-    --reporting main \
-    --alerting main \
-    --notifications main \
+    --app v5.0.0-beta3 \
+    --base v5.0.0-beta3 \
+    --security v5.0.0-beta3 \
+    --securityAnalytics v5.0.0-beta3 \
+    --reporting v5.0.0-beta3 \
+    --alerting v5.0.0-beta3 \
+    --notifications v5.0.0-beta3 \
     --arm \
     --node-version 22.22.0
 ```
 
-This example will create a packages folder that inside will have the packages divided by repository of the main git reference of each one.
+This example will create a packages folder that inside will have the packages divided by repository of the v5.0.0-beta3 git reference of each one.
diff --git a/package.json b/package.json
index fd00f6a642..2f9e53ff8c 100644
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "02"
+    "revision": "03"
   },
   "homepage": "https://opensearch.org",
   "bugs": {
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
