### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -187,11 +187,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -243,6 +246,17 @@ jobs:
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
+
+      - name: 'Result: original bump pull request not found'
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: 'Result: no changes to commit'
+        if: >-
+          (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Show logs
         if: inputs.revert != true


### PR DESCRIPTION
## Description

The release orchestration in `wazuh-qa-automation` now distinguishes a repository bump that **failed** from one that **had nothing to do**, so a release is no longer blocked by a repository where the bump was a no-op (see [wazuh-qa-automation#8027](https://github.com/wazuh/wazuh-qa-automation/issues/8027)).

Previously, `.github/workflows/5_bumper_repository.yml` ended with the `failure` conclusion in two harmless situations, giving the orchestrator no way to tell them apart from a real failure:

- On a revert run (`revert: true`), when the original bump pull request does not exist because that bump introduced no changes, the `Revert references (Revert)` step ran `exit 1`.
- On a bump run, when the bump script produces no changes, no pull request was created (already handled without failing by the existing `Detect if bump produced changes` step, which guards the commit).

Closes #1490

## Proposed Changes

- `Revert references (Revert)` no longer fails when the original bump pull request is not found: it now sets `pr_found=false` / `has_changes=false` outputs and exits `0` instead of running `exit 1`.
- Added a `pr_found=true` output on the success path so downstream steps and the new result step can distinguish "PR not found" from "PR found, nothing to revert".
- Added two reporting steps, matched by the release orchestrator by exact name:
  - `Result: original bump pull request not found` — runs when the revert couldn't locate the original bump PR.
  - `Result: no changes to commit` — runs when a bump run produced no changes, or a revert run found the PR but there were no references to revert.
- `Push changes`, `Create pull request` and `Merge pull request` remain skipped in both no-op cases, since their existing conditions already key off `has_changes`, which is now `false` in both no-op paths instead of the job failing before reaching them.
- Normal bump and normal revert behavior is unchanged: neither result step runs, and the flow proceeds through push/PR-create/merge as before.

### Results and Evidence

<!-- To be attached: links to the 4 validation runs (revert with no original PR, bump with no changes, normal bump, normal revert) with each step's conclusion. -->

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml` (internal CI workflow only; no product artifacts affected).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None (GitHub Actions workflow change; validated by running the workflow itself on the release branch per the issue's validation steps — see Results and Evidence).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)