### PR TITLE
Migrate dashboard package-building workflow runners to AWS CodeBuild

### DIFF
--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -242,7 +242,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/4_builderpackage_dashboard_core.yml@4.14.6
+    uses: wazuh/wazuh-dashboard/.github/workflows/4_builderpackage_dashboard_core.yml@change/5246-4.14.6-migrate-github-runners-to-aws-runners
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -252,7 +252,7 @@ jobs:
     name: Build plugins
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/4_builderpackage_plugins.yml@4.14.6
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/4_builderpackage_plugins.yml@change/5246-4.14.6-migrate-github-runners-to-aws-runners
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
@@ -261,7 +261,7 @@ jobs:
     name: Build security plugin
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/4_builderpackage_security_plugin.yml@4.14.6
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/4_builderpackage_security_plugin.yml@change/5246-4.14.6-migrate-github-runners-to-aws-runners
     with:
       reference: ${{ inputs.reference_security_plugins }}
 

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -397,74 +397,19 @@ jobs:
       - name: DEB - Test package install/uninstall
         if: ${{ inputs.system == 'deb' }}
         run: |
-          sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
-            echo "Package installed"
-          else
-            echo "Package not installed"
-            exit 1
-          fi
-          # Workaround: AWS CodeBuild runners do not use systemd as PID 1
-          if [ -d /run/systemd/system ]; then
-            sudo systemctl daemon-reload
-            sudo systemctl enable wazuh-dashboard
-            sudo systemctl start wazuh-dashboard
-            if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
-              echo "Service running"
-            else
-              echo "Service not running"
-              exit 1
-            fi
-          else
-            echo "Skipping service start — systemd not available in this environment"
-          fi
-          sudo apt-get remove --purge wazuh-dashboard -y
-          if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
-            echo "Package not uninstalled"
-            exit 1
-          else
-            echo "Package uninstalled"
-          fi
+          bash ${{ github.workspace }}/dev-tools/test-packages/run_in_systemd_container.sh \
+            "${{ github.workspace }}" \
+            "bash /test-packages/deb-test-install-uninstall.sh '${{needs.setup-variables.outputs.PACKAGE_NAME}}'"
 
       - name: DEB - Test package upgrade
         if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'deb' }}
         run: |
-          sudo apt-get install debhelper tar curl libcap2-bin #debhelper version 9 or later
-          sudo apt-get install gnupg apt-transport-https
-          sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
-          sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
-          sudo apt-get update
-          sudo apt-get -y install wazuh-dashboard=${{needs.setup-variables.outputs.PREVIOUS}}
-          # Workaround: AWS CodeBuild runners do not use systemd as PID 1
-          if [ -d /run/systemd/system ]; then
-            sudo systemctl daemon-reload
-            sudo systemctl enable wazuh-dashboard
-            sudo systemctl start wazuh-dashboard
-          else
-            echo "Skipping service start — systemd not available in this environment"
-          fi
-          sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          if [ -d /run/systemd/system ]; then
-            sudo systemctl restart wazuh-dashboard
-          fi
-
-          if dpkg -s wazuh-dashboard | grep '^Version:' | grep -q "${{needs.setup-variables.outputs.VERSION}}"; then
-            echo "Package upgraded"
-          else
-            echo "Package not upgraded"
-            exit 1
-          fi
-
-          if [ -d /run/systemd/system ]; then
-            if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
-              echo "Service running"
-            else
-              echo "Service not running"
-              exit 1
-            fi
-          else
-            echo "Skipping service status check — systemd not available in this environment"
-          fi
+          bash ${{ github.workspace }}/dev-tools/test-packages/run_in_systemd_container.sh \
+            "${{ github.workspace }}" \
+            "bash /test-packages/deb-test-upgrade.sh \
+              '${{needs.setup-variables.outputs.PACKAGE_NAME}}' \
+              '${{needs.setup-variables.outputs.PREVIOUS}}' \
+              '${{needs.setup-variables.outputs.VERSION}}'"
 
       - name: RPM - Clone automation repo
         if: ${{ inputs.system == 'rpm' }}

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -113,7 +113,6 @@ jobs:
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     name: Setup variables
     outputs:
-      CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
       VERSION: ${{ steps.setup-variables.outputs.VERSION }}
       PREVIOUS: ${{ steps.setup-variables.outputs.PREVIOUS }}
       REVISION: ${{ steps.setup-variables.outputs.REVISION }}
@@ -154,7 +153,6 @@ jobs:
       - name: Setup variables
         id: setup-variables
         run: |
-          CURRENT_DIR=$(pwd -P)
           VERSION=$(jq -r '.version' VERSION.json)
           # Check the corresponding previous version to be used in the upgrade test
           sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
