### PR TITLE
Remove deprecated isProduction field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added Health Check app [#870](https://github.com/wazuh/wazuh-dashboard/pull/870) [#946](https://github.com/wazuh/wazuh-dashboard/pull/946) [#1366](https://github.com/wazuh/wazuh-dashboard/pull/1366) [#1379](https://github.com/wazuh/wazuh-dashboard/pull/1379)
 - Added manager host configuration for the default configuration file [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)
 - Set v9 theme as default [#1092](https://github.com/wazuh/wazuh-dashboard/pull/1092)
+- Added version, revision, and stage to the Wazuh build metadata [#1327](https://github.com/wazuh/wazuh-dashboard/pull/1327) [#1421](https://github.com/wazuh/wazuh-dashboard/pull/1421)
 
 ### Fixed
 

--- a/dev-tools/build-packages/deb/deb-builder.sh
+++ b/dev-tools/build-packages/deb/deb-builder.sh
@@ -60,12 +60,6 @@ log "Extracting base tar.gz..."
 tar -zxf "${out_dir}/wazuh-dashboard-$version-$revision-linux-$architecture.tar.gz"
 log "Preparing the package..."
 jq '.wazuh.revision="'${revision}'"' package.json > pkgtmp.json && mv pkgtmp.json package.json
-# TODO: Review if we want to set production mode based on is_stage or if we want to have a separate input for that.
-if [ "${is_production}" = "yes" ]; then
-  jq '.wazuh.isProduction = true' package.json > pkgtmp.json && mv pkgtmp.json package.json
-else
-  jq '.wazuh.isProduction = false' package.json > pkgtmp.json && mv pkgtmp.json package.json
-fi
 mkdir -p etc/services
 cp "${config_path}"/* etc/services
 jq '.version="'${version}'"' VERSION.json > VERSION.tmp && mv VERSION.tmp VERSION.json

--- a/dev-tools/build-packages/rpm/rpm-builder.sh
+++ b/dev-tools/build-packages/rpm/rpm-builder.sh
@@ -58,12 +58,6 @@ log "Extracting base tar.gz..."
 tar -zxf "${out_dir}/wazuh-dashboard-$version-$revision-linux-$architecture.tar.gz"
 log "Preparing the package..."
 jq '.wazuh.revision="'${revision}'"' package.json > pkgtmp.json && mv pkgtmp.json package.json
-# TODO: Review if we want to set production mode based on is_stage or if we want to have a separate input for that.
-if [ "${is_production}" = "yes" ]; then
-  jq '.wazuh.isProduction = true' package.json > pkgtmp.json && mv pkgtmp.json package.json
-else
-  jq '.wazuh.isProduction = false' package.json > pkgtmp.json && mv pkgtmp.json package.json
-fi
 mkdir -p etc/services
 cp "${config_path}"/* etc/services
 jq '.version="'${version}'"' VERSION.json > VERSION.tmp && mv VERSION.tmp VERSION.json

--- a/packages/osd-config/src/__snapshots__/env.test.ts.snap
+++ b/packages/osd-config/src/__snapshots__/env.test.ts.snap
@@ -34,6 +34,8 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "v1",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -78,6 +80,8 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "v1",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -121,6 +125,8 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "some-version",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -164,6 +170,8 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "some-version",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -207,6 +215,8 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "some-version",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -250,6 +260,8 @@ Env {
     "buildSha": "feature-v1-build-sha",
     "dist": true,
     "version": "v1",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -293,6 +305,8 @@ Env {
     "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "dist": false,
     "version": "v1",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [
@@ -336,6 +350,8 @@ Env {
     "buildSha": "feature-v1-build-sha",
     "dist": true,
     "version": "v1",
+    "wazuhRevision": "01",
+    "wazuhStage": "",
     "wazuhVersion": "4.x.x",
   },
   "pluginSearchPaths": Array [

--- a/packages/osd-config/src/env.ts
+++ b/packages/osd-config/src/env.ts
@@ -70,7 +70,6 @@ export interface RawPackageInfo {
   wazuh: {
     version: string;
     revision?: string;
-    isProduction?: boolean;
   };
 }
 
@@ -182,7 +181,6 @@ export class Env {
       wazuhVersion: pkg.wazuh.version,
       wazuhRevision: pkg.wazuh.revision ?? '01',
       wazuhStage: wazuhVersionFile.stage ?? '',
-      wazuhIsProduction: pkg.wazuh.isProduction ?? false,
     });
   }
 }

--- a/packages/osd-config/src/types.ts
+++ b/packages/osd-config/src/types.ts
@@ -40,7 +40,6 @@ export interface PackageInfo {
   wazuhVersion: string;
   wazuhRevision: string;
   wazuhStage: string;
-  wazuhIsProduction: boolean;
 }
 
 /**

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -37,7 +37,6 @@ export const mockWazuhBuildInfo: WazuhBuildInfo = {
   version: '4.x.x',
   revision: '01',
   stage: '',
-  isProduction: false,
 };
 
 const createSetupContractMock = () => {

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -151,7 +151,6 @@ function pluginInitializerContextMock() {
         wazuhVersion: 'wazuhVersion',
         wazuhRevision: '01',
         wazuhStage: '',
-        wazuhIsProduction: false,
       },
     },
     config: {
@@ -180,7 +179,6 @@ function createCoreContext(): CoreContext {
         wazuhVersion: 'wazuhVersion',
         wazuhRevision: '01',
         wazuhStage: '',
-        wazuhIsProduction: false,
       },
     },
   };

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -131,7 +131,6 @@ function pluginInitializerContextMock<T>(config: T = {} as T) {
         wazuhVersion: 'wazuhVersion',
         wazuhRevision: '01',
         wazuhStage: '',
-        wazuhIsProduction: false,
       },
       instanceUuid: 'instance-uuid',
     },

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
@@ -48,7 +48,6 @@ const packageInfo = {
   wazuhVersion: '4.0.0',
   wazuhRevision: '01',
   wazuhStage: '',
-  wazuhIsProduction: false,
 };
 
 afterEach(() => {

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -29,6 +29,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -61,7 +63,11 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;
 
@@ -94,6 +100,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -126,7 +134,11 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;
 
@@ -159,6 +171,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -191,7 +205,11 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;
 
@@ -224,6 +242,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -260,7 +280,11 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;
 
@@ -293,6 +317,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -325,7 +351,11 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;
 
@@ -358,6 +388,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -390,7 +422,11 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;
 
@@ -423,6 +459,8 @@ Object {
       "buildSha": Any<String>,
       "dist": Any<Boolean>,
       "version": Any<String>,
+      "wazuhRevision": Any<String>,
+      "wazuhStage": Any<String>,
       "wazuhVersion": Any<String>,
     },
   },
@@ -455,6 +493,10 @@ Object {
   "uiPlugins": Array [],
   "vars": Object {},
   "version": Any<String>,
-  "wazuhVersion": "5.0.0",
+  "wazuhBuildInfo": Object {
+    "revision": Any<String>,
+    "stage": Any<String>,
+    "version": Any<String>,
+  },
 }
 `;

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -74,14 +74,12 @@ const INJECTED_METADATA = {
       wazuhVersion: expect.any(String),
       wazuhRevision: expect.any(String),
       wazuhStage: expect.any(String),
-      wazuhIsProduction: expect.any(Boolean),
     },
   },
   wazuhBuildInfo: {
     version: expect.any(String),
     revision: expect.any(String),
     stage: expect.any(String),
-    isProduction: expect.any(Boolean),
   },
 };
 

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -129,7 +129,6 @@ export class RenderingService {
               version: env.packageInfo.wazuhVersion,
               revision: env.packageInfo.wazuhRevision,
               stage: env.packageInfo.wazuhStage,
-              isProduction: env.packageInfo.wazuhIsProduction,
             },
             basePath,
             serverBasePath,

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -57,7 +57,6 @@ export interface RenderingMetadata {
       version: string;
       revision: string;
       stage: string;
-      isProduction: boolean;
     };
     basePath: string;
     serverBasePath: string;

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -42,7 +42,6 @@ function mockProps() {
           wazuhVersion: '',
           wazuhRevision: '01',
           wazuhStage: '',
-          wazuhIsProduction: false,
         },
         mode: {
           name: 'production' as 'development' | 'production',

--- a/src/core/server/status/routes/integration_tests/status.test.ts
+++ b/src/core/server/status/routes/integration_tests/status.test.ts
@@ -83,7 +83,6 @@ describe('GET /api/status', () => {
           wazuhVersion: '4.2.0',
           wazuhRevision: '01',
           wazuhStage: '',
-          wazuhIsProduction: false,
         },
         serverName: 'xopensearchDashboards',
         uuid: 'xxxx-xxxxx',

--- a/src/core/types/wazuh_build_info.ts
+++ b/src/core/types/wazuh_build_info.ts
@@ -12,5 +12,4 @@ export interface WazuhBuildInfo {
   version: string;
   revision: string;
   stage: string;
-  isProduction: boolean;
 }


### PR DESCRIPTION
### Description

This PR removes the `isProduction` field from WazuhBuildInfo, since **stage** will be the single source of truth.

### Issues Resolved

- **Closes**: https://github.com/wazuh/wazuh-dashboard/issues/1419

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff