### PR TITLE
Remove unnecessary debhelper install-time dependency

### DIFF
--- a/.github/workflows/build_wazuh_dashboard_with_plugins.yml
+++ b/.github/workflows/build_wazuh_dashboard_with_plugins.yml
@@ -411,7 +411,7 @@ jobs:
       - name: DEB - Test package upgrade
         if: ${{ needs.setup-variables.outputs.PREVIOUS != '' && inputs.system == 'deb' }}
         run: |
-          sudo apt-get install debhelper tar curl libcap2-bin #debhelper version 9 or later
+          sudo apt-get install tar curl libcap2-bin
           sudo apt-get install gnupg apt-transport-https
           sudo curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | sudo gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && sudo chmod 644 /usr/share/keyrings/wazuh.gpg
           sudo echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list

--- a/dev-tools/test-packages/deb-test-upgrade.sh
+++ b/dev-tools/test-packages/deb-test-upgrade.sh
@@ -11,7 +11,7 @@ PREVIOUS="$2"
 VERSION="$3"
 
 apt-get update
-apt-get install -y debhelper tar curl libcap2-bin gnupg apt-transport-https
+apt-get install -y tar curl libcap2-bin gnupg apt-transport-https
 curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH \
   | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import
 chmod 644 /usr/share/keyrings/wazuh.gpg


### PR DESCRIPTION
## Description

`debhelper` is only required to **build** the `.deb` package — it is declared
under `Build-Depends` in
[`dev-tools/build-packages/deb/debian/control`](dev-tools/build-packages/deb/debian/control#L5),
not under the package's runtime `Depends`. This repo's package **install/upgrade
test** step was nonetheless installing `debhelper` before installing the
pre-built `.deb`, which is unnecessary: `deb-test-install-uninstall.sh` already
installs/uninstalls the package without it and passes.

Backport of #1483 to `4.14.8`.

Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/8845

## Proposed Changes

- Removed `debhelper` from the `apt-get install` step in
  `.github/workflows/build_wazuh_dashboard_with_plugins.yml` ("DEB - Test
  package upgrade" job).
- Removed `debhelper` from the `apt-get install` step in
  `dev-tools/test-packages/deb-test-upgrade.sh`.
- Left the `Build-Depends: debhelper-compat (= 12)` entry in
  `dev-tools/build-packages/deb/debian/control` untouched — it is the correct,
  build-time-only declaration.

### Results and Evidence

Confirmed no other install-time reference to `debhelper` remains outside the
package build definition:

```
$ grep -rn "debhelper" .github dev-tools
dev-tools/build-packages/deb/debian/rules:3:# Sample debian/rules that uses debhelper.
dev-tools/build-packages/deb/debian/control:5:Build-Depends: debhelper-compat (= 12)
```

### Artifacts Affected

- CI workflow: `.github/workflows/build_wazuh_dashboard_with_plugins.yml`
- Package test script: `dev-tools/test-packages/deb-test-upgrade.sh`

No change to the built `.deb`/`.rpm` packages themselves or their runtime
dependencies.

### Configuration Changes

None.

### Documentation Updates

None in this repo (this repo's docs do not list `debhelper` as an install
dependency). The originating issue tracks follow-ups to remove `debhelper`
from install documentation in `wazuh-dashboard-plugins`,
`wazuh-packages`, and `wazuh-documentation`.

### Tests Introduced

None — this only removes an unused dependency from an existing CI test step.
The existing `deb-test-install-uninstall.sh` and `deb-test-upgrade.sh` CI jobs
continue to cover install/upgrade behavior and will validate that dropping
`debhelper` doesn't break them.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