@@ -203,7 +201,6 @@ jobs:
           else
             ARCHITECTURE_FLAG=--arm
           fi
-          echo "CURRENT_DIR=$CURRENT_DIR" >> $GITHUB_OUTPUT
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "PREVIOUS=$PREVIOUS" >> $GITHUB_OUTPUT
           echo "REVISION=$REVISION" >> $GITHUB_OUTPUT
@@ -286,44 +283,44 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/dashboard
+          path: ${{ github.workspace }}/artifacts/dashboard
 
       - name: Download security plugin artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_SECURITY_PLUGIN }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-plugin
+          path: ${{ github.workspace }}/artifacts/security-plugin
 
       - name: Download main plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_WAZUH }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
+          path: ${{ github.workspace }}/artifacts/plugins
       - name: Download core plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CORE }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
+          path: ${{ github.workspace }}/artifacts/plugins
       - name: Download check update plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
+          path: ${{ github.workspace }}/artifacts/plugins
 
       - name: Zip plugins
         run: |
-          zip -r -j ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/wazuh-package.zip ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
-          zip -r -j ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-package.zip ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-plugin
-          zip -r -j ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/dashboard-package.zip ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/dashboard/${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
+          zip -r -j ${{ github.workspace }}/artifacts/wazuh-package.zip ${{ github.workspace }}/artifacts/plugins
+          zip -r -j ${{ github.workspace }}/artifacts/security-package.zip ${{ github.workspace }}/artifacts/security-plugin
+          zip -r -j ${{ github.workspace }}/artifacts/dashboard-package.zip ${{ github.workspace }}/artifacts/dashboard/${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
 
       - name: Build package
         run: |
-          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages
+          cd ${{ github.workspace }}/dev-tools/build-packages
           bash ./build-packages.sh \
             -r ${{ inputs.revision }} ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG }} \
-            -a file://${{needs.setup-variables.outputs.CURRENT_DIR}}/artifacts/wazuh-package.zip \
-            -s file://${{needs.setup-variables.outputs.CURRENT_DIR}}/artifacts/security-package.zip \
-            -b file://${{needs.setup-variables.outputs.CURRENT_DIR}}/artifacts/dashboard-package.zip \
+            -a file://${{ github.workspace }}/artifacts/wazuh-package.zip \
+            -s file://${{ github.workspace }}/artifacts/security-package.zip \
+            -b file://${{ github.workspace }}/artifacts/dashboard-package.zip \
             --commit-sha ${{needs.setup-variables.outputs.COMMIT_SHA}}-${{needs.setup-variables.outputs.PLUGINS_SHA}}-${{needs.setup-variables.outputs.SECURITY_SHA}} \
             --${{ inputs.system }} ${{ needs.setup-variables.outputs.PRODUCTION }} --debug
 
@@ -332,7 +329,7 @@ jobs:
         if: success()
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}
+          path: ${{ github.workspace }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}
           retention-days: 30
           overwrite: true
 
@@ -341,7 +338,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512
+          path: ${{ github.workspace }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512
           retention-days: 30
           overwrite: true
 
@@ -359,19 +356,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
+          path: ${{ github.workspace }}/dev-tools/test-packages
 
       - name: Test package integrity
         run: |
-          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
-          cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}}  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{ inputs.system }}
+          cd ${{ github.workspace }}/dev-tools/test-packages
+          cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}}  ${{ github.workspace }}/dev-tools/test-packages/${{ inputs.system }}
           bash ./test-packages.sh \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
       - name: DEB - Test package install/uninstall
         if: ${{ inputs.system == 'deb' }}
         run: |
-          sudo dpkg -i ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
+          sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
           if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
             echo "Package installed"
           else
@@ -407,7 +404,7 @@ jobs:
           sudo  systemctl daemon-reload
           sudo  systemctl enable wazuh-dashboard
           sudo  systemctl start wazuh-dashboard
-          sudo dpkg -i ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
+          sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
           sudo systemctl restart wazuh-dashboard
 
           if dpkg -s wazuh-dashboard | grep '^Version:' | grep -q "${{needs.setup-variables.outputs.VERSION}}"; then
@@ -471,7 +468,7 @@ jobs:
         run: |
           # echo 'Installing package...' is necessary to init the ssh connection prior to running scp
           ${{ steps.setup_rpm_env.outputs.ssh_command }} "echo 'Installing package...'"
-          ${{ steps.setup_rpm_env.outputs.scp_command }} ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
+          ${{ steps.setup_rpm_env.outputs.scp_command }} ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
 
           ${{ steps.setup_rpm_env.outputs.ssh_command }} "sudo rpm -i ./${{needs.setup-variables.outputs.PACKAGE_NAME}}; \
               if rpm -q wazuh-dashboard &>/dev/null; then \

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -110,7 +110,7 @@ permissions:
 
 jobs:
   setup-variables:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     name: Setup variables
     outputs:
       CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
