### PR TITLE
Infinite requests after navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed health check padding styles [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276)
 - Sanitized redirect path to prevent open redirect [#1285](https://github.com/wazuh/wazuh-dashboard/pull/1285)
+- Prevent infinite remount loop when navigating from alerting before its bundle finishes loading [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed health check padding styles [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276)
 - Sanitized redirect path to prevent open redirect [#1285](https://github.com/wazuh/wazuh-dashboard/pull/1285)
-- Prevent infinite remount loop when navigating from alerting before its bundle finishes loading [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400)
+- Prevent infinite remount loop when navigating from an app before its bundle finishes loading [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400)
 
 ### Removed
 

--- a/src/core/public/application/ui/app_container.tsx
+++ b/src/core/public/application/ui/app_container.tsx
@@ -101,10 +101,16 @@ export const AppContainer: FunctionComponent<Props> = ({
       unmount();
     }
 
+    // Wazuh: track whether the cleanup has already run so that a slow async mount
+    // can detect it resolved after the user navigated away and self cleanup.
+    let cancelled = false;
+
     const mount = async () => {
       setShowSpinner(true);
       try {
-        unmountRef.current =
+        // Wazuh: if the app is unmounted while the mount() promise is in flight,
+        // we need to call the returned unmount function directly.
+        const appUnmount =
           (await mounter.mount({
             appBasePath: mounter.appBasePath,
             history: createScopedHistory(appPath),
@@ -119,12 +125,21 @@ export const AppContainer: FunctionComponent<Props> = ({
               setAppDescriptionControls(appId, menuMount),
             setHeaderBottomControls: (menuMount) => setAppBottomControls(appId, menuMount),
           })) || null;
+        // Wazuh: cleanup already ran while mount() was in flight, so call umount directly now.
+        if (cancelled) {
+          appUnmount?.();
+        } else {
+          unmountRef.current = appUnmount;
+        }
       } catch (e) {
-        // TODO: add error UI
-        // eslint-disable-next-line no-console
-        console.error(e);
+        if (!cancelled) {
+          // TODO: add error UI
+          // eslint-disable-next-line no-console
+          console.error(e);
+        }
       } finally {
-        if (elementRef.current) {
+        // Wazuh: cleanup already ran while mount() was in flight, so don't try to update state.
+        if (!cancelled && elementRef.current) {
           setShowSpinner(false);
           setIsMounting(false);
         }
@@ -133,7 +148,12 @@ export const AppContainer: FunctionComponent<Props> = ({
 
     mount();
 
-    return unmount;
+    return () => {
+      // Wazuh: track whether the cleanup has already run so that a slow async mount
+      // can detect it resolved after the user navigated away and self cleanup.
+      cancelled = true;
+      unmount();
+    };
   }, [
     appId,
     appStatus,


### PR DESCRIPTION
### Description

Fixes an infinite mount/unmount loop triggered when navigating away from the alerting plugin before it finishes loading.

The issue is a race condition in `AppContainer.useLayoutEffect`, if the user navigates away while `await mounter.mount()` is still resolving, the cleanup runs with `unmountRef.current = null`, so `ReactDOM.unmountComponentAtNode` is never called. The alerting React tree leaks onto the destination page. 

Since both alerting and active responses use independent `HashRouter` instances sharing `window.location.hash`, their catch all `<Redirect>` components redirect against each other indefinitely.

The applied fix is a `cancelled` flag in `app_container.tsx` to avoid this edge case.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard/issues/1399

## Evidence

https://github.com/user-attachments/assets/301e9853-1b76-4e40-a0b6-213077f4ea61

## Testing the changes

1. Do a hard refresh with F5
2. In the browser dev tools, switch the network throttle to a slow network.
3. Navigate to Alerting.
4. Immediately click to Active Responses.
5. Verify the Active Responses page loads normally with no infinite loop.
6. Navigate back to Alerting, verify it loads correctly.

This can also be replicated between Notifications > Active Responses for example.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
