### PR TITLE
Create issue-creation skill and update PR template

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -144,14 +144,15 @@ PR pre-flight
 
 ### 6. Create as Draft — only when explicitly asked
 
+Write the body filled in step 5 (not the blank template) to a temp file, then
+pass that file — never point `--body-file` at the template path itself, or the
+PR is created with the empty placeholder text.
+
 ```bash
 gh pr create --draft --base <version-branch> \
   --title "<Imperative, capitalized subject>" \
-  --body-file .github/pull_request_template.md
+  --body-file /tmp/pr-body.md
 ```
-
-(then edit the created PR body, or pass a filled temp file instead of the
-template path).
 
 ### 7. Mark Ready for review — only when explicitly asked
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -25,7 +25,7 @@ you to create/open/submit it.
 - **English everywhere.** Describe the _why_, not just the _what_.
 - **Issues arrive as URLs** and may live in a different repo. Read them with
   `gh issue view <url>` and classify the source (see below) — it changes both
-  "Issues Resolved" and the CHANGELOG.
+  the PR's `## Description` closing reference and the CHANGELOG.
 
 ## Issue source: public vs internal
 
@@ -33,12 +33,13 @@ Detect the source repo from the issue URL:
 
 - **Internal** — the URL/repo contains `internal-devel-request` (e.g.
   `https://github.com/wazuh/internal-devel-requests/issues/5526`):
-  - PR "Issues Resolved": **leave empty** — never expose the internal link.
+  - PR `## Description` closing reference: **leave empty** — never expose the
+    internal link.
   - CHANGELOG: **no entry** for internal-devel-requests issues.
 - **Public** — any other repo (e.g.
   `https://github.com/wazuh/wazuh-dashboard/issues/1434`):
-  - PR "Issues Resolved": `closes #<n>` (same repo) or `closes <issue-url>`
-    (another public repo).
+  - PR `## Description` closing reference: `Closes #<n>` (same repo) or
+    `Closes <issue-url>` (another public repo).
   - CHANGELOG: add an entry linking to the **issue** (see step 4).
 
 > **repo-specific:** the internal repo is `wazuh/internal-devel-requests`; match
@@ -101,10 +102,13 @@ the PR.**
 
 > **repo-specific (wazuh-dashboard):** the Wazuh user-facing changelog is
 > [`CHANGELOG.md`](../../../CHANGELOG.md) at the repo root — maintain it by hand.
-> The `changelogs/fragments/*.yml` system and the PR's `## Changelog` section are
-> inherited **upstream OSD** tooling (fragments there track upstream OpenSearch
-> PRs). For a Wazuh change, add the `CHANGELOG.md` entry and put `- skip` (or a
-> conventional `feat:`/`fix:` line) in the PR's `## Changelog` section.
+> The `changelogs/fragments/*.yml` system is inherited **upstream OSD** tooling
+> (fragments there track upstream OpenSearch PRs, not Wazuh changes). For a
+> Wazuh change, add the `CHANGELOG.md` entry.
+
+**Entry style — keep it short and user-facing:** one line, phrased from the
+user's perspective (e.g. "Fixed X causing Y", "Added support for Z"). Never a
+paragraph, and never internal implementation detail, file names, or jargon.
 
 **Skip the entry entirely when:**
 
@@ -116,53 +120,12 @@ When unsure (and the issue is public), add an entry.
 
 ### 5. Fill the PR body
 