@@ -220,7 +220,7 @@ jobs:
           echo "ARCHITECTURE_FLAG=$ARCHITECTURE_FLAG" >> $GITHUB_OUTPUT
 
   validate-job:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: setup-variables
     name: Validate inputs
     steps:
@@ -270,7 +270,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' }}
     name: Generate packages
     steps:
       - name: Checkout code
@@ -347,7 +347,7 @@ jobs:
 
   test-package:
     needs: [setup-variables, build-package]
-    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
+    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' }}
     strategy:
       fail-fast: false
     name: Test package
@@ -539,7 +539,7 @@ jobs:
 
   upload-package:
     needs: [setup-variables, test-package]
-    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' }}
     name: Upload package
     steps:
       - name: Set up AWS CLI

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -307,6 +307,7 @@ jobs:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
           path: ${{ github.workspace }}/artifacts/plugins
 
+      # Workaround: AWS CodeBuild ARM runners do not have zip pre-installed
       - name: Install zip
         if: ${{ inputs.architecture == 'arm64' || inputs.architecture == 'aarch64' }}
         run: sudo apt-get update && sudo apt-get install -y zip
@@ -417,6 +418,12 @@ jobs:
           username: 'wazuh-devel-xdrsiem-dashboard'
         run: |
           git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
+          # Workaround: AWS CodeBuild ARM runners do not have pip3 or openssh-client pre-installed
+          if ! command -v pip3 &>/dev/null || ! command -v ssh &>/dev/null; then
+            sudo apt-get update
+            command -v pip3 &>/dev/null || sudo apt-get install -y python3-pip
+            command -v ssh &>/dev/null || sudo apt-get install -y openssh-client
+          fi
           cd wazuh-automation
           pip3 install -r deployability/deps/requirements.txt
 

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -242,7 +242,7 @@ jobs:
   build-base:
     needs: [validate-job]
     name: Build dashboard
-    uses: wazuh/wazuh-dashboard/.github/workflows/4_builderpackage_dashboard_core.yml@change/5246-4.14.6-migrate-github-runners-to-aws-runners
+    uses: wazuh/wazuh-dashboard/.github/workflows/4_builderpackage_dashboard_core.yml@4.14.6
     with:
       CHECKOUT_TO: ${{ github.head_ref || github.ref_name }}
       ARCHITECTURE: ${{ inputs.architecture }}
@@ -252,7 +252,7 @@ jobs:
     name: Build plugins
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/4_builderpackage_plugins.yml@change/5246-4.14.6-migrate-github-runners-to-aws-runners
+    uses: wazuh/wazuh-dashboard-plugins/.github/workflows/4_builderpackage_plugins.yml@4.14.6
     with:
       reference: ${{ inputs.reference_wazuh_plugins }}
 
@@ -261,7 +261,7 @@ jobs:
     name: Build security plugin
     permissions:
       pull-requests: write
-    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/4_builderpackage_security_plugin.yml@change/5246-4.14.6-migrate-github-runners-to-aws-runners
+    uses: wazuh/wazuh-security-dashboards-plugin/.github/workflows/4_builderpackage_security_plugin.yml@4.14.6
     with:
       reference: ${{ inputs.reference_security_plugins }}
 

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -307,11 +307,28 @@ jobs:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
           path: ${{ github.workspace }}/artifacts/plugins
 
+      - name: Install zip
+        if: ${{ inputs.architecture == 'arm64' || inputs.architecture == 'aarch64' }}
+        run: sudo apt-get update && sudo apt-get install -y zip
+
       - name: Zip plugins
         run: |
           zip -r -j ${{ github.workspace }}/artifacts/wazuh-package.zip ${{ github.workspace }}/artifacts/plugins
           zip -r -j ${{ github.workspace }}/artifacts/security-package.zip ${{ github.workspace }}/artifacts/security-plugin
           zip -r -j ${{ github.workspace }}/artifacts/dashboard-package.zip ${{ github.workspace }}/artifacts/dashboard/${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
+
+      # Workaround: AWS CodeBuild runners hit Docker Hub anonymous pull rate limits
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Docker daemon
+        if: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' }}
+        run: |
+          sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+          timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
 
       - name: Build package
         run: |
@@ -357,6 +374,18 @@ jobs:
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}
           path: ${{ github.workspace }}/dev-tools/test-packages
+
+      # Workaround: AWS CodeBuild runners hit Docker Hub anonymous pull rate limits
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Docker daemon
+        run: |
+          sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+          timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
 
       - name: Test package integrity
         run: |

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -404,14 +404,19 @@ jobs:
             echo "Package not installed"
             exit 1
           fi
