### PR TITLE
Prevent 4.x upgrade to 5.0

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -281,6 +281,14 @@ jobs:
           if [ -z "$PREVIOUS" ]; then
             echo "::warning No previous version::No previous version found for this architecture. Upgrade test will be skipped."
           fi
+          # If the previous version is from a different major (e.g. 4.x when building 5.x),
+          # skip the upgrade test — the pre-install guard blocks cross-major upgrades.
+          VERSION_MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          PREVIOUS_MAJOR=$(echo "$PREVIOUS" | cut -d. -f1)
+          if [ -n "$PREVIOUS" ] && [ "$VERSION_MAJOR" != "$PREVIOUS_MAJOR" ]; then
+            echo "Previous version $PREVIOUS major ($PREVIOUS_MAJOR) differs from current major ($VERSION_MAJOR). Upgrade test will be skipped."
+            PREVIOUS=""
+          fi
           if [ "${{ inputs.is_stage }}" = "true" ]; then
             PRODUCTION=--production
           else

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -509,6 +509,18 @@ jobs:
           bash ./test-packages.sh --block-4x-install \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
+      - name: Test package negative (5.x install blocked when 3.x Kibana present)
+        run: |
+          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
+          bash ./test-packages.sh --block-3x-install \
+            -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
+
+      - name: Test package negative (5.x install blocked when remnants exist but version unknown)
+        run: |
+          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
+          bash ./test-packages.sh --block-unknown-install \
+            -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
+
       - name: Test package reinstall (5.x install over 5.x succeeds)
         run: |
           cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -606,7 +606,7 @@ jobs:
             exit 1
           fi
 
-          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard"; then
+          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh dashboard"; then
             echo "Cross-major upgrade correctly blocked"
           else
             echo "ERROR: Expected block message not found"
@@ -750,7 +750,7 @@ jobs:
             exit 1
           fi
 
-          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard"; then
+          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh dashboard"; then
             echo "Cross-major upgrade correctly blocked"
           else
             echo "ERROR: Expected block message not found"

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -509,12 +509,6 @@ jobs:
           bash ./test-packages.sh --block-4x-install \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
-      - name: Test package negative (5.x install blocked when 3.x Kibana present)
-        run: |
-          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
-          bash ./test-packages.sh --block-3x-install \
-            -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
-
       - name: Test package negative (5.x install blocked when remnants exist but version unknown)
         run: |
           cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -281,14 +281,6 @@ jobs:
           if [ -z "$PREVIOUS" ]; then
             echo "::warning No previous version::No previous version found for this architecture. Upgrade test will be skipped."
           fi
-          # If the previous version is from a different major (e.g. 4.x when building 5.x),
-          # skip the upgrade test — the pre-install guard blocks cross-major upgrades.
-          VERSION_MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          PREVIOUS_MAJOR=$(echo "$PREVIOUS" | cut -d. -f1)
-          if [ -n "$PREVIOUS" ] && [ "$VERSION_MAJOR" != "$PREVIOUS_MAJOR" ]; then
-            echo "Previous version $PREVIOUS major ($PREVIOUS_MAJOR) differs from current major ($VERSION_MAJOR). Upgrade test will be skipped."
-            PREVIOUS=""
-          fi
           if [ "${{ inputs.is_stage }}" = "true" ]; then
             PRODUCTION=--production
           else
@@ -553,6 +545,13 @@ jobs:
       - name: DEB - Test package upgrade
         if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'deb' }}
         run: |
+          # Skip when previous and current major differ (pre-install guard blocks cross-major upgrades)
+          VERSION_MAJOR=$(echo "${{needs.setup-variables.outputs.VERSION}}" | cut -d. -f1)
+          PREVIOUS_MAJOR=$(echo "${{needs.setup-variables.outputs.PREVIOUS}}" | cut -d. -f1)
+          if [ "$VERSION_MAJOR" != "$PREVIOUS_MAJOR" ]; then
+            echo "Skipping upgrade test — different major ($PREVIOUS_MAJOR -> $VERSION_MAJOR)"
+            exit 0
+          fi
           sudo apt-get install debhelper tar curl libcap2-bin gnupg apt-transport-https #debhelper version 9 or later
           sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
           sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
@@ -575,6 +574,37 @@ jobs:
             echo "Service running"
           else
             echo "Service not running"
+            exit 1
+          fi
+
+      - name: DEB - Verify cross-major upgrade is blocked
+        if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'deb' }}
+        run: |
+          sudo apt-get install debhelper tar curl libcap2-bin gnupg apt-transport-https
+          sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
+          sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
+          sudo apt-get update || sudo apt-get update
+          sudo apt-get -y install wazuh-dashboard=${{needs.setup-variables.outputs.PREVIOUS}}
+          sudo systemctl daemon-reload
+          sudo systemctl enable wazuh-dashboard
+          sudo systemctl start wazuh-dashboard
+
+          # Attempt 5.x upgrade — MUST fail
+          set +e
+          OUTPUT=$(sudo dpkg -i ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}} 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "ERROR: Installation should have been blocked but succeeded"
+            exit 1
+          fi
+
+          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard"; then
+            echo "Cross-major upgrade correctly blocked"
+          else
+            echo "ERROR: Expected block message not found"
+            echo "$OUTPUT"
             exit 1
           fi
 
@@ -658,6 +688,13 @@ jobs:
       - name: RPM - Test package upgrade
         if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'rpm' }}
         run: |
+          # Skip when previous and current major differ (pre-install guard blocks cross-major upgrades)
+          VERSION_MAJOR=$(echo "${{needs.setup-variables.outputs.VERSION}}" | cut -d. -f1)
+          PREVIOUS_MAJOR=$(echo "${{needs.setup-variables.outputs.PREVIOUS}}" | cut -d. -f1)
+          if [ "$VERSION_MAJOR" != "$PREVIOUS_MAJOR" ]; then
+            echo "Skipping upgrade test — different major ($PREVIOUS_MAJOR -> $VERSION_MAJOR)"
+            exit 0
+          fi
           ${{ steps.setup_rpm_env.outputs.ssh_command }} "sudo yum install libcap; \
             sudo rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH; \
             sudo echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages.wazuh.com/4.x/yum/\nprotect=1' | sudo tee /etc/yum.repos.d/wazuh.repo; \
@@ -680,6 +717,41 @@ jobs:
               exit 1; \
             fi
             "
+      - name: RPM - Verify cross-major upgrade is blocked
+        if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'rpm' }}
+        run: |
+          ${{ steps.setup_rpm_env.outputs.ssh_command }} "sudo yum install libcap; \
+            sudo rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH; \
+            sudo echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages.wazuh.com/4.x/yum/\nprotect=1' | sudo tee /etc/yum.repos.d/wazuh.repo; \
+            sudo yum install -y wazuh-dashboard-${{needs.setup-variables.outputs.PREVIOUS}}; \
+            sudo systemctl daemon-reload; \
+            sudo systemctl enable wazuh-dashboard; \
+            sudo systemctl start wazuh-dashboard; \
+            if sudo systemctl status wazuh-dashboard | grep -q 'active (running)'; then \
+              echo 'Service running'; \
+            else \
+              echo 'ERROR: Service not running'; \
+              exit 1; \
+            fi"
+
+          set +e
+          OUTPUT=$(${{ steps.setup_rpm_env.outputs.ssh_command }} "sudo yum install -y ${{needs.setup-variables.outputs.PACKAGE_NAME}} 2>&1")
+          EXIT_CODE=$?
+          set -e
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "ERROR: Installation should have been blocked but succeeded"
+            exit 1
+          fi
+
+          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard"; then
+            echo "Cross-major upgrade correctly blocked"
+          else
+            echo "ERROR: Expected block message not found"
+            echo "$OUTPUT"
+            exit 1
+          fi
+
       - name: Destroy Allocator Machine
         #DO NOT DELETE. This ensures that the generated instance is destroyed even if the job fails.
         if: ${{ always() }}

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -503,6 +503,18 @@ jobs:
           bash ./test-packages.sh \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
+      - name: Test package negative (5.x install blocked when 4.x present)
+        run: |
+          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
+          bash ./test-packages.sh --block-4x-install \
+            -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
+
+      - name: Test package reinstall (5.x install over 5.x succeeds)
+        run: |
+          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
+          bash ./test-packages.sh --allow-same-major-reinstall \
+            -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
+
       - name: DEB - Test package install/uninstall
         if: ${{ inputs.system == 'deb' }}
         run: |

--- a/dev-tools/build-packages/deb/debian/preinst
+++ b/dev-tools/build-packages/deb/debian/preinst
@@ -9,6 +9,20 @@
 
 set -e
 
