### PR TITLE
Add wazuh-ai-assistant to the 5.x package build pipeline

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -140,6 +140,7 @@ jobs:
       NAME_PLUGIN_WAZUH: ${{ steps.get-plugins.outputs.NAME_PLUGIN_WAZUH }}
       NAME_PLUGIN_CORE: ${{ steps.get-plugins.outputs.NAME_PLUGIN_CORE }}
       NAME_PLUGIN_CHECK_UPDATES: ${{ steps.get-plugins.outputs.NAME_PLUGIN_CHECK_UPDATES }}
+      NAME_PLUGIN_AI_ASSISTANT: ${{ steps.get-plugins.outputs.NAME_PLUGIN_AI_ASSISTANT }}
       NAME_PLUGIN_SECURITY: ${{ steps.get-plugins.outputs.NAME_PLUGIN_SECURITY }}
       NAME_PLUGIN_REPORTING: ${{ steps.get-plugins.outputs.NAME_PLUGIN_REPORTING }}
       NAME_PLUGIN_SECURITY_ANALYTICS: ${{ steps.get-plugins.outputs.NAME_PLUGIN_SECURITY_ANALYTICS }}
@@ -165,6 +166,10 @@ jobs:
             packageName: wazuh-dashboard-plugins_wazuh-check-updates
             repository: https://github.com/wazuh/wazuh-dashboard-plugins.git
             outputNamePackage: NAME_PLUGIN_CHECK_UPDATES
+          - name: plugins-ai-assistant
+            packageName: wazuh-dashboard-plugins_wazuh-ai-assistant
+            repository: https://github.com/wazuh/wazuh-dashboard-plugins.git
+            outputNamePackage: NAME_PLUGIN_AI_ASSISTANT
           - name: reporting
             packageName: wazuh-dashboard-reporting
             repository: https://github.com/wazuh/wazuh-dashboard-reporting.git
@@ -309,6 +314,11 @@ jobs:
             repo: wazuh/wazuh-dashboard-plugins
             pathPlugin: plugins/wazuh-dashboard-plugins
             path: plugins/wazuh-core
+          - name: wazuh-dashboard-plugins_wazuh-ai-assistant
+            packageName: ${{ needs.get-outputs-plugins.outputs.NAME_PLUGIN_AI_ASSISTANT }}
+            repo: wazuh/wazuh-dashboard-plugins
+            pathPlugin: plugins/wazuh-dashboard-plugins
+            path: plugins/wazuh-ai-assistant
           - name: reports-dashboards
             packageName: ${{ needs.get-outputs-plugins.outputs.NAME_PLUGIN_REPORTING }}
             repo: wazuh/wazuh-dashboard-reporting


### PR DESCRIPTION
## Description

[wazuh/wazuh-dashboard-plugins#8790](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8790)
adds a new plugin, **Wazuh AI Assistant**, as `plugins/wazuh-ai-assistant/`
inside `wazuh-dashboard-plugins`, following the same layout as `plugins/main`,
`plugins/wazuh-core` and `plugins/wazuh-check-updates`.

That PR only touches its own repo (its dev-environment CI matrix and the
docker dev-environment plugin list). It does not touch `wazuh-dashboard`,
where the pipeline that actually assembles the final `wazuh-dashboard`
package lives. `5_builderpackage_dashboard.yml` builds each
`wazuh-dashboard-plugins` sub-plugin from two hardcoded matrices — new plugins
are not auto-discovered — so without this change, `wazuh-ai-assistant` would
never be built or bundled into the final package once wazuh/wazuh-dashboard-plugins#8790 merges.

## Proposed Changes

- Added a `plugins-ai-assistant` entry (and its `NAME_PLUGIN_AI_ASSISTANT`
  output) to the `get-outputs-plugins` job matrix in
  `.github/workflows/5_builderpackage_dashboard.yml`, following the same
  pattern already used for `plugins-main`, `plugins-core` and
  `plugins-check-updates`.
- Added a `wazuh-dashboard-plugins_wazuh-ai-assistant` entry to the
  `build-plugins` job matrix in the same file, pointing at
  `plugins/wazuh-ai-assistant` inside the `wazuh-dashboard-plugins` checkout.
- No other file needed changes: the "Download artifacts from S3" and "Zip
  plugins" steps in the `build-package` job already treat any
  `wazuh-dashboard-plugins*` artifact as part of the same merged
  `wazuh-package.zip`, and `dev-tools/build-packages/base/base-builder.sh`
  discovers and installs bundled plugins dynamically (`ls`-based), so the new
  plugin rides along automatically once it's built by CI.

### Results and Evidence

- `actionlint .github/workflows/5_builderpackage_dashboard.yml` — same 144
  pre-existing warnings before and after the change (all pre-existing
  shellcheck/style notices unrelated to this diff); no new warnings
  introduced.
- `npx prettier .github/workflows/5_builderpackage_dashboard.yml --check` —
  passes, no formatting issues.
- No JS/TS/SCSS files were touched, so ESLint/typecheck/Jest are not
  applicable to this change.

<img width="1506" height="1411" alt="image" src="https://github.com/user-attachments/assets/46bcc5d9-d87a-40fe-81d8-3b907b632c34" />
<img width="1506" height="1411" alt="image" src="https://github.com/user-attachments/assets/22b489cc-63e0-4d53-886b-3dab7758a62b" />


### Artifacts Affected

- `.github/workflows/5_builderpackage_dashboard.yml` (CI workflow only — no
  runtime code, no built binaries changed by this PR itself).
- Downstream effect: once merged and once wazuh/wazuh-dashboard-plugins#8790 is
  available, the `wazuh-dashboard` package produced by this workflow will
  include the `wazuh-ai-assistant` plugin.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — this is a CI/build workflow configuration change with no application
code affected.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — not applicable, no application code
- [ ] Configuration changes documented — not applicable, none
- [ ] Developer documentation reflects the changes — not applicable, none
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues — depends on
      wazuh/wazuh-dashboard-plugins#8790 being merged for
      `plugins/wazuh-ai-assistant` to actually exist in that repo
- [ ] PR is linked to the relevant issue(s) — no tracked issue in this repo
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