-          sudo  systemctl daemon-reload
-          sudo  systemctl enable wazuh-dashboard
-          sudo  systemctl start wazuh-dashboard
-          if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
-            echo "Service running"
+          # Workaround: AWS CodeBuild runners do not use systemd as PID 1
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl daemon-reload
+            sudo systemctl enable wazuh-dashboard
+            sudo systemctl start wazuh-dashboard
+            if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
+              echo "Service running"
+            else
+              echo "Service not running"
+              exit 1
+            fi
           else
-            echo "Service not running"
-            exit 1
+            echo "Skipping service start — systemd not available in this environment"
           fi
           sudo apt-get remove --purge wazuh-dashboard -y
           if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
@@ -430,11 +435,18 @@ jobs:
           sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
           sudo apt-get update
           sudo apt-get -y install wazuh-dashboard=${{needs.setup-variables.outputs.PREVIOUS}}
-          sudo  systemctl daemon-reload
-          sudo  systemctl enable wazuh-dashboard
-          sudo  systemctl start wazuh-dashboard
+          # Workaround: AWS CodeBuild runners do not use systemd as PID 1
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl daemon-reload
+            sudo systemctl enable wazuh-dashboard
+            sudo systemctl start wazuh-dashboard
+          else
+            echo "Skipping service start — systemd not available in this environment"
+          fi
           sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          sudo systemctl restart wazuh-dashboard
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl restart wazuh-dashboard
+          fi
 
           if dpkg -s wazuh-dashboard | grep '^Version:' | grep -q "${{needs.setup-variables.outputs.VERSION}}"; then
             echo "Package upgraded"
@@ -443,11 +455,15 @@ jobs:
             exit 1
           fi
 
-          if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
-            echo "Service running"
+          if [ -d /run/systemd/system ]; then
+            if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
+              echo "Service running"
+            else
+              echo "Service not running"
+              exit 1
+            fi
           else
-            echo "Service not running"
-            exit 1
+            echo "Skipping service status check — systemd not available in this environment"
           fi
 
       - name: RPM - Clone automation repo

--- a/.github/workflows/4_builderpackage_dashboard.yml
+++ b/.github/workflows/4_builderpackage_dashboard.yml
@@ -270,7 +270,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-dashboard-amd-{0}-{1}', github.run_id, github.run_attempt) }}
     name: Generate packages
     steps:
       - name: Checkout code
@@ -347,7 +347,7 @@ jobs:
 
   test-package:
     needs: [setup-variables, build-package]
-    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' }}
+    runs-on: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' && format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-dashboard-amd-{0}-{1}', github.run_id, github.run_attempt) }}
     strategy:
       fail-fast: false
     name: Test package
@@ -539,7 +539,7 @@ jobs:
 
   upload-package:
     needs: [setup-variables, test-package]
