### PR TITLE
Remove references to plugins not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Removed
 
 - Removed creation of /usr/lib/.build-id/\* links to prevent conflicts when installing Wazuh Dashboard alongside OpenSearch Dashboards on the same system
+- Removed the Anomaly Detection plugin from the default Wazuh dashboard package [#1382](https://github.com/wazuh/wazuh-dashboard/pull/1382)
 
 ### Changed
 

--- a/dev-tools/build-packages/base/base-builder.sh
+++ b/dev-tools/build-packages/base/base-builder.sh
@@ -112,12 +112,6 @@ log
 category_explore='{id:"explore",label:"Explore",order:100,euiIconType:"search"}'
 category_label_indexer_management='defaultMessage:"Indexer management"'
 
-# Replace app category to Anomaly Detection app
-sed -i -e "s|category:{id:\"opensearch\",label:\"OpenSearch Plugins\",order:2e3}|category:${category_explore}|" ./plugins/anomalyDetectionDashboards/target/public/anomalyDetectionDashboards.plugin.js
-
-# Disable forecasting in Anomaly Detection app
-sed -i -e "s|forecastingEnabled=true|forecastingEnabled=false|g" ./plugins/anomalyDetectionDashboards/target/public/anomalyDetectionDashboards.plugin.js
-
 # Replace app category to Maps app
 sed -i -e "s|category:{id:\"opensearch\",label:\"OpenSearch Plugins\",order:2e3}|category:${category_explore}|" $(js-file "customImportMapDashboards" "plugin")
 
@@ -130,7 +124,6 @@ log
 
 # Generate compressed files
 files_to_recreate=(
-  $(js-file "anomalyDetectionDashboards" "plugin")
   $(js-file "customImportMapDashboards" "plugin")
   $(js-file "indexManagementDashboards" "plugin")
 )

--- a/dev-tools/build-packages/base/plugins
+++ b/dev-tools/build-packages/base/plugins
@@ -1,3 +1,2 @@
-anomalyDetectionDashboards
 customImportMapDashboards
 indexManagementDashboards


### PR DESCRIPTION
### Description

**Changes made:**
- Removed `anomalyDetectionDashboards` from the plugins list (`dev-tools/build-packages/base/plugins`)
- Removed the related Anomaly Detection post-processing in `dev-tools/build-packages/base/base-builder.sh` (the category `sed`, the forecasting `sed`, and the `files_to_recreate` entry), which had to be removed together since they target a path that no longer exists once the plugin is not installed

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard/issues/1381

## Evidence

- https://github.com/wazuh/wazuh-dashboard/actions/runs/28035715449

### Plugin Installation Verification

**Plugin directories in the installed package** (no `anomalyDetectionDashboards`):
```bash
ls
alertingDashboards         indexManagementDashboards  reportsDashboards            securityDashboards  wazuhCheckUpdates
customImportMapDashboards  notificationsDashboards    securityAnalyticsDashboards  wazuh               wazuhCore
```

## Testing the changes

### Prerequisites
- Built Wazuh Dashboard package on this branch, package available at: https://github.com/wazuh/wazuh-dashboard/actions/runs/28035715449

### Test Steps

#### Verify the plugin is not included in the package
```bash
cd /usr/share/wazuh-dashboard/
ls plugins/
# Expected: anomalyDetectionDashboards is NOT present;
```

#### Verify the plugin is not recognized by OpenSearch Dashboards

```bash
cd /usr/share/wazuh-dashboard/bin
./opensearch-dashboards-plugin list --allow-root
# Expected: no anomalyDetectionDashboards entry
```

#### Verify the app is gone in the UI
- Confirm the **Anomaly Detection** app no longer appears under the **Explore** menu
- Navigate to `/app/anomaly-detection-dashboards` and confirm it is not available

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest` (N/A - packaging configuration change only)
  - [ ] `yarn test:jest_integration` (N/A - packaging configuration change only)
- [x] New functionality includes testing. (Testing steps provided above)
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
