### PR TITLE
Fix miscalculation on healthcheck tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 5.0.0
-- Health check service [#811](https://github.com/wazuh/wazuh-dashboard/pull/811) [#866](https://github.com/wazuh/wazuh-dashboard/pull/866) [#961](https://github.com/wazuh/wazuh-dashboard/pull/961) [#1031](https://github.com/wazuh/wazuh-dashboard/pull/1031) [#1179](https://github.com/wazuh/wazuh-dashboard/pull/1179)
-- Added Health Check plugin [#870](https://github.com/wazuh/wazuh-dashboard/pull/870) [#946](https://github.com/wazuh/wazuh-dashboard/pull/946)
+- Health check service [#811](https://github.com/wazuh/wazuh-dashboard/pull/811) [#866](https://github.com/wazuh/wazuh-dashboard/pull/866) [#961](https://github.com/wazuh/wazuh-dashboard/pull/961) [#1031](https://github.com/wazuh/wazuh-dashboard/pull/1031) [#1179](https://github.com/wazuh/wazuh-dashboard/pull/1179) [#1366](https://github.com/wazuh/wazuh-dashboard/pull/1366)
+- Added Health Check app [#870](https://github.com/wazuh/wazuh-dashboard/pull/870) [#946](https://github.com/wazuh/wazuh-dashboard/pull/946) [#1366](https://github.com/wazuh/wazuh-dashboard/pull/1366)
 - Added manager host configuration for the default configuration file [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
 - Set v9 theme as default [#1092](https://github.com/wazuh/wazuh-dashboard/pull/1092)
 

--- a/src/core/common/healthcheck/types.ts
+++ b/src/core/common/healthcheck/types.ts
@@ -12,7 +12,7 @@ export interface TaskInfo {
   createdAt: string | null;
   startedAt: string | null;
   finishedAt: string | null;
-  duration: number | null; // seconds
+  duration: number | null; // milliseconds
   data: any;
   error: string | null;
   enabled: boolean;

--- a/src/core/server/healthcheck/healthcheck/README.md
+++ b/src/core/server/healthcheck/healthcheck/README.md
@@ -167,7 +167,7 @@ interface InitializationTaskRunData {
   createdAt: string | null;
   startedAt: string | null;
   finishedAt: string | null;
-  duration: number | null; // seconds
+  duration: number | null; // milliseconds
   data: any;
   error: string | null;
   enabled: boolean;
@@ -270,7 +270,7 @@ The UI allows exporting the checks to a JSON file to be shared easily.
       "createdAt": "2025-08-08T10:04:59.428Z",
       "startedAt": "2025-08-08T10:19:59.858Z",
       "finishedAt": "2025-08-08T10:19:59.948Z",
-      "duration": 0.09,
+      "duration": 90,
       "error": null,
       "enabled": true,
       "critical": true,
@@ -294,7 +294,7 @@ The UI allows exporting the checks to a JSON file to be shared easily.
       "createdAt": "2025-08-08T10:04:59.428Z",
       "startedAt": "2025-08-08T10:19:59.858Z",
       "finishedAt": "2025-08-08T10:19:59.948Z",
-      "duration": 0.09,
+      "duration": 90,
       "error": null,
       "enabled": true,
       "critical": true,

--- a/src/core/server/healthcheck/healthcheck/dashboard_server_is_not_ready_yet/client/script.js
+++ b/src/core/server/healthcheck/healthcheck/dashboard_server_is_not_ready_yet/client/script.js
@@ -673,7 +673,7 @@ class Components {
    * @returns
    */
   static checkCriticalItem(task) {
-    const created = formatDateTime(task.createdAt);
+    const created = formatDateTime(task.startedAt);
     const finished = formatDateTime(task.finishedAt);
     const duration = formatDuration(task.duration);
     return /* html */ `
@@ -715,7 +715,7 @@ class Components {
     return /* html */ `
       <div class="noncritical-list" role="list">
         ${$map(tasks, (task) => {
-          const created = formatDateTime(task.createdAt);
+          const created = formatDateTime(task.startedAt);
           const finished = formatDateTime(task.finishedAt);
           const duration = formatDuration(task.duration);
           return /* html */ `

--- a/src/core/server/healthcheck/healthcheck/dashboard_server_is_not_ready_yet/client/script.js
+++ b/src/core/server/healthcheck/healthcheck/dashboard_server_is_not_ready_yet/client/script.js
@@ -433,6 +433,7 @@ function formatDateTime(value) {
 }
 
 /**
+ * !This function is duplicated on src/plugins/healthcheck/public/components/table/check_flyout.tsx
  * Format duration in milliseconds to a compact human string
  * @param {number | undefined} ms
  */

--- a/src/core/server/healthcheck/task/task.ts
+++ b/src/core/server/healthcheck/task/task.ts
@@ -65,7 +65,7 @@ export class Task implements ITask {
       const dateStartedAt = new Date(this.startedAt as string);
       const dateFinishedAt = new Date(this.finishedAt);
 
-      this.duration = ((dateFinishedAt.getTime() - dateStartedAt.getTime()) as number);
+      this.duration = (dateFinishedAt.getTime() - dateStartedAt.getTime()) as number;
     }
 
     if (error) {

--- a/src/core/server/healthcheck/task/task.ts
+++ b/src/core/server/healthcheck/task/task.ts
@@ -65,7 +65,7 @@ export class Task implements ITask {
       const dateStartedAt = new Date(this.startedAt as string);
       const dateFinishedAt = new Date(this.finishedAt);
 
-      this.duration = ((dateFinishedAt.getTime() - dateStartedAt.getTime()) as number) / 1000;
+      this.duration = ((dateFinishedAt.getTime() - dateStartedAt.getTime()) as number);
     }
 
     if (error) {

--- a/src/plugins/healthcheck/public/components/table/check_flyout.tsx
+++ b/src/plugins/healthcheck/public/components/table/check_flyout.tsx
@@ -22,6 +22,27 @@ import { TaskInfo } from '../../../../../core/common/healthcheck';
 import { mapTaskStatusToHealthColor } from '../services/health';
 import { BadgeResults } from '../utils/badge_results';
 
+/**
+ * !This function is duplicated on src/core/server/healthcheck/healthcheck/dashboard_server_is_not_ready_yet/client/script.js
+ * Format duration in milliseconds to a compact human string
+ * @param {number | undefined} ms
+ */
+function formatDuration(ms: number) {
+  if (ms == null || isNaN(ms)) return '';
+  const totalMs = Math.max(0, Math.floor(ms));
+  const s = Math.floor(totalMs / 1000);
+  const msR = totalMs % 1000;
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const parts = [];
+  if (h) parts.push(`${h}h`);
+  if (m) parts.push(`${m}m`);
+  if (sec || (!h && !m)) parts.push(`${sec}s`);
+  if (!h && !m && msR) parts.push(`${msR}ms`);
+  return parts.join(' ');
+}
+
 interface CheckFlyoutProps {
   check: TaskInfo;
   formatDate: (date: string) => string;
@@ -171,7 +192,7 @@ export const CheckFlyout = ({ check, formatDate, setIsFlyoutVisible }: CheckFlyo
                 />
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription>
-                <p>{duration ? `${duration}s` : '-'}</p>
+                <p>{duration ? `${formatDuration(duration)}` : '-'}</p>
               </EuiDescriptionListDescription>
             </EuiDescriptionList>
           </EuiFlexItem>


### PR DESCRIPTION
### Description
This PR fixes the calculation of the duration of the tasks during the healthcheck process. It was a unit mismatch, so the solution was to change seconds by milliseconds to align with the format function.

`duration` is now used in milliseconds and shown properly in the UI. In the request it will be on milliseconds.

### Issues Resolved

#1358 

### Evidence

<img width="1861" height="621" alt="evidence1" src="https://github.com/user-attachments/assets/75d46d49-69de-4b04-84d3-56fe85693d0c" />

https://github.com/user-attachments/assets/0e3d0b29-cd43-4327-ab30-0a40f167e1bc

<img width="1224" height="888" alt="imagen" src="https://github.com/user-attachments/assets/0f96e97e-2bde-4e4d-a9fb-771f874a5666" />

### Tests

- Launch dashboard using `--base` parameter with the repo on the branch.
- Use `yarn start --no-base-path` and then reload until you can see the healtcheck window with the server:api-run_as info.
- Validate that all the fields (`startedAt`, `finishedAt` and `duration`) are the same as the request. 
- Navigate to `Dashboard management > Healthcheck` and verify that the `duration` that renders on the detail flyout for the tasks has the same format.

#### Additional

- Test shown in evidence was done adding the following code:

```
      await new Promise(resolve => setTimeout(resolve, 2000));
``` 

Add it to `wazuh-dashboard-plugins/plugins/main/server/health-check/server-api.ts` line 190, that way it takes a couple of seconds more and the difference is more clear.

### Check List

- [x] Commits are signed per the DCO using --signoff