-    runs-on: ${{ inputs.architecture == 'arm64' && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-dashboard-amd-{0}-{1}', github.run_id, github.run_attempt) }}
     name: Upload package
     steps:
       - name: Set up AWS CLI

--- a/.github/workflows/4_builderpackage_dashboard_core.yml
+++ b/.github/workflows/4_builderpackage_dashboard_core.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && format('codebuild-github-actions-codebuild-runner-dashboard-amd-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) }}
     name: Build
     defaults:
       run:
@@ -88,11 +88,18 @@ jobs:
         run: |
           echo "ARTIFACT_BUILD_NAME=wazuh-dashboard_${{ env.WZD_VERSION }}-${{ env.WZD_REVISION }}_${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'x64' || 'arm64' }}.${{ matrix.DISTRIBUTION }}" >> $GITHUB_ENV
 
+      - name: Create non-root build user
+        run: |
+          useradd -m builduser
+          chown -R builduser:builduser .
+
       - name: Run bootstrap
-        run: yarn osd bootstrap
+        run: |
+          chown -R builduser:builduser "$YARN_CACHE_LOCATION" 2>/dev/null || true
+          sudo -u builduser -H env PATH="$PATH" yarn osd bootstrap
 
       - name: Build
-        run: yarn build-platform --${{(inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'linux' || 'linux-arm'}} --skip-os-packages --release
+        run: sudo -u builduser -H env PATH="$PATH" yarn build-platform --${{(inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'linux' || 'linux-arm'}} --skip-os-packages --release
 
       - name: Rename artifact
         run: mv /home/runner/work/wazuh-dashboard/wazuh-dashboard/artifacts/target/opensearch-dashboards-${{ env.VERSION }}-linux-${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'x64' || 'arm64' }}.${{ matrix.DISTRIBUTION }} /home/runner/work/wazuh-dashboard/wazuh-dashboard/artifacts/target/${{ env.ARTIFACT_BUILD_NAME }}

--- a/.github/workflows/4_builderpackage_dashboard_core.yml
+++ b/.github/workflows/4_builderpackage_dashboard_core.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'wz-linux-amd64' || 'wz-linux-arm64' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}' || 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' }}
     name: Build
     defaults:
       run:

--- a/.github/workflows/4_builderpackage_dashboard_core.yml
+++ b/.github/workflows/4_builderpackage_dashboard_core.yml
@@ -102,7 +102,7 @@ jobs:
         run: sudo -u builduser -H env PATH="$PATH" yarn build-platform --${{(inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'linux' || 'linux-arm'}} --skip-os-packages --release
 
       - name: Rename artifact
-        run: mv /home/runner/work/wazuh-dashboard/wazuh-dashboard/artifacts/target/opensearch-dashboards-${{ env.VERSION }}-linux-${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'x64' || 'arm64' }}.${{ matrix.DISTRIBUTION }} /home/runner/work/wazuh-dashboard/wazuh-dashboard/artifacts/target/${{ env.ARTIFACT_BUILD_NAME }}
+        run: mv target/opensearch-dashboards-${{ env.VERSION }}-linux-${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'x64' || 'arm64' }}.${{ matrix.DISTRIBUTION }} target/${{ env.ARTIFACT_BUILD_NAME }}
 
       - uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) }}
     name: Build
     defaults:
       run:

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || 'wz-linux-arm64' }}
+    runs-on: ${{ (inputs.ARCHITECTURE == 'x86_64' || inputs.ARCHITECTURE == 'amd64') && 'ubuntu-latest' || 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' }}
     name: Build
     defaults:
       run:

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -252,7 +252,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-22.04' }}
     name: Generate packages
     steps:
       - name: Checkout code

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -252,7 +252,7 @@ jobs:
 
   build-package:
     needs: [setup-variables, build-main-plugins, build-base, build-security-plugin]
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'codebuild-github-actions-codebuild-runner-dashboard-arm-${{ github.run_id }}-${{ github.run_attempt }}' || 'ubuntu-22.04' }}
     name: Generate packages
     steps:
       - name: Checkout code

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -289,11 +289,28 @@ jobs:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
           path: ${{ github.workspace }}/artifacts/plugins
 
+      - name: Install zip
+        if: ${{ inputs.architecture == 'arm64' || inputs.architecture == 'aarch64' }}
+        run: sudo apt-get update && sudo apt-get install -y zip
+
       - name: Zip plugins
         run: |
           zip -r -j ${{ github.workspace }}/artifacts/wazuh-package.zip ${{ github.workspace }}/artifacts/plugins
           zip -r -j ${{ github.workspace }}/artifacts/security-package.zip ${{ github.workspace }}/artifacts/security-plugin
           zip -r -j ${{ github.workspace }}/artifacts/dashboard-package.zip ${{ github.workspace }}/artifacts/dashboard/${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
+
+      # Workaround: AWS CodeBuild runners hit Docker Hub anonymous pull rate limits
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Docker daemon
+        if: ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG == '--arm' }}
+        run: |
+          sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+          timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
 
       - name: Build package
         run: |
@@ -339,6 +356,18 @@ jobs:
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}
           path: ${{ github.workspace }}/dev-tools/test-packages
+
+      # Workaround: AWS CodeBuild runners hit Docker Hub anonymous pull rate limits
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Docker daemon
+        run: |
+          sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+          timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
 
       - name: Test package integrity
         run: |

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -95,7 +95,6 @@ jobs:
     runs-on: ubuntu-24.04
     name: Setup variables
     outputs:
-      CURRENT_DIR: ${{ steps.setup-variables.outputs.CURRENT_DIR }}
       VERSION: ${{ steps.setup-variables.outputs.VERSION }}
       PREVIOUS: ${{ steps.setup-variables.outputs.PREVIOUS }}
       REVISION: ${{ steps.setup-variables.outputs.REVISION }}
@@ -136,7 +135,6 @@ jobs:
       - name: Setup variables
         id: setup-variables
         run: |
-          CURRENT_DIR=$(pwd -P)
           VERSION=$(jq -r '.version' VERSION.json)
           # Check the corresponding previous version to be used in the upgrade test
           sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
@@ -185,7 +183,6 @@ jobs:
           else
             ARCHITECTURE_FLAG=--arm
           fi
-          echo "CURRENT_DIR=$CURRENT_DIR" >> $GITHUB_OUTPUT
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "PREVIOUS=$PREVIOUS" >> $GITHUB_OUTPUT
           echo "REVISION=$REVISION" >> $GITHUB_OUTPUT
