### PR TITLE
 Add AI assistant encryption key on installation

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -644,6 +644,14 @@ jobs:
                 echo 'Service not running' ;\
                 exit 1 ;\
               fi; \
+              if sudo runuser wazuh-dashboard --shell='/bin/bash' \
+                --command='/usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore list' \
+                | grep -q '^wazuh_ai_assistant.encryptionKey$'; then \
+                echo 'AI assistant encryption key present in keystore'; \
+              else \
+                echo 'AI assistant encryption key missing from keystore'; \
+                exit 1; \
+              fi; \
               sudo yum remove wazuh-dashboard -y ;\
               sudo rm -rf /var/lib/wazuh-dashboard/ ; \
               sudo rm -rf /usr/share/wazuh-dashboard/ ; \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Set v9 theme as default [#1092](https://github.com/wazuh/wazuh-dashboard/pull/1092)
 - Added version, revision, and stage to the Wazuh build metadata [#1327](https://github.com/wazuh/wazuh-dashboard/pull/1327) [#1421](https://github.com/wazuh/wazuh-dashboard/pull/1421)
 - Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)
+- Added automatic generation and storage of the AI assistant encryption key on first install [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)
 
 ### Fixed
 

--- a/dev-tools/build-packages/deb/debian/postinst
+++ b/dev-tools/build-packages/deb/debian/postinst
@@ -42,6 +42,27 @@ configure)
         runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create" >/dev/null 2>&1
         runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" >/dev/null 2>&1
         runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" >/dev/null 2>&1