+# Version guard: block 5.x installation when a pre-5.x version (4.x or earlier) is already installed
+# NOTE: we check VERSION.json on disk rather than dpkg -s because during
+# dpkg -i the old package data remains on disk until postinst runs.
+if [ -f /usr/share/wazuh-dashboard/VERSION.json ]; then
+    INSTALLED_VER=$(grep '"version"' /usr/share/wazuh-dashboard/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+    if [ -n "$INSTALLED_VER" ]; then
+        MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
+        if [ "$MAJOR" -lt 5 ]; then
+            echo "ERROR: Detected Wazuh Dashboard version $INSTALLED_VER. Installation of Wazuh Dashboard 5.x is BLOCKED to prevent incompatibilities. Please follow the migration guide: https://documentation.wazuh.com/current/upgrade-guide/wazuh-dashboard.html" >&2
+            exit 1
+        fi
+    fi
+fi
+
 #
 # This script is executed in the pre-installation phase
 #

--- a/dev-tools/build-packages/deb/debian/preinst
+++ b/dev-tools/build-packages/deb/debian/preinst
@@ -9,13 +9,22 @@
 
 set -e
 
-# Version guard: block 5.x installation when a pre-5.x version (4.x or earlier) is already installed
+# Version guard: block 5.x installation when a pre-5.x Wazuh version is detected on disk.
 # NOTE: we check files on disk rather than dpkg -s because during
 # dpkg -i the old package data remains on disk until postinst runs.
+# Detection order:
+#   1. VERSION.json        — wazuh-dashboard 5.x+
+#   2. VERSION             — wazuh-dashboard 4.x (legacy file)
+#   3. plugin package.json — wazuh-dashboard 4.x+ (plugin metadata)
+#   4. kibana plugin       — wazuh 3.x (Kibana era)
 if [ -f /usr/share/wazuh-dashboard/VERSION.json ]; then
-    INSTALLED_VER=$(grep '"version"' /usr/share/wazuh-dashboard/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+    INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/wazuh-dashboard/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 elif [ -f /usr/share/wazuh-dashboard/VERSION ]; then
     INSTALLED_VER=$(cat /usr/share/wazuh-dashboard/VERSION 2>/dev/null)
+elif [ -f /usr/share/wazuh-dashboard/plugins/wazuh/package.json ]; then
+    INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/wazuh-dashboard/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+elif [ -f /usr/share/kibana/plugins/wazuh/package.json ]; then
+    INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/kibana/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 fi
 
 if [ -n "$INSTALLED_VER" ]; then
@@ -32,6 +41,20 @@ A clean installation of Wazuh Dashboard 5.x is required.
 EOF
         exit 1
     fi
+elif [ "$1" = "upgrade" ] && { [ -d /usr/share/wazuh-dashboard/plugins ] || [ -d /usr/share/kibana/plugins/wazuh ]; }; then
+    # Upgrade requested but version could not be determined from any source.
+    # Files may have been removed or corrupted. Block the upgrade; a fresh
+    # install ($1=install) is still allowed.
+    cat >&2 <<EOF
+==============================================================
+ERROR: A previous Wazuh installation was detected but the
+installed version could not be determined.
+
+A clean installation of Wazuh Dashboard 5.x is required.
+Please remove the previous installation before proceeding.
+==============================================================
+EOF
+    exit 1
 fi
 
 #

--- a/dev-tools/build-packages/deb/debian/preinst
+++ b/dev-tools/build-packages/deb/debian/preinst
@@ -10,14 +10,18 @@
 set -e
 
 # Version guard: block 5.x installation when a pre-5.x version (4.x or earlier) is already installed
-# NOTE: we check VERSION.json on disk rather than dpkg -s because during
+# NOTE: we check files on disk rather than dpkg -s because during
 # dpkg -i the old package data remains on disk until postinst runs.
 if [ -f /usr/share/wazuh-dashboard/VERSION.json ]; then
     INSTALLED_VER=$(grep '"version"' /usr/share/wazuh-dashboard/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-    if [ -n "$INSTALLED_VER" ]; then
-        MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
-        if [ "$MAJOR" -lt 5 ]; then
-            cat >&2 <<EOF
+elif [ -f /usr/share/wazuh-dashboard/VERSION ]; then
+    INSTALLED_VER=$(cat /usr/share/wazuh-dashboard/VERSION 2>/dev/null)
+fi
+
+if [ -n "$INSTALLED_VER" ]; then
+    MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
+    if [ "$MAJOR" -lt 5 ]; then
+        cat >&2 <<EOF
 ==============================================================
 ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
 is not supported.
@@ -26,8 +30,7 @@ Detected installed version: $INSTALLED_VER
 A clean installation of Wazuh Dashboard 5.x is required.
 ==============================================================
 EOF
-            exit 1
-        fi
+        exit 1
     fi
 fi
 

--- a/dev-tools/build-packages/deb/debian/preinst
+++ b/dev-tools/build-packages/deb/debian/preinst
@@ -17,7 +17,15 @@ if [ -f /usr/share/wazuh-dashboard/VERSION.json ]; then
     if [ -n "$INSTALLED_VER" ]; then
         MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
         if [ "$MAJOR" -lt 5 ]; then
-            echo "ERROR: Detected Wazuh Dashboard version $INSTALLED_VER. Installation of Wazuh Dashboard 5.x is BLOCKED to prevent incompatibilities. Please follow the migration guide: https://documentation.wazuh.com/current/upgrade-guide/wazuh-dashboard.html" >&2
+            cat >&2 <<EOF
+==============================================================
+ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
+is not supported.
+
+Detected installed version: $INSTALLED_VER
+A clean installation of Wazuh Dashboard 5.x is required.
+==============================================================
+EOF
             exit 1
         fi
     fi

--- a/dev-tools/build-packages/deb/debian/preinst
+++ b/dev-tools/build-packages/deb/debian/preinst
@@ -16,15 +16,12 @@ set -e
 #   1. VERSION.json        — wazuh-dashboard 5.x+
 #   2. VERSION             — wazuh-dashboard 4.x (legacy file)
 #   3. plugin package.json — wazuh-dashboard 4.x+ (plugin metadata)
-#   4. kibana plugin       — wazuh 3.x (Kibana era)
 if [ -f /usr/share/wazuh-dashboard/VERSION.json ]; then
     INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/wazuh-dashboard/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 elif [ -f /usr/share/wazuh-dashboard/VERSION ]; then
     INSTALLED_VER=$(cat /usr/share/wazuh-dashboard/VERSION 2>/dev/null)
 elif [ -f /usr/share/wazuh-dashboard/plugins/wazuh/package.json ]; then
     INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/wazuh-dashboard/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-elif [ -f /usr/share/kibana/plugins/wazuh/package.json ]; then
-    INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/kibana/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 fi
 
 if [ -n "$INSTALLED_VER" ]; then
@@ -32,16 +29,16 @@ if [ -n "$INSTALLED_VER" ]; then
     if [ "$MAJOR" -lt 5 ]; then
         cat >&2 <<EOF
 ==============================================================
-ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
+ERROR: Direct upgrade from Wazuh dashboard versions prior to 5.x
 is not supported.
 
 Detected installed version: $INSTALLED_VER
-A clean installation of Wazuh Dashboard 5.x is required.
+A clean installation of Wazuh dashboard 5.x is required.
 ==============================================================
 EOF
         exit 1
     fi
-elif [ "$1" = "upgrade" ] && { [ -d /usr/share/wazuh-dashboard/plugins ] || [ -d /usr/share/kibana/plugins/wazuh ]; }; then
+elif [ "$1" = "upgrade" ] && [ -d /usr/share/wazuh-dashboard/plugins ]; then
     # Upgrade requested but version could not be determined from any source.
     # Files may have been removed or corrupted. Block the upgrade; a fresh
     # install ($1=install) is still allowed.
@@ -50,7 +47,7 @@ elif [ "$1" = "upgrade" ] && { [ -d /usr/share/wazuh-dashboard/plugins ] || [ -d
 ERROR: A previous Wazuh installation was detected but the
 installed version could not be determined.
 
-A clean installation of Wazuh Dashboard 5.x is required.
+A clean installation of Wazuh dashboard 5.x is required.
 Please remove the previous installation before proceeding.
 ==============================================================
 EOF

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -110,7 +110,15 @@ if [ -f %{INSTALL_DIR}/VERSION.json ]; then
   if [ -n "$INSTALLED_VER" ]; then
     MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
     if [ "$MAJOR" -lt 5 ]; then
-      echo "ERROR: Detected Wazuh Dashboard version $INSTALLED_VER. Installation of Wazuh Dashboard 5.x is BLOCKED to prevent incompatibilities. Please follow the migration guide: https://documentation.wazuh.com/current/upgrade-guide/wazuh-dashboard.html" >&2
+      cat >&2 <<EOF
+==============================================================
+ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
+is not supported.
+
+Detected installed version: $INSTALLED_VER
+A clean installation of Wazuh Dashboard 5.x is required.
+==============================================================
+EOF
       exit 1
     fi
   fi

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -126,8 +126,6 @@ EOF
     exit 1
   fi
 fi
-  fi
-fi
 
 # Create the wazuh-dashboard group if it doesn't exists
 if [ $1 = 1 ]; then

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -103,14 +103,18 @@ find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 744 -exec chmod 740
 
 %pre
 # Block installation of 5.x if any wazuh-dashboard < 5.0.0 is installed
-# NOTE: we check VERSION.json on disk rather than rpm -qa because during
+# NOTE: we check files on disk rather than rpm -qa because during
 # rpm -Uvh the old package header is removed from the DB before %pre runs.
 if [ -f %{INSTALL_DIR}/VERSION.json ]; then
   INSTALLED_VER=$(grep '"version"' %{INSTALL_DIR}/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-  if [ -n "$INSTALLED_VER" ]; then
-    MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
-    if [ "$MAJOR" -lt 5 ]; then
-      cat >&2 <<EOF
+elif [ -f %{INSTALL_DIR}/VERSION ]; then
+  INSTALLED_VER=$(cat %{INSTALL_DIR}/VERSION 2>/dev/null)
+fi
+
+if [ -n "$INSTALLED_VER" ]; then
+  MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
+  if [ "$MAJOR" -lt 5 ]; then
+    cat >&2 <<EOF
 ==============================================================
 ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
 is not supported.
@@ -119,8 +123,9 @@ Detected installed version: $INSTALLED_VER
 A clean installation of Wazuh Dashboard 5.x is required.
 ==============================================================
 EOF
-      exit 1
-    fi
+    exit 1
+  fi
+fi
   fi
 fi
 

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -102,13 +102,22 @@ find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 744 -exec chmod 740
 # -----------------------------------------------------------------------------
 
 %pre
-# Block installation of 5.x if any wazuh-dashboard < 5.0.0 is installed
+# Block installation of 5.x if any Wazuh < 5.0.0 is detected on disk.
 # NOTE: we check files on disk rather than rpm -qa because during
 # rpm -Uvh the old package header is removed from the DB before %pre runs.
+# Detection order:
+#   1. VERSION.json        — wazuh-dashboard 5.x+
+#   2. VERSION             — wazuh-dashboard 4.x (legacy file)
+#   3. plugin package.json — wazuh-dashboard 4.x+ (plugin metadata)
+#   4. kibana plugin       — wazuh 3.x (Kibana era)
 if [ -f %{INSTALL_DIR}/VERSION.json ]; then
-  INSTALLED_VER=$(grep '"version"' %{INSTALL_DIR}/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+  INSTALLED_VER=$(grep -m 1 '"version"' %{INSTALL_DIR}/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 elif [ -f %{INSTALL_DIR}/VERSION ]; then
   INSTALLED_VER=$(cat %{INSTALL_DIR}/VERSION 2>/dev/null)
+elif [ -f %{INSTALL_DIR}/plugins/wazuh/package.json ]; then
+  INSTALLED_VER=$(grep -m 1 '"version"' %{INSTALL_DIR}/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+elif [ -f /usr/share/kibana/plugins/wazuh/package.json ]; then
+  INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/kibana/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 fi
 
 if [ -n "$INSTALLED_VER" ]; then
@@ -125,6 +134,20 @@ A clean installation of Wazuh Dashboard 5.x is required.
 EOF
     exit 1
   fi
+elif [ "$1" = "2" ] && { [ -d %{INSTALL_DIR}/plugins ] || [ -d /usr/share/kibana/plugins/wazuh ]; }; then
+  # Upgrade requested but version could not be determined from any source.
+  # Files may have been removed or corrupted. Block the upgrade; a fresh
+  # install ($1=1) is still allowed.
+  cat >&2 <<EOF
+==============================================================
+ERROR: A previous Wazuh installation was detected but the
+installed version could not be determined.
+
+A clean installation of Wazuh Dashboard 5.x is required.
+Please remove the previous installation before proceeding.
+==============================================================
+EOF
+  exit 1
 fi
 
 # Create the wazuh-dashboard group if it doesn't exists

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -102,6 +102,20 @@ find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 744 -exec chmod 740
 # -----------------------------------------------------------------------------
 
 %pre
+# Block installation of 5.x if any wazuh-dashboard < 5.0.0 is installed
+# NOTE: we check VERSION.json on disk rather than rpm -qa because during
+# rpm -Uvh the old package header is removed from the DB before %pre runs.
+if [ -f %{INSTALL_DIR}/VERSION.json ]; then
+  INSTALLED_VER=$(grep '"version"' %{INSTALL_DIR}/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+  if [ -n "$INSTALLED_VER" ]; then
+    MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
+    if [ "$MAJOR" -lt 5 ]; then
+      echo "ERROR: Detected Wazuh Dashboard version $INSTALLED_VER. Installation of Wazuh Dashboard 5.x is BLOCKED to prevent incompatibilities. Please follow the migration guide: https://documentation.wazuh.com/current/upgrade-guide/wazuh-dashboard.html" >&2
+      exit 1
+    fi
+  fi
+fi
+
 # Create the wazuh-dashboard group if it doesn't exists
 if [ $1 = 1 ]; then
   if command -v getent > /dev/null 2>&1 && ! getent group %{GROUP} > /dev/null 2>&1; then

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -109,15 +109,12 @@ find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 744 -exec chmod 740
 #   1. VERSION.json        — wazuh-dashboard 5.x+
 #   2. VERSION             — wazuh-dashboard 4.x (legacy file)
 #   3. plugin package.json — wazuh-dashboard 4.x+ (plugin metadata)
-#   4. kibana plugin       — wazuh 3.x (Kibana era)
 if [ -f %{INSTALL_DIR}/VERSION.json ]; then
   INSTALLED_VER=$(grep -m 1 '"version"' %{INSTALL_DIR}/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 elif [ -f %{INSTALL_DIR}/VERSION ]; then
   INSTALLED_VER=$(cat %{INSTALL_DIR}/VERSION 2>/dev/null)
 elif [ -f %{INSTALL_DIR}/plugins/wazuh/package.json ]; then
   INSTALLED_VER=$(grep -m 1 '"version"' %{INSTALL_DIR}/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-elif [ -f /usr/share/kibana/plugins/wazuh/package.json ]; then
-  INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/kibana/plugins/wazuh/package.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 fi
 
 if [ -n "$INSTALLED_VER" ]; then
@@ -125,16 +122,16 @@ if [ -n "$INSTALLED_VER" ]; then
   if [ "$MAJOR" -lt 5 ]; then
     cat >&2 <<EOF
 ==============================================================
-ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
+ERROR: Direct upgrade from Wazuh dashboard versions prior to 5.x
 is not supported.
 
 Detected installed version: $INSTALLED_VER
-A clean installation of Wazuh Dashboard 5.x is required.
+A clean installation of Wazuh dashboard 5.x is required.
 ==============================================================
 EOF
     exit 1
   fi
-elif [ "$1" = "2" ] && { [ -d %{INSTALL_DIR}/plugins ] || [ -d /usr/share/kibana/plugins/wazuh ]; }; then
+elif [ "$1" = "2" ] && [ -d %{INSTALL_DIR}/plugins ]; then
   # Upgrade requested but version could not be determined from any source.
   # Files may have been removed or corrupted. Block the upgrade; a fresh
   # install ($1=1) is still allowed.
@@ -143,7 +140,7 @@ elif [ "$1" = "2" ] && { [ -d %{INSTALL_DIR}/plugins ] || [ -d /usr/share/kibana
 ERROR: A previous Wazuh installation was detected but the
 installed version could not be determined.
 
-A clean installation of Wazuh Dashboard 5.x is required.
+A clean installation of Wazuh dashboard 5.x is required.
 Please remove the previous installation before proceeding.
 ==============================================================
 EOF

--- a/dev-tools/test-packages/deb/Dockerfile
+++ b/dev-tools/test-packages/deb/Dockerfile
@@ -1,23 +1,23 @@
 FROM ubuntu:jammy
 ARG PACKAGE
-ARG SIMULATE_4X
-ARG REINSTALL_5X
+ARG BLOCK_4X_INSTALL
+ARG ALLOW_SAME_MAJOR_REINSTALL
 RUN mkdir -p /tmp
 RUN apt-get update --fix-missing
 RUN apt-get install -y curl libcap2-bin
 
-# If SIMULATE_4X is set, create a VERSION.json on disk to simulate
+# If BLOCK_4X_INSTALL is set, create a VERSION.json on disk to simulate
 # an existing pre-5.x installation (the preinst guard checks this file)
-RUN if [ -n "$SIMULATE_4X" ]; then \
+RUN if [ -n "$BLOCK_4X_INSTALL" ]; then \
       mkdir -p /usr/share/wazuh-dashboard && \
       printf '{"version": "4.14.5"}' > /usr/share/wazuh-dashboard/VERSION.json; \
     fi
 
 COPY ${PACKAGE} /tmp/wazuh.deb
 
-# If REINSTALL_5X: install the 5.x package once, then force a reinstall
+# If ALLOW_SAME_MAJOR_REINSTALL: install the 5.x package once, then force a reinstall
 # to exercise the preinst guard again (must allow same-major-version reinstall)
-RUN if [ -n "$REINSTALL_5X" ]; then \
+RUN if [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
       dpkg -i /tmp/wazuh.deb && \
       dpkg -i /tmp/wazuh.deb; \
     else \

--- a/dev-tools/test-packages/deb/Dockerfile
+++ b/dev-tools/test-packages/deb/Dockerfile
@@ -1,7 +1,25 @@
 FROM ubuntu:jammy
 ARG PACKAGE
+ARG SIMULATE_4X
+ARG REINSTALL_5X
 RUN mkdir -p /tmp
 RUN apt-get update --fix-missing
 RUN apt-get install -y curl libcap2-bin
+
+# If SIMULATE_4X is set, create a VERSION.json on disk to simulate
+# an existing pre-5.x installation (the preinst guard checks this file)
+RUN if [ -n "$SIMULATE_4X" ]; then \
+      mkdir -p /usr/share/wazuh-dashboard && \
+      printf '{"version": "4.14.5"}' > /usr/share/wazuh-dashboard/VERSION.json; \
+    fi
+
 COPY ${PACKAGE} /tmp/wazuh.deb
-RUN dpkg -i /tmp/wazuh.deb
+
+# If REINSTALL_5X: install the 5.x package once, then force a reinstall
+# to exercise the preinst guard again (must allow same-major-version reinstall)
+RUN if [ -n "$REINSTALL_5X" ]; then \
+      dpkg -i /tmp/wazuh.deb && \
+      dpkg -i /tmp/wazuh.deb; \
+    else \
+      dpkg -i /tmp/wazuh.deb; \
+    fi

--- a/dev-tools/test-packages/deb/Dockerfile
+++ b/dev-tools/test-packages/deb/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:jammy
 ARG PACKAGE
 ARG BLOCK_4X_INSTALL
-ARG BLOCK_3X_INSTALL
 ARG BLOCK_UNKNOWN_INSTALL
 ARG ALLOW_SAME_MAJOR_REINSTALL
 RUN mkdir -p /tmp
@@ -15,13 +14,6 @@ RUN if [ -n "$BLOCK_4X_INSTALL" ]; then \
       printf '{"name":"wazuh","version":"4.14.5"}\n' > /usr/share/wazuh-dashboard/plugins/wazuh/package.json; \
     fi
 
-# If BLOCK_3X_INSTALL is set, simulate a 3.x Kibana-era installation
-# (the preinst guard falls through to /usr/share/kibana/plugins/wazuh/package.json)
-RUN if [ -n "$BLOCK_3X_INSTALL" ]; then \
-      mkdir -p /usr/share/kibana/plugins/wazuh && \
-      printf '{"name":"wazuh","version":"3.13.6"}\n' > /usr/share/kibana/plugins/wazuh/package.json; \
-    fi
-
 COPY ${PACKAGE} /tmp/wazuh.deb
 
 # BLOCK_UNKNOWN_INSTALL: install once (fresh, $1=install — allowed), then corrupt
@@ -30,8 +22,7 @@ COPY ${PACKAGE} /tmp/wazuh.deb
 #
 # ALLOW_SAME_MAJOR_REINSTALL: install twice — must succeed (5.x over 5.x).
 #
-# Default: normal install (also handles BLOCK_4X_INSTALL and BLOCK_3X_INSTALL
-# via the files pre-created above).
+# Default: normal install (also handles BLOCK_4X_INSTALL via the files pre-created above).
 RUN if [ -n "$BLOCK_UNKNOWN_INSTALL" ]; then \
       dpkg -i /tmp/wazuh.deb && \
       rm -f /usr/share/wazuh-dashboard/VERSION.json && \

--- a/dev-tools/test-packages/deb/Dockerfile
+++ b/dev-tools/test-packages/deb/Dockerfile
@@ -1,23 +1,44 @@
 FROM ubuntu:jammy
 ARG PACKAGE
 ARG BLOCK_4X_INSTALL
+ARG BLOCK_3X_INSTALL
+ARG BLOCK_UNKNOWN_INSTALL
 ARG ALLOW_SAME_MAJOR_REINSTALL
 RUN mkdir -p /tmp
 RUN apt-get update --fix-missing
 RUN apt-get install -y curl libcap2-bin
 
-# If BLOCK_4X_INSTALL is set, create a VERSION.json on disk to simulate
-# an existing pre-5.x installation (the preinst guard checks this file)
+# If BLOCK_4X_INSTALL is set, simulate a 4.x installation via the plugin's package.json
+# (the preinst guard falls through VERSION.json -> VERSION -> plugin package.json)
 RUN if [ -n "$BLOCK_4X_INSTALL" ]; then \
-      mkdir -p /usr/share/wazuh-dashboard && \
-      printf '{"version": "4.14.5"}' > /usr/share/wazuh-dashboard/VERSION.json; \
+      mkdir -p /usr/share/wazuh-dashboard/plugins/wazuh && \
+      printf '{"name":"wazuh","version":"4.14.5"}\n' > /usr/share/wazuh-dashboard/plugins/wazuh/package.json; \
+    fi
+
+# If BLOCK_3X_INSTALL is set, simulate a 3.x Kibana-era installation
+# (the preinst guard falls through to /usr/share/kibana/plugins/wazuh/package.json)
+RUN if [ -n "$BLOCK_3X_INSTALL" ]; then \
+      mkdir -p /usr/share/kibana/plugins/wazuh && \
+      printf '{"name":"wazuh","version":"3.13.6"}\n' > /usr/share/kibana/plugins/wazuh/package.json; \
     fi
 
 COPY ${PACKAGE} /tmp/wazuh.deb
 
-# If ALLOW_SAME_MAJOR_REINSTALL: install the 5.x package once, then force a reinstall
-# to exercise the preinst guard again (must allow same-major-version reinstall)
-RUN if [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
+# BLOCK_UNKNOWN_INSTALL: install once (fresh, $1=install — allowed), then corrupt
+# version files so the version cannot be determined, then attempt a reinstall
+# ($1=upgrade) which must be blocked by the preinst guard.
+#
+# ALLOW_SAME_MAJOR_REINSTALL: install twice — must succeed (5.x over 5.x).
+#
+# Default: normal install (also handles BLOCK_4X_INSTALL and BLOCK_3X_INSTALL
+# via the files pre-created above).
+RUN if [ -n "$BLOCK_UNKNOWN_INSTALL" ]; then \
+      dpkg -i /tmp/wazuh.deb && \
+      rm -f /usr/share/wazuh-dashboard/VERSION.json && \
+      rm -f /usr/share/wazuh-dashboard/VERSION && \
+      rm -f /usr/share/wazuh-dashboard/plugins/wazuh/package.json && \
+      dpkg -i /tmp/wazuh.deb; \
+    elif [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
       dpkg -i /tmp/wazuh.deb && \
       dpkg -i /tmp/wazuh.deb; \
     else \

--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -1,9 +1,27 @@
 FROM centos:8
 RUN mkdir -p /tmp
 ARG PACKAGE
+ARG SIMULATE_4X
+ARG REINSTALL_5X
 RUN cd /etc/yum.repos.d/
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum update -y
+
+# If SIMULATE_4X is set, create a VERSION.json on disk to simulate
+# an existing pre-5.x installation (the %pre guard checks this file)
+RUN if [ -n "$SIMULATE_4X" ]; then \
+      mkdir -p /usr/share/wazuh-dashboard && \
+      printf '{"version": "4.14.5"}' > /usr/share/wazuh-dashboard/VERSION.json; \
+    fi
+
 COPY ${PACKAGE} /tmp/wazuh.rpm
-RUN yum install /tmp/wazuh.rpm -y
+
+# If REINSTALL_5X: install the 5.x package once, then force a reinstall
+# to exercise the %pre guard again (must allow same-major-version reinstall)
+RUN if [ -n "$REINSTALL_5X" ]; then \
+      rpm -ivh /tmp/wazuh.rpm --nodeps && \
+      rpm -Uvh /tmp/wazuh.rpm --nodeps; \
+    else \
+      yum install /tmp/wazuh.rpm -y; \
+    fi

--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -2,7 +2,6 @@ FROM centos:8
 RUN mkdir -p /tmp
 ARG PACKAGE
 ARG BLOCK_4X_INSTALL
-ARG BLOCK_3X_INSTALL
 ARG BLOCK_UNKNOWN_INSTALL
 ARG ALLOW_SAME_MAJOR_REINSTALL
 RUN cd /etc/yum.repos.d/
@@ -17,13 +16,6 @@ RUN if [ -n "$BLOCK_4X_INSTALL" ]; then \
       printf '{"name":"wazuh","version":"4.14.5"}\n' > /usr/share/wazuh-dashboard/plugins/wazuh/package.json; \
     fi
 
-# If BLOCK_3X_INSTALL is set, simulate a 3.x Kibana-era installation
-# (the %pre guard falls through to /usr/share/kibana/plugins/wazuh/package.json)
-RUN if [ -n "$BLOCK_3X_INSTALL" ]; then \
-      mkdir -p /usr/share/kibana/plugins/wazuh && \
-      printf '{"name":"wazuh","version":"3.13.6"}\n' > /usr/share/kibana/plugins/wazuh/package.json; \
-    fi
-
 COPY ${PACKAGE} /tmp/wazuh.rpm
 
 # BLOCK_UNKNOWN_INSTALL: install once (fresh, $1=1 — allowed), then corrupt
@@ -32,8 +24,7 @@ COPY ${PACKAGE} /tmp/wazuh.rpm
 #
 # ALLOW_SAME_MAJOR_REINSTALL: install then upgrade — must succeed (5.x over 5.x).
 #
-# Default: normal install (also handles BLOCK_4X_INSTALL and BLOCK_3X_INSTALL
-# via the files pre-created above).
+# Default: normal install (also handles BLOCK_4X_INSTALL via the files pre-created above).
 RUN if [ -n "$BLOCK_UNKNOWN_INSTALL" ]; then \
       rpm -ivh /tmp/wazuh.rpm --nodeps && \
       rm -f /usr/share/wazuh-dashboard/VERSION.json && \

--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -1,25 +1,25 @@
 FROM centos:8
 RUN mkdir -p /tmp
 ARG PACKAGE
-ARG SIMULATE_4X
-ARG REINSTALL_5X
+ARG BLOCK_4X_INSTALL
+ARG ALLOW_SAME_MAJOR_REINSTALL
 RUN cd /etc/yum.repos.d/
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum update -y
 
-# If SIMULATE_4X is set, create a VERSION.json on disk to simulate
+# If BLOCK_4X_INSTALL is set, create a VERSION.json on disk to simulate
 # an existing pre-5.x installation (the %pre guard checks this file)
-RUN if [ -n "$SIMULATE_4X" ]; then \
+RUN if [ -n "$BLOCK_4X_INSTALL" ]; then \
       mkdir -p /usr/share/wazuh-dashboard && \
       printf '{"version": "4.14.5"}' > /usr/share/wazuh-dashboard/VERSION.json; \
     fi
 
 COPY ${PACKAGE} /tmp/wazuh.rpm
 
-# If REINSTALL_5X: install the 5.x package once, then force a reinstall
+# If ALLOW_SAME_MAJOR_REINSTALL: install the 5.x package once, then force a reinstall
 # to exercise the %pre guard again (must allow same-major-version reinstall)
-RUN if [ -n "$REINSTALL_5X" ]; then \
+RUN if [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
       rpm -ivh /tmp/wazuh.rpm --nodeps && \
       rpm -Uvh /tmp/wazuh.rpm --nodeps; \
     else \

--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -21,7 +21,7 @@ COPY ${PACKAGE} /tmp/wazuh.rpm
 # to exercise the %pre guard again (must allow same-major-version reinstall)
 RUN if [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
       rpm -ivh /tmp/wazuh.rpm --nodeps && \
-      rpm -Uvh /tmp/wazuh.rpm --nodeps; \
+      rpm -Uvh /tmp/wazuh.rpm --nodeps --force; \
     else \
       yum install /tmp/wazuh.rpm -y; \
     fi

--- a/dev-tools/test-packages/rpm/Dockerfile
+++ b/dev-tools/test-packages/rpm/Dockerfile
@@ -2,24 +2,45 @@ FROM centos:8
 RUN mkdir -p /tmp
 ARG PACKAGE
 ARG BLOCK_4X_INSTALL
+ARG BLOCK_3X_INSTALL
+ARG BLOCK_UNKNOWN_INSTALL
 ARG ALLOW_SAME_MAJOR_REINSTALL
 RUN cd /etc/yum.repos.d/
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum update -y
 
-# If BLOCK_4X_INSTALL is set, create a VERSION.json on disk to simulate
-# an existing pre-5.x installation (the %pre guard checks this file)
+# If BLOCK_4X_INSTALL is set, simulate a 4.x installation via the plugin's package.json
+# (the %pre guard falls through VERSION.json -> VERSION -> plugin package.json)
 RUN if [ -n "$BLOCK_4X_INSTALL" ]; then \
-      mkdir -p /usr/share/wazuh-dashboard && \
-      printf '{"version": "4.14.5"}' > /usr/share/wazuh-dashboard/VERSION.json; \
+      mkdir -p /usr/share/wazuh-dashboard/plugins/wazuh && \
+      printf '{"name":"wazuh","version":"4.14.5"}\n' > /usr/share/wazuh-dashboard/plugins/wazuh/package.json; \
+    fi
+
+# If BLOCK_3X_INSTALL is set, simulate a 3.x Kibana-era installation
+# (the %pre guard falls through to /usr/share/kibana/plugins/wazuh/package.json)
+RUN if [ -n "$BLOCK_3X_INSTALL" ]; then \
+      mkdir -p /usr/share/kibana/plugins/wazuh && \
+      printf '{"name":"wazuh","version":"3.13.6"}\n' > /usr/share/kibana/plugins/wazuh/package.json; \
     fi
 
 COPY ${PACKAGE} /tmp/wazuh.rpm
 
-# If ALLOW_SAME_MAJOR_REINSTALL: install the 5.x package once, then force a reinstall
-# to exercise the %pre guard again (must allow same-major-version reinstall)
-RUN if [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
+# BLOCK_UNKNOWN_INSTALL: install once (fresh, $1=1 — allowed), then corrupt
+# version files so the version cannot be determined, then attempt an upgrade
+# ($1=2) which must be blocked by the %pre guard.
+#
+# ALLOW_SAME_MAJOR_REINSTALL: install then upgrade — must succeed (5.x over 5.x).
+#
+# Default: normal install (also handles BLOCK_4X_INSTALL and BLOCK_3X_INSTALL
+# via the files pre-created above).
+RUN if [ -n "$BLOCK_UNKNOWN_INSTALL" ]; then \
+      rpm -ivh /tmp/wazuh.rpm --nodeps && \
+      rm -f /usr/share/wazuh-dashboard/VERSION.json && \
+      rm -f /usr/share/wazuh-dashboard/VERSION && \
+      rm -f /usr/share/wazuh-dashboard/plugins/wazuh/package.json && \
+      rpm -Uvh /tmp/wazuh.rpm --nodeps --force; \
+    elif [ -n "$ALLOW_SAME_MAJOR_REINSTALL" ]; then \
       rpm -ivh /tmp/wazuh.rpm --nodeps && \
       rpm -Uvh /tmp/wazuh.rpm --nodeps --force; \
     else \

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -11,7 +11,6 @@ FILES="/etc/wazuh-dashboard/opensearch_dashboards.yml /usr/share/wazuh-dashboard
 FILE_OWNER="wazuh-dashboard"
 # Test mode flags
 NEGATIVE_TEST=false
-NEGATIVE_3X_TEST=false
 NEGATIVE_UNKNOWN_TEST=false
 REINSTALL_TEST=false
 
@@ -155,8 +154,8 @@ block_4x_install_test() {
     exit 1
   fi
 
-  if grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard" "$BUILD_LOG"; then
-    BLOCK_MSG=$(grep -F 'ERROR: Direct upgrade from Wazuh Dashboard' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+  if grep -F -q "ERROR: Direct upgrade from Wazuh dashboard" "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'ERROR: Direct upgrade from Wazuh dashboard' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
     echo "  $BLOCK_MSG"
   else
     echo "ERROR: Expected error message not found in build output"
@@ -167,47 +166,6 @@ block_4x_install_test() {
   fi
 
   echo "SUCCESS: 5.x installation correctly blocked when 4.x is installed"
-  rm -f "$BUILD_LOG"
-}
-
-# Block-3x-install test: assert 5.x install is BLOCKED when 3.x (Kibana era) is pre-installed
-block_3x_install_test() {
-  BUILD_LOG=$(mktemp)
-
-  if [[ $PACKAGE == *".deb" ]]; then
-    set +e
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_3X_INSTALL=true -t "$CONTAINER_NAME" ./deb/ > "$BUILD_LOG" 2>&1
-    BUILD_EXIT_CODE=$?
-    set -e
-  elif [[ $PACKAGE == *".rpm" ]]; then
-    set +e
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_3X_INSTALL=true -t "$CONTAINER_NAME" ./rpm/ > "$BUILD_LOG" 2>&1
-    BUILD_EXIT_CODE=$?
-    set -e
-  else
-    echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm)"
-    rm -f "$BUILD_LOG"
-    exit 1
-  fi
-
-  if [ "$BUILD_EXIT_CODE" -eq 0 ]; then
-    echo "ERROR: Installation should have been blocked but succeeded"
-    rm -f "$BUILD_LOG"
-    exit 1
-  fi
-
-  if grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard" "$BUILD_LOG"; then
-    BLOCK_MSG=$(grep -F 'ERROR: Direct upgrade from Wazuh Dashboard' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
-    echo "  $BLOCK_MSG"
-  else
-    echo "ERROR: Expected error message not found in build output"
-    echo "--- Build output ---"
-    cat "$BUILD_LOG"
-    rm -f "$BUILD_LOG"
-    exit 1
-  fi
-
-  echo "SUCCESS: 5.x installation correctly blocked when 3.x (Kibana) is installed"
   rm -f "$BUILD_LOG"
 }
 
@@ -300,7 +258,6 @@ help() {
   echo
   echo "    -p, --package <path>       Set Wazuh Dashboard rpm package name,which has to be in the <repository>/dev-tools/test-packages/<DISTRIBUTION>/ folder."
   echo "    --block-4x-install         Run block test: assert 5.x install is blocked when 4.x is pre-installed."
-  echo "    --block-3x-install         Run block test: assert 5.x install is blocked when 3.x (Kibana) is pre-installed."
   echo "    --block-unknown-install    Run block test: assert 5.x install is blocked when remnants exist but version is unknown."
   echo "    --allow-same-major-reinstall Run reinstall test: assert 5.x reinstall over 5.x succeeds."
   echo "    -h, --help                 Show this help."
@@ -326,10 +283,6 @@ main() {
       NEGATIVE_TEST=true
       shift
       ;;
-    "--block-3x-install")
-      NEGATIVE_3X_TEST=true
-      shift
-      ;;
     "--block-unknown-install")
       NEGATIVE_UNKNOWN_TEST=true
       shift
@@ -351,7 +304,6 @@ main() {
   # Count how many test modes are active — only one allowed at a time
   MODE_COUNT=0
   [ "$NEGATIVE_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
-  [ "$NEGATIVE_3X_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
   [ "$NEGATIVE_UNKNOWN_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
   [ "$REINSTALL_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
 
@@ -362,8 +314,6 @@ main() {
 
   if [ "$NEGATIVE_TEST" = true ]; then
     block_4x_install_test
-  elif [ "$NEGATIVE_3X_TEST" = true ]; then
-    block_3x_install_test
   elif [ "$NEGATIVE_UNKNOWN_TEST" = true ]; then
     block_unknown_install_test
   elif [ "$REINSTALL_TEST" = true ]; then

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -15,22 +15,25 @@ REINSTALL_TEST=false
 
 # Remove container and image
 clean() {
-  docker stop $CONTAINER_NAME
-  # This is done because in the construction of packages arm sometimes fails because it is not finished destroying the container and when trying to delete the image fails because it is in use.
-  MAX_RETRIES=30
-  RETRY_COUNT=0
-  echo "Waiting for the container ($CONTAINER_NAME) to be removed"
-  while docker ps -a --format "{{.Names}}" | grep $CONTAINER_NAME; do
-    echo "The $(docker ps -a --format "{{.Names}}" | grep $CONTAINER_NAME) container has not been removed yet. Retry number $RETRY_COUNT."
-    if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
-      echo "WARNING: Maximum retries reached while waiting for container to stop"
-      break
-    fi
-    sleep 2
-    RETRY_COUNT=$((RETRY_COUNT + 1))
-  done
-  echo "Container removed. Removing the image"
-  docker rmi -f $CONTAINER_NAME
+  # Only clean if the container exists (negative test may not create one)
+  if docker ps -a --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
+    docker stop $CONTAINER_NAME
+    # This is done because in the construction of packages arm sometimes fails because it is not finished destroying the container and when trying to delete the image fails because it is in use.
+    MAX_RETRIES=30
+    RETRY_COUNT=0
+    echo "Waiting for the container ($CONTAINER_NAME) to be removed"
+    while docker ps -a --format "{{.Names}}" | grep $CONTAINER_NAME; do
+      echo "The $(docker ps -a --format "{{.Names}}" | grep $CONTAINER_NAME) container has not been removed yet. Retry number $RETRY_COUNT."
+      if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+        echo "WARNING: Maximum retries reached while waiting for container to stop"
+        break
+      fi
+      sleep 2
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+    done
+    echo "Container removed. Removing the image"
+    docker rmi -f $CONTAINER_NAME
+  fi
 }
 
 # Check if files exist and are owned by wazuh-dashboard

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -11,6 +11,8 @@ FILES="/etc/wazuh-dashboard/opensearch_dashboards.yml /usr/share/wazuh-dashboard
 FILE_OWNER="wazuh-dashboard"
 # Test mode flags
 NEGATIVE_TEST=false
+NEGATIVE_3X_TEST=false
+NEGATIVE_UNKNOWN_TEST=false
 REINSTALL_TEST=false
 
 # Remove container and image
@@ -168,6 +170,88 @@ block_4x_install_test() {
   rm -f "$BUILD_LOG"
 }
 
+# Block-3x-install test: assert 5.x install is BLOCKED when 3.x (Kibana era) is pre-installed
+block_3x_install_test() {
+  BUILD_LOG=$(mktemp)
+
+  if [[ $PACKAGE == *".deb" ]]; then
+    set +e
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_3X_INSTALL=true -t "$CONTAINER_NAME" ./deb/ > "$BUILD_LOG" 2>&1
+    BUILD_EXIT_CODE=$?
+    set -e
+  elif [[ $PACKAGE == *".rpm" ]]; then
+    set +e
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_3X_INSTALL=true -t "$CONTAINER_NAME" ./rpm/ > "$BUILD_LOG" 2>&1
+    BUILD_EXIT_CODE=$?
+    set -e
+  else
+    echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm)"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  if [ "$BUILD_EXIT_CODE" -eq 0 ]; then
+    echo "ERROR: Installation should have been blocked but succeeded"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  if grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard" "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'ERROR: Direct upgrade from Wazuh Dashboard' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+    echo "  $BLOCK_MSG"
+  else
+    echo "ERROR: Expected error message not found in build output"
+    echo "--- Build output ---"
+    cat "$BUILD_LOG"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  echo "SUCCESS: 5.x installation correctly blocked when 3.x (Kibana) is installed"
+  rm -f "$BUILD_LOG"
+}
+
+# Block-unknown-install test: assert 5.x install is BLOCKED when remnants exist but version is unknown
+block_unknown_install_test() {
+  BUILD_LOG=$(mktemp)
+
+  if [[ $PACKAGE == *".deb" ]]; then
+    set +e
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_UNKNOWN_INSTALL=true -t "$CONTAINER_NAME" ./deb/ > "$BUILD_LOG" 2>&1
+    BUILD_EXIT_CODE=$?
+    set -e
+  elif [[ $PACKAGE == *".rpm" ]]; then
+    set +e
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_UNKNOWN_INSTALL=true -t "$CONTAINER_NAME" ./rpm/ > "$BUILD_LOG" 2>&1
+    BUILD_EXIT_CODE=$?
+    set -e
+  else
+    echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm)"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  if [ "$BUILD_EXIT_CODE" -eq 0 ]; then
+    echo "ERROR: Installation should have been blocked but succeeded"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  if grep -F -q "version could not be determined" "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'version could not be determined' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+    echo "  $BLOCK_MSG"
+  else
+    echo "ERROR: Expected error message not found in build output"
+    echo "--- Build output ---"
+    cat "$BUILD_LOG"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  echo "SUCCESS: 5.x installation correctly blocked when previous install remnants exist with unknown version"
+  rm -f "$BUILD_LOG"
+}
+
 # Reinstall test: assert 5.x install over 5.x succeeds (same-major reinstall)
 same_major_reinstall_test() {
   if [[ $PACKAGE == *".deb" ]]; then
@@ -216,6 +300,8 @@ help() {
   echo
   echo "    -p, --package <path>       Set Wazuh Dashboard rpm package name,which has to be in the <repository>/dev-tools/test-packages/<DISTRIBUTION>/ folder."
   echo "    --block-4x-install         Run block test: assert 5.x install is blocked when 4.x is pre-installed."
+  echo "    --block-3x-install         Run block test: assert 5.x install is blocked when 3.x (Kibana) is pre-installed."
+  echo "    --block-unknown-install    Run block test: assert 5.x install is blocked when remnants exist but version is unknown."
   echo "    --allow-same-major-reinstall Run reinstall test: assert 5.x reinstall over 5.x succeeds."
   echo "    -h, --help                 Show this help."
   echo
@@ -240,6 +326,14 @@ main() {
       NEGATIVE_TEST=true
       shift
       ;;
+    "--block-3x-install")
+      NEGATIVE_3X_TEST=true
+      shift
+      ;;
+    "--block-unknown-install")
+      NEGATIVE_UNKNOWN_TEST=true
+      shift
+      ;;
     "--allow-same-major-reinstall")
       REINSTALL_TEST=true
       shift
@@ -254,13 +348,24 @@ main() {
     help 1
   fi
 
-  if [ "$NEGATIVE_TEST" = true ] && [ "$REINSTALL_TEST" = true ]; then
-    echo "ERROR: --block-4x-install and --allow-same-major-reinstall are mutually exclusive"
+  # Count how many test modes are active — only one allowed at a time
+  MODE_COUNT=0
+  [ "$NEGATIVE_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
+  [ "$NEGATIVE_3X_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
+  [ "$NEGATIVE_UNKNOWN_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
+  [ "$REINSTALL_TEST" = true ] && MODE_COUNT=$((MODE_COUNT + 1))
+
+  if [ "$MODE_COUNT" -gt 1 ]; then
+    echo "ERROR: Only one test mode flag can be used at a time"
     exit 1
   fi
 
   if [ "$NEGATIVE_TEST" = true ]; then
     block_4x_install_test
+  elif [ "$NEGATIVE_3X_TEST" = true ]; then
+    block_3x_install_test
+  elif [ "$NEGATIVE_UNKNOWN_TEST" = true ]; then
+    block_unknown_install_test
   elif [ "$REINSTALL_TEST" = true ]; then
     same_major_reinstall_test
   else

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -153,8 +153,8 @@ block_4x_install_test() {
     exit 1
   fi
 
-  if grep -F -q "ERROR: Detected Wazuh Dashboard version" "$BUILD_LOG"; then
-    BLOCK_MSG=$(grep -F 'ERROR: Detected Wazuh Dashboard version' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+  if grep -F -q "ERROR: Direct upgrade from Wazuh Dashboard" "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'ERROR: Direct upgrade from Wazuh Dashboard' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
     echo "  $BLOCK_MSG"
   else
     echo "ERROR: Expected error message not found in build output"

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -124,8 +124,8 @@ check_metadata_rpm() {
   echo "metadata package is correct: $metadataPackage"
 }
 
-# Negative test: assert 5.x install is BLOCKED when 4.x is pre-installed
-negative_test() {
+# Block-4x-install test: assert 5.x install is BLOCKED when 4.x is pre-installed
+block_4x_install_test() {
   BUILD_LOG=$(mktemp)
 
   if [[ $PACKAGE == *".deb" ]]; then
@@ -150,7 +150,10 @@ negative_test() {
     exit 1
   fi
 
-  if ! grep -F -q "ERROR: Detected Wazuh Dashboard version" "$BUILD_LOG"; then
+  if grep -F -q "ERROR: Detected Wazuh Dashboard version" "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'ERROR: Detected Wazuh Dashboard version' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+    echo "  $BLOCK_MSG"
+  else
     echo "ERROR: Expected error message not found in build output"
     echo "--- Build output ---"
     cat "$BUILD_LOG"
@@ -163,14 +166,14 @@ negative_test() {
 }
 
 # Reinstall test: assert 5.x install over 5.x succeeds (same-major reinstall)
-reinstall_test() {
+same_major_reinstall_test() {
   if [[ $PACKAGE == *".deb" ]]; then
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg ALLOW_SAME_MAJOR_REINSTALL=true -t "$CONTAINER_NAME" ./deb/
-    docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME"
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg ALLOW_SAME_MAJOR_REINSTALL=true -t "$CONTAINER_NAME" ./deb/ && \
+    docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME" && \
     check_metadata_deb
   elif [[ $PACKAGE == *".rpm" ]]; then
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg ALLOW_SAME_MAJOR_REINSTALL=true -t "$CONTAINER_NAME" ./rpm/
-    docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME"
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg ALLOW_SAME_MAJOR_REINSTALL=true -t "$CONTAINER_NAME" ./rpm/ && \
+    docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME" && \
     check_metadata_rpm
   else
     echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm)"
@@ -254,9 +257,9 @@ main() {
   fi
 
   if [ "$NEGATIVE_TEST" = true ]; then
-    negative_test
+    block_4x_install_test
   elif [ "$REINSTALL_TEST" = true ]; then
-    reinstall_test
+    same_major_reinstall_test
   else
     test
   fi

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -130,12 +130,12 @@ negative_test() {
 
   if [[ $PACKAGE == *".deb" ]]; then
     set +e
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg SIMULATE_4X=true -t "$CONTAINER_NAME" ./deb/ > "$BUILD_LOG" 2>&1
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_4X_INSTALL=true -t "$CONTAINER_NAME" ./deb/ > "$BUILD_LOG" 2>&1
     BUILD_EXIT_CODE=$?
     set -e
   elif [[ $PACKAGE == *".rpm" ]]; then
     set +e
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg SIMULATE_4X=true -t "$CONTAINER_NAME" ./rpm/ > "$BUILD_LOG" 2>&1
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg BLOCK_4X_INSTALL=true -t "$CONTAINER_NAME" ./rpm/ > "$BUILD_LOG" 2>&1
     BUILD_EXIT_CODE=$?
     set -e
   else
@@ -165,11 +165,11 @@ negative_test() {
 # Reinstall test: assert 5.x install over 5.x succeeds (same-major reinstall)
 reinstall_test() {
   if [[ $PACKAGE == *".deb" ]]; then
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg REINSTALL_5X=true -t "$CONTAINER_NAME" ./deb/
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg ALLOW_SAME_MAJOR_REINSTALL=true -t "$CONTAINER_NAME" ./deb/
     docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME"
     check_metadata_deb
   elif [[ $PACKAGE == *".rpm" ]]; then
-    docker build --build-arg PACKAGE="$PACKAGE" --build-arg REINSTALL_5X=true -t "$CONTAINER_NAME" ./rpm/
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg ALLOW_SAME_MAJOR_REINSTALL=true -t "$CONTAINER_NAME" ./rpm/
     docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME"
     check_metadata_rpm
   else
@@ -209,8 +209,8 @@ help() {
   echo "Usage: $0 [OPTIONS]"
   echo
   echo "    -p, --package <path>       Set Wazuh Dashboard rpm package name,which has to be in the <repository>/dev-tools/test-packages/<DISTRIBUTION>/ folder."
-  echo "    --negative                 Run negative test: assert 5.x install is blocked when 4.x is pre-installed."
-  echo "    --reinstall                Run reinstall test: assert 5.x reinstall over 5.x succeeds."
+  echo "    --block-4x-install         Run block test: assert 5.x install is blocked when 4.x is pre-installed."
+  echo "    --allow-same-major-reinstall Run reinstall test: assert 5.x reinstall over 5.x succeeds."
   echo "    -h, --help                 Show this help."
   echo
   exit $1
@@ -230,11 +230,11 @@ main() {
         help 1
       fi
       ;;
-    "--negative")
+    "--block-4x-install")
       NEGATIVE_TEST=true
       shift
       ;;
-    "--reinstall")
+    "--allow-same-major-reinstall")
       REINSTALL_TEST=true
       shift
       ;;
@@ -249,7 +249,7 @@ main() {
   fi
 
   if [ "$NEGATIVE_TEST" = true ] && [ "$REINSTALL_TEST" = true ]; then
-    echo "ERROR: --negative and --reinstall are mutually exclusive"
+    echo "ERROR: --block-4x-install and --allow-same-major-reinstall are mutually exclusive"
     exit 1
   fi
 

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -u
 
 # Package name
 PACKAGE=""
@@ -8,6 +9,9 @@ CONTAINER_NAME="wazuh-dashboard"
 FILES="/etc/wazuh-dashboard/opensearch_dashboards.yml /usr/share/wazuh-dashboard"
 # Owner of the files
 FILE_OWNER="wazuh-dashboard"
+# Test mode flags
+NEGATIVE_TEST=false
+REINSTALL_TEST=false
 
 # Remove container and image
 clean() {
@@ -120,6 +124,64 @@ check_metadata_rpm() {
   echo "metadata package is correct: $metadataPackage"
 }
 
+# Negative test: assert 5.x install is BLOCKED when 4.x is pre-installed
+negative_test() {
+  BUILD_LOG=$(mktemp)
+
+  if [[ $PACKAGE == *".deb" ]]; then
+    set +e
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg SIMULATE_4X=true -t "$CONTAINER_NAME" ./deb/ > "$BUILD_LOG" 2>&1
+    BUILD_EXIT_CODE=$?
+    set -e
+  elif [[ $PACKAGE == *".rpm" ]]; then
+    set +e
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg SIMULATE_4X=true -t "$CONTAINER_NAME" ./rpm/ > "$BUILD_LOG" 2>&1
+    BUILD_EXIT_CODE=$?
+    set -e
+  else
+    echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm)"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  if [ "$BUILD_EXIT_CODE" -eq 0 ]; then
+    echo "ERROR: Installation should have been blocked but succeeded"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  if ! grep -F -q "ERROR: Detected Wazuh Dashboard version" "$BUILD_LOG"; then
+    echo "ERROR: Expected error message not found in build output"
+    echo "--- Build output ---"
+    cat "$BUILD_LOG"
+    rm -f "$BUILD_LOG"
+    exit 1
+  fi
+
+  echo "SUCCESS: 5.x installation correctly blocked when 4.x is installed"
+  rm -f "$BUILD_LOG"
+}
+
+# Reinstall test: assert 5.x install over 5.x succeeds (same-major reinstall)
+reinstall_test() {
+  if [[ $PACKAGE == *".deb" ]]; then
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg REINSTALL_5X=true -t "$CONTAINER_NAME" ./deb/
+    docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME"
+    check_metadata_deb
+  elif [[ $PACKAGE == *".rpm" ]]; then
+    docker build --build-arg PACKAGE="$PACKAGE" --build-arg REINSTALL_5X=true -t "$CONTAINER_NAME" ./rpm/
+    docker run -it --rm -d --name "$CONTAINER_NAME" "$CONTAINER_NAME"
+    check_metadata_rpm
+  else
+    echo "ERROR: $PACKAGE is not a valid package (valid packages are .deb and .rpm)"
+    exit 1
+  fi
+
+  echo "SUCCESS: 5.x reinstall over 5.x succeeded"
+  files_exist
+  check_opensearch_dashboard_yml
+}
+
 # Run test
 test() {
 
@@ -147,12 +209,15 @@ help() {
   echo "Usage: $0 [OPTIONS]"
   echo
   echo "    -p, --package <path>       Set Wazuh Dashboard rpm package name,which has to be in the <repository>/dev-tools/test-packages/<DISTRIBUTION>/ folder."
+  echo "    --negative                 Run negative test: assert 5.x install is blocked when 4.x is pre-installed."
+  echo "    --reinstall                Run reinstall test: assert 5.x reinstall over 5.x succeeds."
+  echo "    -h, --help                 Show this help."
   echo
   exit $1
 }
 
 main() {
-  while [ -n "${1}" ]; do
+  while [ $# -gt 0 ]; do
     case "${1}" in
     "-h" | "--help")
       help 0
@@ -165,6 +230,14 @@ main() {
         help 1
       fi
       ;;
+    "--negative")
+      NEGATIVE_TEST=true
+      shift
+      ;;
+    "--reinstall")
+      REINSTALL_TEST=true
+      shift
+      ;;
     *)
       help 1
       ;;
@@ -175,7 +248,18 @@ main() {
     help 1
   fi
 
-  test
+  if [ "$NEGATIVE_TEST" = true ] && [ "$REINSTALL_TEST" = true ]; then
+    echo "ERROR: --negative and --reinstall are mutually exclusive"
+    exit 1
+  fi
+
+  if [ "$NEGATIVE_TEST" = true ]; then
+    negative_test
+  elif [ "$REINSTALL_TEST" = true ]; then
+    reinstall_test
+  else
+    test
+  fi
 
   clean
 }


### PR DESCRIPTION
### Description

This PR adds pre-install version guards to RPM (%pre in .spec) and DEB (preinst script) that block Wazuh Dashboard 5.x installation when a pre-5.x version is detected on the system. Detection reads /usr/share/wazuh-dashboard/VERSION.json (written to disk by the installed package)

### Issues Resolved

IDR#4982

### Evidence

**RPM x64_86 job run:** 

https://github.com/wazuh/wazuh-dashboard/actions/runs/26954943607

<details><summary>

**Blocking if 4.x installation exists:**
</summary>
<p>

**VERSION.json (4.14.5)**
```bash
[root@centos8 vagrant]# yum localinstall -y wazuh-dashboard_5.0.0-0_x86_64_f88c74993c.rpm
Last metadata expiration check: 0:01:26 ago on Wed 03 Jun 2026 04:45:41 PM UTC.
Dependencies resolved.
==========================================================================================================================================================================================================================================================================
 Package                                                              Architecture                                                Version                                                         Repository                                                         Size
==========================================================================================================================================================================================================================================================================
Upgrading:
 wazuh-dashboard                                                      x86_64                                                      5.0.0-0                                                         @commandline                                                      368 M

Transaction Summary
==========================================================================================================================================================================================================================================================================
Upgrade  1 Package

Total size: 368 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                                                  1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
==============================================================
ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
is not supported.

Detected installed version: 4.14.5
A clean installation of Wazuh Dashboard 5.x is required.
==============================================================
error: %prein(wazuh-dashboard-5.0.0-0.x86_64) scriptlet failed, exit status 1

Error in PREIN scriptlet in rpm package wazuh-dashboard
  Verifying        : wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Verifying        : wazuh-dashboard-4.14.5-1.x86_64                                                                                                                                                                                                                  2/2

Failed:
  wazuh-dashboard-4.14.5-1.x86_64                                                                                                      wazuh-dashboard-5.0.0-0.x86_64

Error: Transaction failed
[root@centos8 vagrant]#
```

**VERSION (plain file)**
```bash
[root@centos8 vagrant]# yum localinstall -y wazuh-dashboard_5.0.0-0_x86_64_f88c74993c.rpm
CentOS Linux 8 - AppStream                                                                                                                                                                                                                 13 kB/s | 4.3 kB     00:00
CentOS Linux 8 - BaseOS                                                                                                                                                                                                                    33 kB/s | 3.9 kB     00:00
CentOS Linux 8 - Extras                                                                                                                                                                                                                    13 kB/s | 1.5 kB     00:00
Elasticsearch repository for 7.x packages                                                                                                                                                                                                 3.5 kB/s | 1.3 kB     00:00
Extra Packages for Enterprise Linux 8 - x86_64                                                                                                                                                                                             95 kB/s |  78 kB     00:00
Dependencies resolved.
==========================================================================================================================================================================================================================================================================
 Package                                                              Architecture                                                Version                                                         Repository                                                         Size
==========================================================================================================================================================================================================================================================================
Upgrading:
 wazuh-dashboard                                                      x86_64                                                      5.0.0-0                                                         @commandline                                                      368 M

Transaction Summary
==========================================================================================================================================================================================================================================================================
Upgrade  1 Package

Total size: 368 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                                                  1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
==============================================================
ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
is not supported.

Detected installed version: 4.5.4
A clean installation of Wazuh Dashboard 5.x is required.
==============================================================
error: %prein(wazuh-dashboard-5.0.0-0.x86_64) scriptlet failed, exit status 1

Error in PREIN scriptlet in rpm package wazuh-dashboard
  Verifying        : wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Verifying        : wazuh-dashboard-4.5.4-1.x86_64                                                                                                                                                                                                                   2/2

Failed:
  wazuh-dashboard-4.5.4-1.x86_64                                                                                                      wazuh-dashboard-5.0.0-0.x86_64

Error: Transaction failed
[root@centos8 vagrant]#
```
</p>
</details> 

<details><summary>

**Allow upgrade/downgrade when 5.x is installed**
</summary>
<p>

```bash
[root@centos8 vagrant]# yum localinstall -y wazuh-dashboard_5.0.0-0_x86_64_f88c74993c.rpm
Last metadata expiration check: 0:02:11 ago on Wed 03 Jun 2026 04:50:57 PM UTC.
Dependencies resolved.
==========================================================================================================================================================================================================================================================================
 Package                                                              Architecture                                                Version                                                         Repository                                                         Size
==========================================================================================================================================================================================================================================================================
Downgrading:
 wazuh-dashboard                                                      x86_64                                                      5.0.0-0                                                         @commandline                                                      368 M

Transaction Summary
==========================================================================================================================================================================================================================================================================
Downgrade  1 Package

Total size: 368 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                                                  1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Downgrading      : wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Running scriptlet: wazuh-dashboard-5.0.0-1.x86_64                                                                                                                                                                                                                   2/2
  Cleanup          : wazuh-dashboard-5.0.0-1.x86_64                                                                                                                                                                                                                   2/2
  Running scriptlet: wazuh-dashboard-5.0.0-1.x86_64                                                                                                                                                                                                                   2/2
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   2/2
  Running scriptlet: wazuh-dashboard-5.0.0-1.x86_64                                                                                                                                                                                                                   2/2
  Verifying        : wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Verifying        : wazuh-dashboard-5.0.0-1.x86_64                                                                                                                                                                                                                   2/2

Downgraded:
  wazuh-dashboard-5.0.0-0.x86_64

Complete!
[root@centos8 vagrant]#
```

</p>
</details> 

<details><summary>

**Block installation if version could not be determined**
</summary>
<p>

```bash
[root@centos8 vagrant]# yum localinstall -y wazuh-dashboard_5.0.0-0_x86_64_f88c74993c.rpm
Last metadata expiration check: 0:01:47 ago on Wed 03 Jun 2026 04:57:19 PM UTC.
Dependencies resolved.
==========================================================================================================================================================================================================================================================================
 Package                                                              Architecture                                                Version                                                         Repository                                                         Size
==========================================================================================================================================================================================================================================================================
Downgrading:
 wazuh-dashboard                                                      x86_64                                                      5.0.0-0                                                         @commandline                                                      368 M

Transaction Summary
==========================================================================================================================================================================================================================================================================
Downgrade  1 Package

Total size: 368 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                                                  1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/1
  Running scriptlet: wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
==============================================================
ERROR: A previous Wazuh installation was detected but the
installed version could not be determined.

A clean installation of Wazuh Dashboard 5.x is required.
Please remove the previous installation before proceeding.
==============================================================
error: %prein(wazuh-dashboard-5.0.0-0.x86_64) scriptlet failed, exit status 1

Error in PREIN scriptlet in rpm package wazuh-dashboard
  Verifying        : wazuh-dashboard-5.0.0-0.x86_64                                                                                                                                                                                                                   1/2
  Verifying        : wazuh-dashboard-5.0.0-1.x86_64                                                                                                                                                                                                                   2/2

Failed:
  wazuh-dashboard-5.0.0-0.x86_64                                                                                                      wazuh-dashboard-5.0.0-1.x86_64

Error: Transaction failed
[root@centos8 vagrant]#
```

</p>
</details> 

### Testing the changes

<details><summary>E2E Testing</summary>
<p>

**Prerequisites:** Build the 5.x DEB and RPM packages from this branch. Follow the provided packaging guide (`wazuh_custom_packages_guide_en.md`) to generate them before proceeding.

1. Create 2 Vagrant machines running the following OS:
   - Ubuntu 22.04 (or later)
   - CentOS 8 / Rocky Linux 8 / RHEL 8

2. In each VM install Wazuh Dashboard 4.14.5 following the official guide:
   https://documentation.wazuh.com/current/installation-guide/wazuh-dashboard/step-by-step.html

3. Verify that Wazuh Dashboard 4.14.5 is correctly installed:
   - **Ubuntu (DEB):**
     ```bash
     dpkg -s wazuh-dashboard | grep '^Version:'
     # Expected: Version: 4.14.5-1
     ```
   - **CentOS/RHEL (RPM):**
     ```bash
     rpm -q wazuh-dashboard
     # Expected: wazuh-dashboard-4.14.5-1.x86_64
     ```

4. Transfer the built 5.x package to the VM (e.g., via `vagrant upload` from your host).

5. Attempt to install/upgrade to Wazuh Dashboard 5.x. The installation **MUST be blocked** with the version guard error:

   - **Ubuntu (DEB):**
     ```bash
     dpkg -i wazuh-dashboard_5.0.0-0_amd64.deb
     ```
     **Expected output (stderr):**
     ```
     ==============================================================
     ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
     is not supported.

     Detected installed version: 4.14.5
     A clean installation of Wazuh Dashboard 5.x is required.
     ==============================================================
     dpkg: error processing package wazuh-dashboard (--install):
      installed wazuh-dashboard package pre-installation script subprocess returned error exit status 1
     ```

   - **CentOS/RHEL (RPM):**
     ```bash
     yum localinstall -y wazuh-dashboard-5.0.0-0.x86_64.rpm
     ```
     **Expected output (stderr):**
     ```
     ==============================================================
     ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
     is not supported.

     Detected installed version: 4.14.5
     A clean installation of Wazuh Dashboard 5.x is required.
     ==============================================================
     error: %pre(wazuh-dashboard-5.0.0-0.x86_64) scriptlet failed, exit status 1
     ```

6. Verify that Wazuh Dashboard 4.14.5 remains installed and intact after the failed upgrade attempt:
   - **Ubuntu (DEB):**
     ```bash
     dpkg -s wazuh-dashboard | grep '^Version:'
     # Expected: Version: 4.14.5-1
     ```
   - **CentOS/RHEL (RPM):**
     ```bash
     rpm -q wazuh-dashboard
     # Expected: wazuh-dashboard-4.14.5-1.x86_64
     ```

</p>
</details>

<details><summary>Unit testing via test-packages.sh (Docker):</summary>
<p>

All commands run from the repository root (`dev-tools/test-packages/`).

**Prerequisites:** Build the 5.x DEB and/or RPM packages from this branch. Follow the provided packaging guide (`wazuh_custom_packages_guide_en.md`) to generate them first.

Place the built package inside the corresponding subdirectory:
```bash
cp /path/to/wazuh-dashboard_5.0.0-0_amd64.deb  dev-tools/test-packages/deb/
cp /path/to/wazuh-dashboard-5.0.0-0.x86_64.rpm dev-tools/test-packages/rpm/
```

---

### 1. Integrity test

Verifies metadata, file ownership, and that the installed config matches the packaged one.

```bash
# DEB
bash dev-tools/test-packages/test-packages.sh \
  -p wazuh-dashboard_5.0.0-0_amd64.deb

# RPM
bash dev-tools/test-packages/test-packages.sh \
  -p wazuh-dashboard-5.0.0-0.x86_64.rpm
```

**Expected output:**
```
metadata version is correct: 5.0.0-0
metadata package is correct: wazuh-dashboard
metadata status is Status: install ok installed
/etc/wazuh-dashboard/opensearch_dashboards.yml exist and is owned by wazuh-dashboard
/usr/share/wazuh-dashboard exist and is owned by wazuh-dashboard
opensearch_dashboards.yml is the same as the one in the package
```

---

### 2. Block 4.x installation test

Simulates a pre-existing 4.14.5 installation and confirms 5.x is **blocked**.

```bash
# DEB
bash dev-tools/test-packages/test-packages.sh \
  --block-4x-install \
  -p wazuh-dashboard_5.0.0-0_amd64.deb

# RPM
bash dev-tools/test-packages/test-packages.sh \
  --block-4x-install \
  -p wazuh-dashboard-5.0.0-0.x86_64.rpm
```

**Expected output (first line is the version guard error extracted from the build log; second line is the test success message):**
```
  ERROR: Direct upgrade from Wazuh Dashboard versions prior to 5.x
SUCCESS: 5.x installation correctly blocked when 4.x is installed
```

---

### 3. Same-major reinstall test

Installs 5.x twice to confirm that reinstalling over the same major version is **allowed**.

```bash
# DEB
bash dev-tools/test-packages/test-packages.sh \
  --allow-same-major-reinstall \
  -p wazuh-dashboard_5.0.0-0_amd64.deb

# RPM
bash dev-tools/test-packages/test-packages.sh \
  --allow-same-major-reinstall \
  -p wazuh-dashboard-5.0.0-0.x86_64.rpm
```

**Expected output:**
```
metadata version is correct: 5.0.0-0
metadata package is correct: wazuh-dashboard
SUCCESS: 5.x reinstall over 5.x succeeded
/etc/wazuh-dashboard/opensearch_dashboards.yml exist and is owned by wazuh-dashboard
/usr/share/wazuh-dashboard exist and is owned by wazuh-dashboard
opensearch_dashboards.yml is the same as the one in the package
```
</p>
</details>

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