@@ -268,44 +265,44 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/dashboard
+          path: ${{ github.workspace }}/artifacts/dashboard
 
       - name: Download security plugin artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_SECURITY_PLUGIN }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-plugin
+          path: ${{ github.workspace }}/artifacts/security-plugin
 
       - name: Download main plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_WAZUH }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
+          path: ${{ github.workspace }}/artifacts/plugins
       - name: Download core plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CORE }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
+          path: ${{ github.workspace }}/artifacts/plugins
       - name: Download check update plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.setup-variables.outputs.WAZUH_PLUGINS_CHECK_UPDATES }}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
+          path: ${{ github.workspace }}/artifacts/plugins
 
       - name: Zip plugins
         run: |
-          zip -r -j ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/wazuh-package.zip ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/plugins
-          zip -r -j ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-package.zip ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/security-plugin
-          zip -r -j ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/dashboard-package.zip ${{ needs.setup-variables.outputs.CURRENT_DIR }}/artifacts/dashboard/${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
+          zip -r -j ${{ github.workspace }}/artifacts/wazuh-package.zip ${{ github.workspace }}/artifacts/plugins
+          zip -r -j ${{ github.workspace }}/artifacts/security-package.zip ${{ github.workspace }}/artifacts/security-plugin
+          zip -r -j ${{ github.workspace }}/artifacts/dashboard-package.zip ${{ github.workspace }}/artifacts/dashboard/${{ needs.setup-variables.outputs.WAZUH_DASHBOARD_SLIM }}
 
       - name: Build package
         run: |
-          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages
+          cd ${{ github.workspace }}/dev-tools/build-packages
           bash ./build-packages.sh \
             -r ${{ inputs.revision }} ${{ needs.setup-variables.outputs.ARCHITECTURE_FLAG }} \
-            -a file://${{needs.setup-variables.outputs.CURRENT_DIR}}/artifacts/wazuh-package.zip \
-            -s file://${{needs.setup-variables.outputs.CURRENT_DIR}}/artifacts/security-package.zip \
-            -b file://${{needs.setup-variables.outputs.CURRENT_DIR}}/artifacts/dashboard-package.zip \
+            -a file://${{ github.workspace }}/artifacts/wazuh-package.zip \
+            -s file://${{ github.workspace }}/artifacts/security-package.zip \
+            -b file://${{ github.workspace }}/artifacts/dashboard-package.zip \
             --commit-sha ${{needs.setup-variables.outputs.COMMIT_SHA}}-${{needs.setup-variables.outputs.PLUGINS_SHA}}-${{needs.setup-variables.outputs.SECURITY_SHA}} \
             --${{ inputs.system }} ${{ needs.setup-variables.outputs.PRODUCTION }} --debug
 
@@ -314,7 +311,7 @@ jobs:
         if: success()
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}
+          path: ${{ github.workspace }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}
           retention-days: 30
           overwrite: true
 
@@ -323,7 +320,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512
+          path: ${{ github.workspace }}/dev-tools/build-packages/output/${{needs.setup-variables.outputs.PACKAGE_NAME}}.sha512
           retention-days: 30
           overwrite: true
 
@@ -341,19 +338,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          path: ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
+          path: ${{ github.workspace }}/dev-tools/test-packages
 
       - name: Test package integrity
         run: |
-          cd ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages
-          cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}}  ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{ inputs.system }}
+          cd ${{ github.workspace }}/dev-tools/test-packages
+          cp ./${{needs.setup-variables.outputs.PACKAGE_NAME}}  ${{ github.workspace }}/dev-tools/test-packages/${{ inputs.system }}
           bash ./test-packages.sh \
             -p ${{needs.setup-variables.outputs.PACKAGE_NAME}}
 
       - name: DEB - Test package install/uninstall
         if: ${{ inputs.system == 'deb' }}
         run: |
-          sudo dpkg -i ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
+          sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
           if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
             echo "Package installed"
           else
@@ -389,7 +386,7 @@ jobs:
           sudo  systemctl daemon-reload
           sudo  systemctl enable wazuh-dashboard
           sudo  systemctl start wazuh-dashboard
-          sudo dpkg -i ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
+          sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
           sudo systemctl restart wazuh-dashboard
 
           if dpkg -s wazuh-dashboard | grep '^Version:' | grep -q "${{needs.setup-variables.outputs.VERSION}}"; then
@@ -450,7 +447,7 @@ jobs:
         run: |
           # echo 'Installing package...' is necessary to init the ssh connection prior to running scp
           ${{ steps.setup_rpm_env.outputs.ssh_command }} "echo 'Installing package...'"
