### PR TITLE
Adds changelog entries for versions 4.10.2–4.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,34 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fix redirection on IDP initiated SAML configurations [#171](https://github.com/wazuh/wazuh-security-dashboards-plugin/pull/171)
 
+## Wazuh dashboard v4.10.5 - OpenSearch Dashboards 2.19.5 - Revision 00
+
+### Added
+
+- Support for Wazuh 4.10.5
+
+## Wazuh dashboard v4.10.4 - OpenSearch Dashboards 2.19.5 - Revision 01
+
+### Added
+
+- Support for Wazuh 4.10.4
+
+## Wazuh dashboard v4.10.3 - OpenSearch Dashboards 2.16.0 - Revision 01
+
+### Added
+
+- Support for Wazuh 4.10.3
+
+### Changed
+
+- Added `noreplace` directive to `/etc/default/wazuh-dashboard` for RPM packages to prevent overwriting user-modified configurations during package upgrades. [#668](https://github.com/wazuh/wazuh-dashboard/pull/668)
+
+## Wazuh dashboard v4.10.2 - OpenSearch Dashboards 2.16.0 - Revision 01
+
+### Added
+
+- Support for Wazuh 4.10.2
+
 ## Wazuh dashboard v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 01
 
 ### Added

--- a/dev-tools/build-packages/deb/debian/changelog
+++ b/dev-tools/build-packages/deb/debian/changelog
@@ -4,6 +4,18 @@ wazuh-dashboard (4.14.6-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 14 May 2026 12:00:00 +0000
 
+wazuh-dashboard (4.10.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 03 Sep 2026 12:00:00 +0000
+
+wazuh-dashboard (4.10.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 12:00:00 +0000
+
 wazuh-dashboard (4.14.5-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-14-5.html
@@ -45,6 +57,12 @@ wazuh-dashboard (4.13.0-RELEASE) stable; urgency=low
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-13-0.html
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 18 Sep 2025 12:00:00 +0000
+
+wazuh-dashboard (4.10.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Fri, 22 Aug 2025 12:00:00 +0000
 
 wazuh-dashboard (4.10.2-RELEASE) stable; urgency=low
 

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -411,6 +411,10 @@ rm -fr %{buildroot}
 %attr(644, root, root) "/etc/systemd/system/wazuh-dashboard.service"
 
 %changelog
+* Thu Sep 03 2026 support <info@wazuh.com> - 4.10.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.4
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
 * Thu May 14 2026 support <info@wazuh.com> - 4.14.6
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-6.html
 * Thu Apr 23 2026 support <info@wazuh.com> - 4.14.5
@@ -429,6 +433,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-13-1.html
 * Thu Sep 18 2025 support <info@wazuh.com> - 4.13.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-13-0.html
+* Fri Aug 22 2025 support <info@wazuh.com> - 4.10.3
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
 * Wed May 21 2025 support <info@wazuh.com> - 4.10.2
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
 * Wed May 07 2025 support <info@wazuh.com> - 4.12.0


### PR DESCRIPTION
### Description

Adding the entries for versions 4.10.3, 4.10.4, and 4.10.5 to the changelog

### Issues Resolved

- #1308 

### Workflows

- [Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26529526334)
- [Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26529523970)
- [Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26529521302)
- [Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/26529518994)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
