### PR TITLE
Hide all visible references to the Sample Data App

### DIFF
--- a/src/plugins/dashboard/public/application/utils/__snapshots__/get_no_items_message.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/utils/__snapshots__/get_no_items_message.test.tsx.snap
@@ -304,26 +304,6 @@ exports[`dashboard listing table with no item and with write controls 1`] = `
             }
           />
         </p>
-        <p>
-          <FormattedMessage
-            defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
-            id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
-            values={
-              Object {
-                "appName": "Wazuh dashboard",
-                "sampleDataInstallLink": <EuiLink
-                  onClick={[Function]}
-                >
-                  <FormattedMessage
-                    defaultMessage="Install some sample data"
-                    id="dashboard.listing.createNewDashboard.sampleDataInstallLinkText"
-                    values={Object {}}
-                  />
-                </EuiLink>,
-              }
-            }
-          />
-        </p>
       </EuiText>
     </React.Fragment>
   }
@@ -627,47 +607,6 @@ exports[`dashboard listing table with no item and with write controls 1`] = `
                     }
                   >
                     You can combine data views from any Wazuh dashboard app into one dashboard and see everything in one place.
-                  </FormattedMessage>
-                </p>
-                <p>
-                  <FormattedMessage
-                    defaultMessage="New to {appName}? {sampleDataInstallLink} to take a test drive."
-                    id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
-                    values={
-                      Object {
-                        "appName": "Wazuh dashboard",
-                        "sampleDataInstallLink": <EuiLink
-                          onClick={[Function]}
-                        >
-                          <FormattedMessage
-                            defaultMessage="Install some sample data"
-                            id="dashboard.listing.createNewDashboard.sampleDataInstallLinkText"
-                            values={Object {}}
-                          />
-                        </EuiLink>,
-                      }
-                    }
-                  >
-                    New to Wazuh dashboard? 
-                    <EuiLink
-                      onClick={[Function]}
-                    >
-                      <button
-                        className="euiLink euiLink--primary"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <FormattedMessage
-                          defaultMessage="Install some sample data"
-                          id="dashboard.listing.createNewDashboard.sampleDataInstallLinkText"
-                          values={Object {}}
-                        >
-                          Install some sample data
-                        </FormattedMessage>
-                      </button>
-                    </EuiLink>
-                     to take a test drive.
                   </FormattedMessage>
                 </p>
               </div>

--- a/src/plugins/dashboard/public/application/utils/get_no_items_message.test.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_no_items_message.test.tsx
@@ -31,8 +31,12 @@ describe('dashboard listing table with no item', () => {
     const component = mountWithIntl(getNoItemsMessage(false, jest.fn(), application));
 
     expect(component).toMatchSnapshot();
-    component.find(EuiLink).simulate('click');
 
-    expect(application.navigateToApp).toHaveBeenCalledWith('sample-data');
+    // Wazuh - Temporary: Sample Data App link is hidden in Wazuh 5.0 until updated for new features.
+    // Restore the following assertions when the Sample Data App is re-enabled:
+    // component.find(EuiLink).simulate('click');
+    // expect(application.navigateToApp).toHaveBeenCalledWith('sample-data');
+    expect(component.find(EuiLink).length).toBe(0);
+    expect(application.navigateToApp).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
@@ -57,6 +57,7 @@ export const getNoItemsMessage = (
                 }}
               />
             </p>
+            {/* Wazuh - Sample Data App is hidden in Wazuh 5.0 until updated for new features
             <p>
               <FormattedMessage
                 id="dashboard.listing.createNewDashboard.newToOpenSearchDashboardsDescription"
@@ -74,6 +75,7 @@ export const getNoItemsMessage = (
                 }}
               />
             </p>
+            */}
           </EuiText>
         </Fragment>
       }


### PR DESCRIPTION
### Description

This PR removes visible references to the Sample Data app until it is updated to support the features introduced in version 5.0.0.

### Issues Resolved

- **Closes**: https://github.com/wazuh/wazuh-dashboard/issues/1389

## Screenshot

<img width="1725" height="949" alt="image" src="https://github.com/user-attachments/assets/d594999a-1467-4b4f-8598-9b6bff1421f9" />

## Testing the changes

1. Go to **Explore** > **Dashboards**
2. Confirm that there are no links to the Sample Data app.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
