### PR TITLE
Standardize Wazuh dashboard 5.x upgrade error message

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -609,8 +609,9 @@ jobs:
             exit 1
           fi
 
-          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh dashboard"; then
-            echo "Cross-major upgrade correctly blocked"
+          if echo "$OUTPUT" | grep -F -q "ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported."; then
+            echo "TEST: Cross-major upgrade correctly blocked"
+            echo "$OUTPUT"
           else
             echo "ERROR: Expected block message not found"
             echo "$OUTPUT"
@@ -753,8 +754,9 @@ jobs:
             exit 1
           fi
 
-          if echo "$OUTPUT" | grep -F -q "ERROR: Direct upgrade from Wazuh dashboard"; then
-            echo "Cross-major upgrade correctly blocked"
+          if echo "$OUTPUT" | grep -F -q "ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported."; then
+            echo "TEST: Cross-major upgrade correctly blocked"
+            echo "$OUTPUT"
           else
             echo "ERROR: Expected block message not found"
             echo "$OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed the default value of `metaFields` and `timepicker:timeDefaults` settings [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
 - Excluded Wazuh dashboards and visualizations listing [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278) [#1279](https://github.com/wazuh/wazuh-dashboard/pull/1279)
 - Changed log level of the cross compatibility service on start [#1330](https://github.com/wazuh/wazuh-dashboard/pull/1330)
+- Changed pre install scripts to block Wazuh dashboard installation if there's an existing installation prior to 5.x [#1328](https://github.com/wazuh/wazuh-dashboard/pull/1328) [#1365](https://github.com/wazuh/wazuh-dashboard/pull/1365)
 
 ## Wazuh dashboard v4.14.7 - OpenSearch Dashboards 2.19.5 - Revision 00
 

--- a/dev-tools/build-packages/deb/debian/preinst
+++ b/dev-tools/build-packages/deb/debian/preinst
@@ -16,6 +16,19 @@ set -e
 #   1. VERSION.json        — wazuh-dashboard 5.x+
 #   2. VERSION             — wazuh-dashboard 4.x (legacy file)
 #   3. plugin package.json — wazuh-dashboard 4.x+ (plugin metadata)
+print_upgrade_error() {
+    cat >&2 <<EOF
+==============================================================
+ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported.
+
+Detected installed version: ${1:-undetermined}
+
+A clean installation of Wazuh dashboard 5.x is required.
+Refer to the 5.x migration guide for more information.
+==============================================================
+EOF
+}
+
 if [ -f /usr/share/wazuh-dashboard/VERSION.json ]; then
     INSTALLED_VER=$(grep -m 1 '"version"' /usr/share/wazuh-dashboard/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 elif [ -f /usr/share/wazuh-dashboard/VERSION ]; then
@@ -27,30 +40,14 @@ fi
 if [ -n "$INSTALLED_VER" ]; then
     MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
     if [ "$MAJOR" -lt 5 ]; then
-        cat >&2 <<EOF
-==============================================================
-ERROR: Direct upgrade from Wazuh dashboard versions prior to 5.x
-is not supported.
-
-Detected installed version: $INSTALLED_VER
-A clean installation of Wazuh dashboard 5.x is required.
-==============================================================
-EOF
+        print_upgrade_error "$INSTALLED_VER"
         exit 1
     fi
 elif [ "$1" = "upgrade" ] && [ -d /usr/share/wazuh-dashboard/plugins ]; then
     # Upgrade requested but version could not be determined from any source.
     # Files may have been removed or corrupted. Block the upgrade; a fresh
     # install ($1=install) is still allowed.
-    cat >&2 <<EOF
-==============================================================
-ERROR: A previous Wazuh installation was detected but the
-installed version could not be determined.
-
-A clean installation of Wazuh dashboard 5.x is required.
-Please remove the previous installation before proceeding.
-==============================================================
-EOF
+    print_upgrade_error
     exit 1
 fi
 

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -109,6 +109,19 @@ find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 744 -exec chmod 740
 #   1. VERSION.json        — wazuh-dashboard 5.x+
 #   2. VERSION             — wazuh-dashboard 4.x (legacy file)
 #   3. plugin package.json — wazuh-dashboard 4.x+ (plugin metadata)
+print_upgrade_error() {
+    cat >&2 <<EOF
+==============================================================
+ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported.
+
+Detected installed version: ${1:-undetermined}
+
+A clean installation of Wazuh dashboard 5.x is required.
+Refer to the 5.x migration guide for more information.
+==============================================================
+EOF
+}
+
 if [ -f %{INSTALL_DIR}/VERSION.json ]; then
   INSTALLED_VER=$(grep -m 1 '"version"' %{INSTALL_DIR}/VERSION.json 2>/dev/null | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 elif [ -f %{INSTALL_DIR}/VERSION ]; then
@@ -120,30 +133,14 @@ fi
 if [ -n "$INSTALLED_VER" ]; then
   MAJOR=$(echo "$INSTALLED_VER" | cut -d. -f1)
   if [ "$MAJOR" -lt 5 ]; then
-    cat >&2 <<EOF
-==============================================================
-ERROR: Direct upgrade from Wazuh dashboard versions prior to 5.x
-is not supported.
-
-Detected installed version: $INSTALLED_VER
-A clean installation of Wazuh dashboard 5.x is required.
-==============================================================
-EOF
+    print_upgrade_error "$INSTALLED_VER"
     exit 1
   fi
 elif [ "$1" = "2" ] && [ -d %{INSTALL_DIR}/plugins ]; then
   # Upgrade requested but version could not be determined from any source.
   # Files may have been removed or corrupted. Block the upgrade; a fresh
   # install ($1=1) is still allowed.
-  cat >&2 <<EOF
-==============================================================
-ERROR: A previous Wazuh installation was detected but the
-installed version could not be determined.
-
-A clean installation of Wazuh dashboard 5.x is required.
-Please remove the previous installation before proceeding.
-==============================================================
-EOF
+  print_upgrade_error
   exit 1
 fi
 

--- a/dev-tools/test-packages/test-packages.sh
+++ b/dev-tools/test-packages/test-packages.sh
@@ -154,8 +154,8 @@ block_4x_install_test() {
     exit 1
   fi
 
-  if grep -F -q "ERROR: Direct upgrade from Wazuh dashboard" "$BUILD_LOG"; then
-    BLOCK_MSG=$(grep -F 'ERROR: Direct upgrade from Wazuh dashboard' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+  if grep -F -q "ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported." "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported.' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
     echo "  $BLOCK_MSG"
   else
     echo "ERROR: Expected error message not found in build output"
@@ -195,8 +195,8 @@ block_unknown_install_test() {
     exit 1
   fi
 
-  if grep -F -q "version could not be determined" "$BUILD_LOG"; then
-    BLOCK_MSG=$(grep -F 'version could not be determined' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
+  if grep -F -q "Detected installed version: undetermined" "$BUILD_LOG"; then
+    BLOCK_MSG=$(grep -F 'Detected installed version: undetermined' "$BUILD_LOG" | head -1 | sed 's/^ *#[0-9]* *[0-9.]* *//')
     echo "  $BLOCK_MSG"
   else
     echo "ERROR: Expected error message not found in build output"


### PR DESCRIPTION
### Description

This PR standarizes the upgrade error message for Wazuh dashboard.

### Issues Resolved

- **Closes:** IDR 5235

### Evidence

- **Github action run**: https://github.com/wazuh/wazuh-dashboard/actions/runs/27638914901 (In queue due to GH major incident)

### Testing

#### With existing VERSION.json

1. Build a Wazuh Dashboard package locally from this branch.
2. Run a vagrant box and install Wazuh 4.14.5 using the [quickstart docs](https://documentation.wazuh.com/current/quickstart.html).
3. Upload the previously built package to your vagrant box and attempt to install it.
4. Verify that the error message is the following:

```bash
==============================================================
ERROR: Upgrade from Wazuh dashboard versions prior to 5.x is not supported.

Detected installed version: 4.14.5

A clean installation of Wazuh dashboard 5.x is required.
Refer to the 5.x migration guide for more information.
==============================================================
```  

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