+        WD_ENC_KEY=""
+        if command -v openssl >/dev/null 2>&1; then
+            WD_ENC_KEY=$(openssl rand -base64 32 2>/dev/null | tr -d '\n') || WD_ENC_KEY=""
+        fi
+        if [ -z "${WD_ENC_KEY}" ] && [ -r /dev/urandom ] && command -v base64 >/dev/null 2>&1; then
+            WD_ENC_KEY=$(head -c 32 /dev/urandom | base64 | tr -d '\n') || WD_ENC_KEY=""
+        fi
+        if [ -z "${WD_ENC_KEY}" ] && [ -x "${INSTALLATION_DIR}"/node/bin/node ]; then
+            WD_ENC_KEY=$("${INSTALLATION_DIR}"/node/bin/node -e \
+                "process.stdout.write(require('crypto').randomBytes(32).toString('base64'))" 2>/dev/null) || WD_ENC_KEY=""
+        fi
+        # base64 of exactly 32 raw bytes is always 44 characters (with one '=' pad)
+        if [ ${#WD_ENC_KEY} -eq 44 ]; then
+            echo "${WD_ENC_KEY}" | runuser "${NAME}" --shell="/bin/bash" \
+                --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add wazuh_ai_assistant.encryptionKey --stdin" \
+                >/dev/null 2>&1 \
+                || echo "wazuh-dashboard: warning: failed to store wazuh_ai_assistant.encryptionKey; configure it manually to enable the AI assistant." >&2
+        else
+            echo "wazuh-dashboard: warning: unable to generate wazuh_ai_assistant.encryptionKey; configure it manually to enable the AI assistant." >&2
+        fi
+        unset WD_ENC_KEY
     fi
     ;;
 

--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -178,6 +178,28 @@ if [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
   runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
+  WD_ENC_KEY=""
+  if command -v openssl > /dev/null 2>&1; then
+    WD_ENC_KEY=$(openssl rand -base64 32 2>/dev/null | tr -d '\n') || WD_ENC_KEY=""
+  fi
+  if [ -z "${WD_ENC_KEY}" ] && [ -r /dev/urandom ] && command -v base64 > /dev/null 2>&1; then
+    WD_ENC_KEY=$(head -c 32 /dev/urandom | base64 | tr -d '\n') || WD_ENC_KEY=""
+  fi
+  if [ -z "${WD_ENC_KEY}" ] && [ -x %{INSTALL_DIR}/node/bin/node ]; then
+    WD_ENC_KEY=$(%{INSTALL_DIR}/node/bin/node -e \
+      "process.stdout.write(require('crypto').randomBytes(32).toString('base64'))" 2>/dev/null) || WD_ENC_KEY=""
+  fi
+  # base64 of exactly 32 raw bytes is always 44 characters (with one '=' pad)
+  if [ ${#WD_ENC_KEY} -eq 44 ]; then
+    echo "${WD_ENC_KEY}" | runuser %{USER} --shell="/bin/bash" \
+      --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore add wazuh_ai_assistant.encryptionKey --stdin" \
+      > /dev/null 2>&1 \
+      || echo "wazuh-dashboard: warning: failed to store wazuh_ai_assistant.encryptionKey; configure it manually to enable the AI assistant." >&2
+  else
+    echo "wazuh-dashboard: warning: unable to generate wazuh_ai_assistant.encryptionKey; configure it manually to enable the AI assistant." >&2
+  fi
+  unset WD_ENC_KEY
+  true
 fi
 
 # -----------------------------------------------------------------------------

--- a/dev-tools/test-packages/deb-test-install-uninstall.sh
+++ b/dev-tools/test-packages/deb-test-install-uninstall.sh
@@ -26,6 +26,15 @@ else
   exit 1
 fi
 
+if runuser wazuh-dashboard --shell="/bin/bash" \
+  --command="/usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore list" \
+  | grep -q "^wazuh_ai_assistant.encryptionKey$"; then
+  echo "AI assistant encryption key present in keystore"
+else
+  echo "AI assistant encryption key missing from keystore"
+  exit 1
+fi
+
 apt-get remove --purge wazuh-dashboard -y
 if dpkg-query -W -f='${Status}' wazuh-dashboard 2>/dev/null | grep -q "install ok installed"; then
   echo "Package not uninstalled"


### PR DESCRIPTION
## Description

The `wazuh-ai-assistant` plugin requires a `wazuh_ai_assistant.encryptionKey` to encrypt stored AI provider API keys, but nothing currently provisions it automatically. Without a manually configured key, the plugin fails to start (or blocks saving API keys once the plugins-repo enforcement lands).

This PR generates and stores that key automatically during a fresh install, so the AI assistant works out of the box without manual keystore setup.

Closes #1480

## Proposed Changes

- Extended the existing first-install-only keystore provisioning block (the one that already sets `opensearch.username`/`opensearch.password`) in both packaging scripts to also generate and store `wazuh_ai_assistant.encryptionKey`:
  - `dev-tools/build-packages/deb/debian/postinst`
  - `dev-tools/build-packages/rpm/wazuh-dashboard.spec` (`%post`)
- The key is a random 32-byte secret, base64-encoded (`openssl rand -base64 32`), matching the format the AI assistant plugin's cipher expects.
- Fallback chain if `openssl` is unavailable: `/dev/urandom` + `base64`, then the bundled Node binary's `crypto.randomBytes`.
- If generation fails entirely, a non-fatal warning is logged to stderr and the install continues without the key (does not abort the package install).

### Results and Evidence

Manually verified by building an RPM package from this branch (`dev-tools/build-packages/build-packages.sh`) and installing it on a clean VM:
- The generation/validation logic to uses `openssl rand -base64 32` (44-character base64 string decoding to exactly 32 bytes) instead of hex. The dashboard started correctly and `opensearch-dashboards-keystore list` showed `wazuh_ai_assistant.encryptionKey` present after a fresh install.

https://github.com/user-attachments/assets/0ba9048c-4303-4fa8-999c-18c870eaadf3

#### Dashboard keystore entries:

```console
[root@wazuh-aio vagrant]# sudo /usr/share/wazuh-dashboard/node/bin/node -e '
const { Keystore } = require("/usr/share/wazuh-dashboard/src/legacy/server/keystore/keystore.js");
const k = new Keystore("/etc/wazuh-dashboard/opensearch_dashboards.keystore");
for (const key of k.keys()) console.log(key, "=", k.data[key]);
'
opensearch.username = kibanaserver
opensearch.password = kibanaserver
wazuh_ai_assistant.encryptionKey = qw/0XcIxc7xinPEkNim5A1ElQ/qooqNZoAzoOVEDaXE=
[root@wazuh-aio vagrant]#
```

#### Package build

<img width="1286" height="778" alt="image" src="https://github.com/user-attachments/assets/71091444-67d7-4a3a-af1b-97e383c03671" />

https://github.com/wazuh/wazuh-dashboard/actions/runs/30842558053/job/91798530514

### Artifacts Affected

- `dev-tools/build-packages/deb/debian/postinst` (Debian package)
- `dev-tools/build-packages/rpm/wazuh-dashboard.spec` (RPM package)

### Configuration Changes

- New keystore entry `wazuh_ai_assistant.encryptionKey`, auto-generated on install only.

### Documentation Updates

None in this PR.

### Tests Introduced

Extended the existing CI package smoke tests to assert the key is actually provisioned on a real fresh install:
- `dev-tools/test-packages/deb-test-install-uninstall.sh`: after the service starts, runs `opensearch-dashboards-keystore list` as the `wazuh-dashboard` user and fails the job if `wazuh_ai_assistant.encryptionKey` is missing.
- `.github/workflows/5_builderpackage_dashboard.yml` (RPM install/uninstall step): same assertion, run over SSH against the test VM.

### How to test

On a fresh 5.0.0 installation, verify that running the following command shows the `wazuh_ai_assistant.encryptionKey` entry:

```console
sudo /usr/share/wazuh-dashboard/node/bin/node -e '
const { Keystore } = require("/usr/share/wazuh-dashboard/src/legacy/server/keystore/keystore.js");
const k = new Keystore("/etc/wazuh-dashboard/opensearch_dashboards.keystore");
for (const key of k.keys()) console.log(key, "=", k.data[key]);
'
```

Also, from the UI, try configuring a provider in the AI assistant and confirm it saves correctly.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)