-          ${{ steps.setup_rpm_env.outputs.scp_command }} ${{ needs.setup-variables.outputs.CURRENT_DIR }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
+          ${{ steps.setup_rpm_env.outputs.scp_command }} ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
 
           ${{ steps.setup_rpm_env.outputs.ssh_command }} "sudo rpm -i ./${{needs.setup-variables.outputs.PACKAGE_NAME}}; \
               if rpm -q wazuh-dashboard &>/dev/null; then \

--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -386,14 +386,19 @@ jobs:
             echo "Package not installed"
             exit 1
           fi
-          sudo  systemctl daemon-reload
-          sudo  systemctl enable wazuh-dashboard
-          sudo  systemctl start wazuh-dashboard
-          if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
-            echo "Service running"
+          # Workaround: AWS CodeBuild runners do not use systemd as PID 1
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl daemon-reload
+            sudo systemctl enable wazuh-dashboard
+            sudo systemctl start wazuh-dashboard
+            if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
+              echo "Service running"
+            else
+              echo "Service not running"
+              exit 1
+            fi
           else
-            echo "Service not running"
-            exit 1
+            echo "Skipping service start — systemd not available in this environment"
           fi
           sudo apt-get remove --purge wazuh-dashboard -y
           if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
@@ -412,11 +417,18 @@ jobs:
           sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
           sudo apt-get update
           sudo apt-get -y install wazuh-dashboard=${{needs.setup-variables.outputs.PREVIOUS}}
-          sudo  systemctl daemon-reload
-          sudo  systemctl enable wazuh-dashboard
-          sudo  systemctl start wazuh-dashboard
+          # Workaround: AWS CodeBuild runners do not use systemd as PID 1
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl daemon-reload
+            sudo systemctl enable wazuh-dashboard
+            sudo systemctl start wazuh-dashboard
+          else
+            echo "Skipping service start — systemd not available in this environment"
+          fi
           sudo dpkg -i ${{ github.workspace }}/dev-tools/test-packages/${{needs.setup-variables.outputs.PACKAGE_NAME}}
-          sudo systemctl restart wazuh-dashboard
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl restart wazuh-dashboard
+          fi
 
           if dpkg -s wazuh-dashboard | grep '^Version:' | grep -q "${{needs.setup-variables.outputs.VERSION}}"; then
             echo "Package upgraded"
@@ -425,11 +437,15 @@ jobs:
             exit 1
           fi
 
-          if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
-            echo "Service running"
+          if [ -d /run/systemd/system ]; then
+            if sudo systemctl status wazuh-dashboard | grep -q "active (running)"; then
+              echo "Service running"
+            else
+              echo "Service not running"
+              exit 1
+            fi
           else
-            echo "Service not running"
-            exit 1
+            echo "Skipping service status check — systemd not available in this environment"
           fi
 
       - name: RPM - Clone automation repo

--- a/dev-tools/test-packages/builder/systemd-test.Dockerfile
+++ b/dev-tools/test-packages/builder/systemd-test.Dockerfile
@@ -1,0 +1,29 @@
+# Minimal systemd-enabled Ubuntu image for DEB package tests, booted with
+# /sbin/init. Built from AWS ECR Public to avoid Docker Hub unauthenticated
+# pull-rate limits on CodeBuild runners.
+FROM public.ecr.aws/ubuntu/ubuntu:jammy
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV container=docker
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        dbus \
+        curl \
+        ca-certificates \
+        gnupg \
+        apt-transport-https \
+        libcap2-bin && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Drop units that are pointless (and slow/noisy) inside a container.
+    rm -f /lib/systemd/system/systemd-update-utc* \
+          /lib/systemd/system/systemd-tmpfiles-setup* \
+          /lib/systemd/system/sysinit.target.wants/systemd-firstboot.service \
+          /lib/systemd/system/multi-user.target.wants/systemd-update-utmp-runlevel.service
+
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/sbin/init"]

--- a/dev-tools/test-packages/deb-test-install-uninstall.sh
+++ b/dev-tools/test-packages/deb-test-install-uninstall.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Runs inside the systemd container started by run_in_systemd_container.sh.
+# Tests that the package installs, the service starts, and the package uninstalls cleanly.
+#
+# Usage: deb-test-install-uninstall.sh <package-name>
+
+set -euo pipefail
+
+PACKAGE_NAME="$1"
+
+dpkg -i "/test-packages/${PACKAGE_NAME}"
+if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
+  echo "Package installed"
+else
+  echo "Package not installed"
+  exit 1
+fi
+
+systemctl daemon-reload
+systemctl enable wazuh-dashboard
+systemctl start wazuh-dashboard
+if systemctl status wazuh-dashboard | grep -q "active (running)"; then
+  echo "Service running"
+else
+  echo "Service not running"
+  exit 1
+fi
+
+apt-get remove --purge wazuh-dashboard -y
+if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
+  echo "Package not uninstalled"
+  exit 1
+else
+  echo "Package uninstalled"
+fi

--- a/dev-tools/test-packages/deb-test-upgrade.sh
+++ b/dev-tools/test-packages/deb-test-upgrade.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Runs inside the systemd container started by run_in_systemd_container.sh.
+# Tests that a same-major upgrade installs correctly and the service restarts.
+#
+# Usage: deb-test-upgrade.sh <package-name> <previous-version> <current-version>
+
+set -euo pipefail
+
+PACKAGE_NAME="$1"
+PREVIOUS="$2"
+VERSION="$3"
+
+apt-get update
+apt-get install -y debhelper tar curl libcap2-bin gnupg apt-transport-https
+curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH \
+  | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import
+chmod 644 /usr/share/keyrings/wazuh.gpg
+echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" \
+  | tee -a /etc/apt/sources.list.d/wazuh.list
+apt-get update
+apt-get -y install "wazuh-dashboard=${PREVIOUS}"
+
+systemctl daemon-reload
+systemctl enable wazuh-dashboard
+systemctl start wazuh-dashboard
+
+dpkg -i "/test-packages/${PACKAGE_NAME}"
+systemctl restart wazuh-dashboard
+
+if dpkg -s wazuh-dashboard | grep '^Version:' | grep -q "${VERSION}"; then
+  echo "Package upgraded"
+else
+  echo "Package not upgraded"
+  exit 1
+fi
+
+if systemctl status wazuh-dashboard | grep -q "active (running)"; then
+  echo "Service running"
+else
+  echo "Service not running"
+  exit 1
+fi

--- a/dev-tools/test-packages/run_in_systemd_container.sh
+++ b/dev-tools/test-packages/run_in_systemd_container.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Run a DEB package test body inside a privileged, systemd-enabled container.
+# The CI runner has no systemd as PID 1, so wazuh-dashboard's maintainer scripts
+# (which call systemctl) can't run on the host. This boots a throwaway systemd
+# container, waits for systemd, runs the body via `docker exec`, and tears it down.
+#
+# Usage: run_in_systemd_container.sh <workspace> <script-body>
+#   workspace    Host workspace root; dev-tools/test-packages is bind-mounted to /test-packages.
+#   script-body  Bash snippet executed inside the container.
+
+set -e
+
+WORKSPACE="$1"
+SCRIPT_BODY="$2"
+
+if [ -z "$WORKSPACE" ] || [ -z "$SCRIPT_BODY" ]; then
+  echo "Usage: $0 <workspace> <script-body>"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Built locally on first call and reused via the layer cache.
+# Override SYSTEMD_IMAGE with a prebuilt image to skip the build.
+SYSTEMD_IMAGE="${SYSTEMD_IMAGE:-wazuh-dashboard-systemd-test:jammy}"
+
+if ! docker image inspect "$SYSTEMD_IMAGE" >/dev/null 2>&1; then
+  echo "Building systemd test image ${SYSTEMD_IMAGE}..."
+  docker build -t "$SYSTEMD_IMAGE" \
+    -f "${SCRIPT_DIR}/builder/systemd-test.Dockerfile" \
+    "${SCRIPT_DIR}/builder"
+fi
+
+cid=$(docker run -d --rm \
+  --privileged \
+  --cgroupns=host \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+  -v "${WORKSPACE}/dev-tools/test-packages:/test-packages" \
+  "$SYSTEMD_IMAGE" /sbin/init)
+
+trap 'docker stop "$cid" >/dev/null 2>&1 || true' EXIT
+
+# Wait for systemd to finish booting before exercising any service units.
+ready=false
+for _ in $(seq 1 30); do
+  state=$(docker exec "$cid" systemctl is-system-running 2>/dev/null || true)
+  case "$state" in
+    running | degraded)
+      ready=true
+      break
+      ;;
+  esac
+  sleep 1
+done
+
+if [ "$ready" != true ]; then
+  echo "ERROR: systemd did not become ready in the container (last state: ${state:-unknown})"
+  docker logs "$cid" || true
+  exit 1
+fi
+
+docker exec "$cid" bash -c "$SCRIPT_BODY"


### PR DESCRIPTION
### Description

The workflow runners are being updated

### Test

[Build deb wazuh-dashboard on arm64](https://github.com/wazuh/wazuh-dashboard/actions/runs/27849580611)
[Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/27849581790)
[Build deb wazuh-dashboard on amd64](https://github.com/wazuh/wazuh-dashboard/actions/runs/27849583237)
[Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/27849584666)


### Depends on 
- https://github.com/wazuh/wazuh-dashboard-plugins/pull/8651
- https://github.com/wazuh/wazuh-security-dashboards-plugin/pull/635

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
