### PR TITLE
Fix  package generation failed because the SHA-512 file was missing

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -466,9 +466,9 @@ jobs:
       - name: Upload package to S3
         if: success()
         run: |
-          aws s3 cp ${{steps.get-package-name.outputs.PACKAGE_NAME_PATH}} ${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.EXECUTION_REPOSITORY }}/${{ github.run_id }}/$PACKAGE_NAME
+          aws s3 cp ${{steps.get-package-name.outputs.PACKAGE_NAME_PATH}} ${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.EXECUTION_REPOSITORY }}/${{ github.run_id }}/${{steps.get-package-name.outputs.PACKAGE_NAME}}
           if [ "${{ inputs.checksum }}" = "true" ]; then
-            aws s3 cp ${{steps.get-package-name.outputs.PACKAGE_NAME_PATH}}.sha512 ${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.EXECUTION_REPOSITORY }}/${{ github.run_id }}/$PACKAGE_NAME.sha512
+            aws s3 cp ${{steps.get-package-name.outputs.PACKAGE_NAME_PATH}}.sha512 ${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.EXECUTION_REPOSITORY }}/${{ github.run_id }}/${{steps.get-package-name.outputs.PACKAGE_NAME}}.sha512
           fi
 
   test-package:


### PR DESCRIPTION
### Description

This pull request fixes the package generation failed because the SHA-512 file was missing.

### Issues Resolved

#1406

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] Commits are signed per the DCO using --signoff
