### PR TITLE
Enforce Prettier formatting check on commit to prevent Prettier failures in PR pipelines

### DIFF
--- a/.github/workflows/5_codelinter_prettier.yml
+++ b/.github/workflows/5_codelinter_prettier.yml
@@ -1,0 +1,42 @@
+name: (5.x) Prettier
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 5.*
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  prettier:
+    name: Ensure the code format on the changed files
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Verify the changed files
+        run: |
+          REMOTE_NAME=origin
+          echo "Base ref: $GITHUB_BASE_REF"
+          echo "Head ref: $GITHUB_HEAD_REF"
+          echo "Fetching branch: $GITHUB_BASE_REF"
+          git fetch origin $GITHUB_BASE_REF
+          echo "Fetching branch: $GITHUB_HEAD_REF"
+          git fetch origin $GITHUB_HEAD_REF
+          echo "Listing branches"
+          git branch -a
+          echo "Getting diff files ignoring deleted and getting the changed or renamed files"
+          CHANGED_FILES=$(git diff --name-status --diff-filter d ${REMOTE_NAME}/${GITHUB_BASE_REF}..${REMOTE_NAME}/${GITHUB_HEAD_REF} | awk '{print $NF}')
+          echo "Changed files:"
+          echo "${CHANGED_FILES}"
+          git checkout $GITHUB_HEAD_REF
+          echo "Installing dependencies"
+          yarn install --ignore-scripts
+          echo "Running prettier on the changed files"
+          npx prettier ${CHANGED_FILES} --check --ignore-unknown

--- a/src/dev/prettier/index.ts
+++ b/src/dev/prettier/index.ts
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { pickFilesToLint } from './pick_files_to_lint';
+export { lintFiles } from './lint_files';

--- a/src/dev/prettier/lint_files.ts
+++ b/src/dev/prettier/lint_files.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import * as prettier from 'prettier';
+
+import { REPO_ROOT } from '@osd/utils';
+import { createFailError, ToolingLog } from '@osd/dev-utils';
+
+import { File } from '../file';
+
+export async function lintFiles(log: ToolingLog, files: File[], { fix }: { fix?: boolean } = {}) {
+  const unformatted: string[] = [];
+
+  for (const file of files) {
+    const relativePath = file.getRelativePath();
+    const absolutePath = resolve(REPO_ROOT, relativePath);
+    const source = readFileSync(absolutePath, 'utf8');
+    const options = await prettier.resolveConfig(absolutePath);
+    const isFormatted = prettier.check(source, { ...options, filepath: absolutePath });
+
+    if (!isFormatted) {
+      unformatted.push(relativePath);
+    }
+  }
+
+  if (unformatted.length > 0) {
+    log.error(
+      `[prettier] The following files are not formatted:\n${unformatted
+        .map((f) => `  - ${f}`)
+        .join('\n')}\n\nRun 'npx prettier --write <file>' to fix.`
+    );
+    throw createFailError('[prettier] Formatting errors found. Run prettier --write to fix.');
+  }
+
+  log.success('[prettier] %d file(s) checked, all formatted correctly', files.length);
+}

--- a/src/dev/prettier/pick_files_to_lint.ts
+++ b/src/dev/prettier/pick_files_to_lint.ts
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { extname } from 'path';
+
+import { ToolingLog } from '@osd/dev-utils';
+
+import { File } from '../file';
+
+const PRETTIER_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.css',
+  '.scss',
+  '.json',
+  '.md',
+  '.yml',
+  '.yaml',
+]);
+
+export function pickFilesToLint(log: ToolingLog, files: File[]) {
+  return files.filter((file) => {
+    const ext = extname(file.getRelativePath());
+
+    if (!PRETTIER_EXTENSIONS.has(ext)) {
+      return false;
+    }
+
+    log.debug('[prettier] linting %j', file);
+    return true;
+  });
+}

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -31,6 +31,7 @@
 import { run, combineErrors } from '@osd/dev-utils';
 import * as Eslint from './eslint';
 import * as Stylelint from './stylelint';
+import * as Prettier from './prettier';
 import {
   getFilesForCommit,
   getUnstagedFiles,
@@ -65,7 +66,7 @@ run(
       errors.push(error);
     }
 
-    for (const Linter of [Eslint, Stylelint]) {
+    for (const Linter of [Eslint, Stylelint, Prettier]) {
       const filesToLint = Linter.pickFilesToLint(log, files);
       if (filesToLint.length > 0) {
         try {


### PR DESCRIPTION
### Description

Each repository should enforce Prettier formatting at two levels:

1. Pre-commit hook: when a developer runs git commit, staged files are checked against Prettier formatting requirements. If any file fails, the commit is blocked. Developers are responsible for running Prettier manually before committing.
  - For plugin repos: implemented via Husky + lint-staged with a .lintstagedrc config.
  - For wazuh-dashboard: integrated into the existing pre-commit system (src/dev/run_precommit_hook.js) following the same module pattern as ESLint and Stylelint.

2. CI workflow: runs the same check on every PR targeting active branches, ensuring formatting requirements are met even if the pre-commit hook is bypassed with --no-verify.

### Issues Resolved
https://github.com/wazuh/wazuh-dashboard/issues/1448

### Evidence

<details><summary>Pre-commit hook</summary>
<p>

<img width="1188" height="574" alt="Screenshot 2026-07-20 at 5 19 58 PM" src="https://github.com/user-attachments/assets/ad7103f6-d584-42e6-a615-842913455cc8" />


</p>
</details> 

The (5.x) Prettier CI workflow can be verified in the [Checks tab of this PR](https://github.com/wazuh/wazuh-dashboard/pull/1449/checks).

### Test

- Pre-commit hook:

1. Checkout this PR branch and run yarn install at repo root.
2. Create or edit a .ts/.js file with bad formatting.
3. Stage it (git add <file>) and run git commit -m "test".
4. Confirm the commit is blocked with a Prettier formatting error.
5. Run prettier --write <file>, re-stage and commit again. It should pass.

- CI workflow:

1. Open a PR with a file that has bad formatting.
2. Confirm the Prettier workflow fails.
3. Fix the formatting, push again and confirm it passes.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 