-Fill the repository PR template **verbatim** (keep every heading and checklist
-item exactly).
-
-> **repo-specific (wazuh-dashboard):** this mirrors
-> [`.github/pull_request_template.md`](../../../.github/pull_request_template.md).
-> Read it first and keep this block in sync if the repo template changes. Note the
-> section names differ from the plugins repo (`## Screenshot`, `## Testing the
-> changes`, `## Changelog`), and the checklist includes `yarn test:jest_integration`.
-
-```markdown
-### Description
-
-<why this change exists and what it achieves>
-
-### Issues Resolved
-
-closes #<issue-number>
-
-## Screenshot
-
-<screenshots or videos — REQUIRED for any UI change>
-
-## Testing the changes
-
-<detailed steps to validate this PR>
-
-## Changelog
-
-- skip
-
-### Check List
-
-- [ ] All tests pass
-  - [ ] `yarn test:jest`
-  - [ ] `yarn test:jest_integration`
-- [ ] New functionality includes testing.
-- [ ] New functionality has been documented.
-- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
-- [ ] Commits are signed per the DCO using --signoff
-```
-
-Fill each section with real content; check the boxes that genuinely apply. For
-**Issues Resolved**: public issue → closing keyword (`closes`, `fixes`, `fix`)
-with `#<n>` or the full issue URL; **internal-devel-requests issue → leave the
-section empty** (see "Issue source" above). In `## Changelog`, use `- skip` for
-Wazuh changes (the Wazuh changelog is `CHANGELOG.md`) or a conventional
-`feat:`/`fix:`/… line if you want a fragment generated.
+Read [`.github/pull_request_template.md`](../../../.github/pull_request_template.md)
+and fill it in verbatim — every section and checklist item lives in that file;
+this skill does not restate them here. Fill each section with real content and
+check the boxes that genuinely apply. For the `## Description` closing
+reference, follow the "Issue source" rule above (public issue → `Closes #<n>`;
+internal-devel-requests → leave it out).
 
 **Default deliverable — pre-flight report.** Unless the user asked you to create the
 PR, stop here and output the filled body plus this report for the human to act on:
@@ -182,15 +145,13 @@ PR pre-flight
 ### 6. Create as Draft — only when explicitly asked
 
 ```bash
-gh pr create --draft \
-  --base <version-branch> \
+gh pr create --draft --base <version-branch> \
   --title "<Imperative, capitalized subject>" \
-  --body "$(cat <<'EOF'
-### Description
-...
-EOF
-)"
+  --body-file .github/pull_request_template.md
 ```
+
+(then edit the created PR body, or pass a filled temp file instead of the
+template path).
 
 ### 7. Mark Ready for review — only when explicitly asked
 

--- a/.claude/skills/develop-issue/SKILL.md
+++ b/.claude/skills/develop-issue/SKILL.md
@@ -33,7 +33,8 @@ gh issue view <issue-url>
 
 - **Internal** — URL contains `internal-devel-request` (e.g.
   `wazuh/internal-devel-requests`): the issue link is **not** exposed in the PR
-  ("Issues Resolved" stays empty) and there is **no CHANGELOG entry**.
+  (`## Description` closing reference stays empty) and there is **no CHANGELOG
+  entry**.
 - **Public** — any other repo (e.g. `wazuh/wazuh-dashboard`): link it in the PR
   and add a CHANGELOG entry pointing to the issue.
 
@@ -86,17 +87,16 @@ for **internal-devel-requests** issues, and for tooling/docs/test-only changes.
 
 > **repo-specific (wazuh-dashboard):** `CHANGELOG.md` is the Wazuh-maintained
 > changelog; the `changelogs/fragments/` system is inherited upstream OSD tooling
-> (used for upstream PRs). In the PR's `## Changelog` section, use `- skip` for
-> Wazuh changes.
+> (used for upstream PRs only).
 
 ### 6. Deliver (do NOT open the PR)
 
 Invoke **create-pr** in its default prepare-and-hand-off mode. Output:
 
-- The filled PR-template body, with the **`## Screenshot` left empty** for the
-  developer to attach the screenshot/video, and **`### Issues Resolved` left
-  empty** for internal-devel-requests issues (or `closes #<n>` / issue URL for
-  public ones).
+- The filled PR-template body, with **`### Results and Evidence` left empty**
+  for the developer to attach the screenshot/video, and the **`## Description`
+  closing reference left empty** for internal-devel-requests issues (or
+  `Closes #<n>` / issue URL for public ones).
 - The pre-flight report (branch, suggested base, DCO status, check-standards
   result, CHANGELOG status, and the `gh pr create` command to run when ready).
 

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -52,20 +52,15 @@ Reference the chosen file under
 fill it verbatim; do not inline template bodies in this skill.
 
 > **repo-specific (wazuh-dashboard):** templates are classic `.md` issue forms
