### PR TITLE
Change bumper_repository workflows merge type

### DIFF
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         run: |

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Merge pull request
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         if: inputs.revert != true

--- a/.github/workflows/6_bumper_repository.yml
+++ b/.github/workflows/6_bumper_repository.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         run: |


### PR DESCRIPTION
## Description

`4_bumper_repository.yml`, `5_bumper_repository.yml`, and `6_bumper_repository.yml` currently merge their generated bump PRs with `gh pr merge --merge --admin`, which creates a merge commit — inconsistent with this repo's squash-merge convention for single-purpose PRs. This PR switches all three to `--squash --admin`.

Closes #1459

## Proposed Changes

- `.github/workflows/4_bumper_repository.yml`: `gh pr merge ... --merge --admin` → `gh pr merge ... --squash --admin`.
- `.github/workflows/5_bumper_repository.yml`: same change.
- `.github/workflows/6_bumper_repository.yml`: same change.

### Results and Evidence

`git diff origin/5.0.0..HEAD` shows exactly 3 files changed, 3 lines total — no other content touched:

```diff
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -144,7 +144,7 @@
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -242,7 +242,7 @@
       - name: Merge pull request
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin

--- a/.github/workflows/6_bumper_repository.yml
+++ b/.github/workflows/6_bumper_repository.yml
@@ -144,7 +144,7 @@
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
```

### Artifacts Affected

- `.github/workflows/4_bumper_repository.yml`, `5_bumper_repository.yml`, `6_bumper_repository.yml` (CI workflows, no runtime/build artifact).

### Configuration Changes

None (CI merge-strategy flag only — no new parameters, no default-value changes).

### Documentation Updates

None.

### Tests Introduced

None. This is a non-executable CLI flag change in 3 GitHub Actions steps — no unit-testable logic exists, and `tools/tests/test_repository_bumper.sh` only covers the local version-bump script, never the `gh pr merge` step. Verified manually via direct diff/read inspection against `origin/5.0.0`.

### How to Test

1. Confirm each of `4_/5_/6_bumper_repository.yml` passes `--squash --admin` (not `--merge --admin`) in its "Merge pull request" step.
2. (Optional, real effect only observable in CI) On the next bumper run on this branch, confirm the generated bump PR is merged via squash rather than a merge commit.

### Review Checklist

- [ ] All tests pass
  - [ ] `yarn test:jest` — N/A, no JS/TS changed
  - [ ] `yarn test:jest_integration` — N/A, no JS/TS changed
- [ ] New functionality includes testing. — N/A, no executable logic changed (see Tests Introduced)
- [ ] New functionality has been documented. — N/A
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md) — Skipped: internal CI tooling, no user-facing impact
- [x] Commits are signed per the DCO using --signoff