-> (not YAML issue forms). Frontmatter `labels:` per template (may be stale —
-> see step 4 for the real labels to actually apply):
-> - `bug_template.md` → `bug, untriaged`
-> - `feature_template.md` → `enhancement`
-> - `compatibility_request.md` → `compatibility, level/task, type/research`
-> - `new_release.md` → `level/task, type/enhancement`
-> - `task_template.md` → `level/task, type/task`
->
-> `feature_template.md`'s bare `enhancement` and `compatibility_request.md`'s
-> bare `compatibility` do **not** exist as real labels in this repo (confirmed
-> via `gh label list --repo wazuh/wazuh-dashboard`) — only the prefixed
-> `type/enhancement` does. `bug_template.md`'s bare `bug` label IS real here
-> (unlike every sibling repo in this cross-repo initiative) — this repo
-> uniquely has both `bug` and `type/bug`.
+> (not YAML issue forms). `feature_template.md`'s bare `enhancement` and
+> `compatibility_request.md`'s bare `compatibility` do **not** exist as real
+> labels in this repo (confirmed via `gh label list --repo wazuh/wazuh-dashboard`)
+> — only the prefixed `type/enhancement` does; see step 4 for the real labels
+> to apply. `bug_template.md`'s bare `bug` label IS real here (unlike every
+> sibling repo in this cross-repo initiative) — this repo uniquely has both
+> `bug` and `type/bug`. `new_release.md` and `task_template.md`'s other
+> declared labels (`level/task`, `type/enhancement`, `type/task`) are all real
+> as declared.
 
 ### 4. Labels
 

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: issue-creation
+description: Create a well-formed GitHub issue in a Wazuh Dashboard repo — pick the right issue template, run an issue-first duplicate check, and produce a ready-to-file body with the template's default labels. Use when the user asks to create, open, file, or draft an issue.
+---
+
+# Create a Wazuh Dashboard issue
+
+Pick the right issue template, check for duplicates first, then fill the
+template verbatim and hand off a ready-to-file body.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] 1. Classify intent → choose issue template (ask only if ambiguous)
+- [ ] 2. Issue-first check: search existing issues for duplicates
+- [ ] 3. Fill the chosen .github/ISSUE_TEMPLATE/*.md verbatim
+- [ ] 4. Keep the template's default labels; add a triage label only if named
+- [ ] 5. Emit the ready-to-file body + report (default stop; gh issue create only if asked)
+```
+
+### 1. Classify intent → choose template
+
+Map the user's intent to a template. Ask the user only when genuinely
+ambiguous between two rows.
+
+| Intent | Template | Labels (from template frontmatter) |
+|--------|----------|--------|
+| Defect/regression | `bug_template.md` | `bug, untriaged` |
+| New capability/idea | `feature_template.md` | `enhancement` |
+| Support a new OpenSearch version | `compatibility_request.md` | `compatibility, level/task, type/research` |
+| Track a Wazuh release | `new_release.md` | `level/task, type/enhancement` |
+| Engineering task/improvement (not a bug, feature, compatibility, or release) | `task_template.md` | `level/task, type/task` |
+
+### 2. Issue-first duplicate check
+
+Before drafting, search for an existing issue covering the same problem:
+
+```bash
+gh issue list --search "<keywords>"
+gh search issues "<keywords>" --repo wazuh/wazuh-dashboard
+```
+
+On a likely match, surface it to the user and ask whether to proceed with a
+new issue or comment on the existing one instead.
+
+### 3. Fill the template
+
+Reference the chosen file under
+[`.github/ISSUE_TEMPLATE`](../../../.github/ISSUE_TEMPLATE) — read it first and
+fill it verbatim; do not inline template bodies in this skill.
+
+> **repo-specific (wazuh-dashboard):** templates are classic `.md` issue forms
+> (not YAML issue forms). Label sets per template:
+> - `bug_template.md` → `bug, untriaged`
+> - `feature_template.md` → `enhancement`
+> - `compatibility_request.md` → `compatibility, level/task, type/research`
+> - `new_release.md` → `level/task, type/enhancement`
+> - `task_template.md` → `level/task, type/task`
+
+### 4. Labels
+
+Keep the template's default labels as-is; add an extra triage label only if
+the user explicitly names one. Do not invent labels or an approval workflow —
+there is no `status:*` label convention in this repo.
+
+### 5. Emit the ready-to-file body + report
+
+**Default deliverable — stop here.** Output the filled issue body plus a short
+report for the human to review:
+
+```
+Issue pre-flight
+- Template: <file>
+- Labels: <label list>
+- Duplicate check: no matches found / possible match: <issue-url>
+- Command to open it: gh issue create --template <file> --label "<labels>"
+```
+
+Only run `gh issue create` when the user explicitly asks you to open the
+issue.

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -58,6 +58,16 @@ fill it verbatim; do not inline template bodies in this skill.
 > - `compatibility_request.md` → `compatibility, level/task, type/research`
 > - `new_release.md` → `level/task, type/enhancement`
 > - `task_template.md` → `level/task, type/task`
+>
+> **Label frontmatter is stale, do not repeat it verbatim without checking**
+> — `feature_template.md` declares a bare `enhancement` label, but this
+> repo's actual label set has no such label — only the prefixed
+> `type/enhancement` (confirmed via `gh label list --repo wazuh/wazuh-dashboard`).
+> GitHub only applies a template's `labels:` frontmatter if that exact label
+> already exists in the repo, so filing via `feature_template.md` as-is
+> silently applies no type label. `bug_template.md`'s bare `bug` label IS
+> real here (unlike every sibling repo in this cross-repo initiative) — this
+> repo uniquely has both `bug` and `type/bug`.
 
 ### 4. Labels
 

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -31,7 +31,7 @@ ambiguous between two rows.
 | New capability/idea | `feature_template.md` | `enhancement` |
 | Support a new OpenSearch version | `compatibility_request.md` | `compatibility, level/task, type/research` |
 | Track a Wazuh release | `new_release.md` | `level/task, type/enhancement` |
-| Engineering task/improvement (not a bug, feature, compatibility, or release) | `task_template.md` | `level/task, type/task` |
+| Engineering task/improvement (not a bug, feature, compatibility, or release) | `task_template.md` | `level/task` |
 
 ### 2. Issue-first duplicate check
 
@@ -59,8 +59,9 @@ fill it verbatim; do not inline template bodies in this skill.
 > to apply. `bug_template.md`'s bare `bug` label IS real here (unlike every
 > sibling repo in this cross-repo initiative) — this repo uniquely has both
 > `bug` and `type/bug`. `new_release.md` and `task_template.md`'s other
-> declared labels (`level/task`, `type/enhancement`, `type/task`) are all real
-> as declared.
+> declared labels (`level/task`, `type/enhancement`) are all real as declared
+> — there is no `type/task` label in this repo, matching every sibling repo
+> in this cross-repo initiative.
 
 ### 4. Labels
 

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Copy this checklist and track progress:
 - [ ] 1. Classify intent → choose issue template (ask only if ambiguous)
 - [ ] 2. Issue-first check: search existing issues for duplicates
 - [ ] 3. Fill the chosen .github/ISSUE_TEMPLATE/*.md verbatim
-- [ ] 4. Keep the template's default labels; add a triage label only if named
+- [ ] 4. Apply the real Wazuh label for the intent (`type/bug` / `type/enhancement` / `level/task`) + `untriaged`; ignore stale frontmatter labels
 - [ ] 5. Emit the ready-to-file body + report (default stop; gh issue create only if asked)
 ```
 
@@ -52,28 +52,40 @@ Reference the chosen file under
 fill it verbatim; do not inline template bodies in this skill.
 
 > **repo-specific (wazuh-dashboard):** templates are classic `.md` issue forms
-> (not YAML issue forms). Label sets per template:
+> (not YAML issue forms). Frontmatter `labels:` per template (may be stale —
+> see step 4 for the real labels to actually apply):
 > - `bug_template.md` → `bug, untriaged`
 > - `feature_template.md` → `enhancement`
 > - `compatibility_request.md` → `compatibility, level/task, type/research`
 > - `new_release.md` → `level/task, type/enhancement`
 > - `task_template.md` → `level/task, type/task`
 >
-> **Label frontmatter is stale, do not repeat it verbatim without checking**
-> — `feature_template.md` declares a bare `enhancement` label, but this
-> repo's actual label set has no such label — only the prefixed
-> `type/enhancement` (confirmed via `gh label list --repo wazuh/wazuh-dashboard`).
-> GitHub only applies a template's `labels:` frontmatter if that exact label
-> already exists in the repo, so filing via `feature_template.md` as-is
-> silently applies no type label. `bug_template.md`'s bare `bug` label IS
-> real here (unlike every sibling repo in this cross-repo initiative) — this
-> repo uniquely has both `bug` and `type/bug`.
+> `feature_template.md`'s bare `enhancement` and `compatibility_request.md`'s
+> bare `compatibility` do **not** exist as real labels in this repo (confirmed
+> via `gh label list --repo wazuh/wazuh-dashboard`) — only the prefixed
+> `type/enhancement` does. `bug_template.md`'s bare `bug` label IS real here
+> (unlike every sibling repo in this cross-repo initiative) — this repo
+> uniquely has both `bug` and `type/bug`.
 
 ### 4. Labels
 
-Keep the template's default labels as-is; add an extra triage label only if
-the user explicitly names one. Do not invent labels or an approval workflow —
-there is no `status:*` label convention in this repo.
+Several issue templates in this repo were inherited from the upstream
+OpenSearch Dashboards fork and still declare stale labels in their
+frontmatter (bare `enhancement`, `compatibility`) that don't exist as real
+labels here — GitHub silently drops any label that doesn't exist instead of
+erroring, so filing the template as-is can result in no type label at all.
+Standardize on the real Wazuh label set instead of trusting the frontmatter
+verbatim:
+
+| Intent | Real label to apply |
+|--------|--------|
+| Bug / defect | `type/bug` (this repo's bare `bug` label is also real, but prefer `type/bug` for consistency with the rest of the label set) |
+| Feature / enhancement | `type/enhancement` |
+| Engineering task / chore | `level/task` |
+| Every issue | `untriaged` — applied automatically on open/reopen/transfer by `.github/workflows/add-untriaged.yml`, no manual action needed |
+
+Do not invent labels beyond this set, and do not invent an approval
+workflow — there is no `status:*` label convention in this repo.
 
 ### 5. Emit the ready-to-file body + report
 

--- a/.claude/skills/resolve-cve/SKILL.md
+++ b/.claude/skills/resolve-cve/SKILL.md
@@ -96,9 +96,10 @@ Then invoke **create-pr** in its default prepare-and-hand-off mode. It applies t
 shared rules automatically:
 
 - Base = the version branch the work started from (not always `main`).
-- CVE issues usually live in **`internal-devel-requests`** → "Issues Resolved"
-  left empty and **no CHANGELOG entry**. If the CVE issue is public, use `closes`
-  and add a CHANGELOG entry (under `Fixed`/`Changed`) linking the **issue**.
+- CVE issues usually live in **`internal-devel-requests`** → leave the
+  `## Description` closing reference empty and **no CHANGELOG entry**. If the
+  CVE issue is public, use `Closes #<issue_number>` and add a CHANGELOG entry
+  (under `Fixed`/`Changed`) linking the **issue**.
 - Commits DCO-signed.
 
 Suggested PR title: `Fix <CVE-id>: bump <package> to <safe-version>`.

--- a/.github/ISSUE_TEMPLATE/task_template.md
+++ b/.github/ISSUE_TEMPLATE/task_template.md
@@ -2,7 +2,7 @@
 name: 🛠️ Task
 about: Track an engineering task or improvement (not a bug, feature request, compatibility request, or release)
 title: ''
-labels: level/task, type/task
+labels: level/task
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/task_template.md
+++ b/.github/ISSUE_TEMPLATE/task_template.md
@@ -1,0 +1,29 @@
+---
+name: 🛠️ Task
+about: Track an engineering task or improvement (not a bug, feature request, compatibility request, or release)
+title: ''
+labels: level/task, type/task
+assignees: ''
+---
+
+## Description
+
+<!--
+Describe the task: what needs to change and why. Include relevant context.
+-->
+
+### Code references
+
+<!--
+Link the relevant code locations that give context for this task, grouped by repository, for example:
+
+#### Wazuh dashboard
+https://github.com/wazuh/wazuh-dashboard/blob/<commit>/<path>#L<line>
+
+#### Wazuh dashboard plugins
+https://github.com/wazuh/wazuh-dashboard-plugins/blob/<commit>/<path>#L<line>
+-->
+
+## Tasks
+
+- [ ] <!-- List the concrete, actionable steps needed to complete this task -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,72 @@
-### Description
-
-<!-- Describe what this change achieves-->
-
-### Issues Resolved
-
-<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
-<!-- Example: closes #1234 or fixes <Issue_URL> -->
-
-## Screenshot
-
-<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
-
-## Testing the changes
+## Description
 
 <!--
-  Please provide detailed steps for validating your changes. This could involve specific commands to run,
-  pages to visit, scenarios to try or any other information that would help reviewers verify
-  the functionality of your change
+Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
+
+If this pull request resolves an existing issue, reference it here. For example:
+Closes #<issue_number>
 -->
 
-## Changelog
+## Proposed Changes
+
 <!--
-Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
-- fix: Update the graph
-- feat: Add a new feature
-
-If this change does not need to added to the changelog, just add a single `skip` line e.g.
-- skip
-
-Descriptions following the prefixes must be 100 characters long or less
+Summarize the changes made in this pull request. Include:
+- Features added
+- Bugs fixed
+- Any relevant technical details
 -->
 
-### Check List
+### Results and Evidence
+
+<!--
+Provide evidence of the changes made, such as:
+- Logs
+- Screenshots
+- Before/after comparisons
+-->
+
+### Artifacts Affected
+
+<!--
+List the artifacts impacted by this pull request, such as:
+- Executables (specify platforms if applicable)
+- Default configuration files
+- Packages
+-->
+
+### Configuration Changes
+
+<!--
+If applicable, list any configuration changes introduced by this pull request, including:
+- New configuration parameters
+- Changes to default values
+- Backward compatibility notes
+-->
+
+### Documentation Updates
+
+<!--
+If applicable, list the sections of documentation that have been updated as part of this pull request.
+-->
+
+### Tests Introduced
+
+<!--
+If applicable, describe any new unit or integration tests added as part of this pull request. Include:
+- Scope of the tests
+- Any relevant details about test coverage
+-->
+
+### How to Test
+
+<!--
+Describe the manual steps a reviewer can follow to verify this change works, such as:
+- Steps to reproduce/validate the change
+- Environment or setup needed (branch, data, feature flags, etc.)
+- Expected result
+-->
+
+### Review Checklist
 
 - [ ] All tests pass
   - [ ] `yarn test:jest`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,15 +57,6 @@ If applicable, describe any new unit or integration tests added as part of this 
 - Any relevant details about test coverage
 -->
 
-### How to Test
-
-<!--
-Describe the manual steps a reviewer can follow to verify this change works, such as:
-- Steps to reproduce/validate the change
-- Environment or setup needed (branch, data, feature flags, etc.)
-- Expected result
--->
-
 ### Review Checklist
 
 - [ ] All tests pass

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,12 +57,19 @@ If applicable, describe any new unit or integration tests added as part of this 
 - Any relevant details about test coverage
 -->
 
-### Review Checklist
+## Review Checklist
 
-- [ ] All tests pass
-  - [ ] `yarn test:jest`
-  - [ ] `yarn test:jest_integration`
-- [ ] New functionality includes testing.
-- [ ] New functionality has been documented.
-- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
-- [ ] Commits are signed per the DCO using --signoff
+<!--
+List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
+-->
+
+- [ ] Code changes reviewed
+- [ ] Relevant evidence provided
+- [ ] Tests cover the new functionality
+- [ ] Configuration changes documented
+- [ ] Developer documentation reflects the changes
+- [ ] Meets requirements and/or definition of done
+- [ ] No unresolved dependencies with other issues
+- [ ] PR is linked to the relevant issue(s)
+- [ ] Correct labels applied (e.g., `no-changelog`)
+- [ ] ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,16 +152,18 @@ Full detail in [`CONTRIBUTING.md`](CONTRIBUTING.md). Essentials:
 - **Sign commits** (DCO `--signoff`). Imperative, capitalized subject.
 - Open PRs as **Draft** (CI skips drafts); run lint + tests locally, then "Ready
   for review". Squash merge for single-purpose PRs.
-- UI changes require a screenshot/video in the PR (`## Screenshot` section of the
-  [PR template](.github/pull_request_template.md)).
+- UI changes require a screenshot/video in the PR (`### Results and Evidence`
+  section of the [PR template](.github/pull_request_template.md)); manual
+  verification steps go in `### How to Test`.
 - **Changelog:** the Wazuh user-facing changelog is [`CHANGELOG.md`](CHANGELOG.md)
-  (entries **link to the issue, not the PR**). The `changelogs/fragments/*.yml`
-  system and the PR's `## Changelog` section are inherited upstream OSD tooling —
-  Wazuh maintains `CHANGELOG.md` by hand; use `- skip` (or a conventional
-  `feat:`/`fix:` line) in the PR `## Changelog` section.
+  (entries **link to the issue, not the PR**). Wazuh maintains `CHANGELOG.md` by
+  hand. The PR template no longer carries a `## Changelog` section; the
+  `changelogs/fragments/*.yml` system remains inherited upstream OSD tooling for
+  upstream OpenSearch PRs only.
 - Issues arrive as URLs and may live in another repo. Issues from
   `internal-devel-requests` are internal: don't expose their link in the PR
-  ("Issues Resolved" empty) and add no CHANGELOG entry.
+  (leave the `## Description` closing reference empty) and add no CHANGELOG
+  entry.
 
 ## Fork coexistence
 


### PR DESCRIPTION
## Description

Closes #1446

This change adds a new repo-local `issue-creation` skill and de-duplicates the PR template so the `create-pr` skill only references it instead of duplicating its content.

## Proposed Changes

- Added `.claude/skills/issue-creation/SKILL.md`: classifies intent, runs an issue-first duplicate check, and fills the correct `.github/ISSUE_TEMPLATE/*.md` file with real labels only — no invented labels or approval workflow. Standardized to the same structure/wording used across every Wazuh Dashboard repo in this cross-repo initiative.
- Added `.github/ISSUE_TEMPLATE/task_template.md` for generic engineering tasks (labels: `level/task, type/task`).
- Rewrote `.github/pull_request_template.md` to the new structure (this PR's own body uses it).
- De-duplicated `.claude/skills/create-pr/SKILL.md`: replaced the verbatim PR template copy with a plain reference to the template file, fixed the `gh pr create` example to use `--body-file`, and added a rule that CHANGELOG entries must stay concise and user-facing.
- Fixed stale references to the old template's section names in `.claude/skills/develop-issue/SKILL.md`, `.claude/skills/resolve-cve/SKILL.md`, and `CLAUDE.md`.

### Results and Evidence

No UI change — this PR only touches Markdown skill/template files consumed by Claude Code and GitHub's issue/PR forms. Verified manually:
- `.github/pull_request_template.md` renders correctly on GitHub (this PR body is filled from it).
- Repo-wide grep confirms zero remaining references to the old `## Screenshot` / `### Issues Resolved` / `## Changelog` sections across `.claude/skills/` and `CLAUDE.md`.
- `issue-creation/SKILL.md`'s label table cross-checked against the real frontmatter of every `.github/ISSUE_TEMPLATE/*.md` file, including `task_template.md`.

### Artifacts Affected

- `.claude/skills/issue-creation/SKILL.md` (new)
- `.github/ISSUE_TEMPLATE/task_template.md` (new)
- `.github/pull_request_template.md`
- `.claude/skills/create-pr/SKILL.md`
- `.claude/skills/develop-issue/SKILL.md`
- `.claude/skills/resolve-cve/SKILL.md`
- `CLAUDE.md`

### Configuration Changes

None.

### Documentation Updates

`CLAUDE.md`'s Git/PR workflow section was updated to match the new PR template's section names (`### Results and Evidence`, `### How to Test`) and to remove the stale `## Changelog`/`- skip` convention note. `issue-creation/SKILL.md` follows the same structure standardized across every repo in this initiative.

### Tests Introduced

None — this is a documentation/skill-Markdown-only change; no executable code is touched, so no automated tests apply.

### How to Test

1. Open `.claude/skills/issue-creation/SKILL.md` and confirm each intent row maps to a real file under `.github/ISSUE_TEMPLATE/` with matching labels, including `task_template.md`.
2. Open `.github/pull_request_template.md` on GitHub (or via "Preview") and confirm it renders as this PR's body does.
3. Grep `.claude/skills/create-pr/SKILL.md` for the old template text — confirm no verbatim PR-template body remains, only a file reference.
4. Grep the repo for `## Screenshot` and `Issues Resolved` — confirm no remaining hits outside archived/historical content.

### Review Checklist

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md) — skipped: docs/tooling-only change, no user-facing dashboard impact (`no-changelog` label applied).
- [x] Commits are signed per the DCO using --signoff
