### PR TITLE
Adapt RPM smoke-test workflow to Allocator package layout

### DIFF
--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -578,7 +578,7 @@ jobs:
         env:
           username: 'wazuh-devel-xdrsiem-dashboard'
         run: |
-          git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git
+          git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
           # Workaround: AWS CodeBuild ARM runners do not have pip3 or openssh-client pre-installed
           if ! command -v pip3 &>/dev/null || ! command -v ssh &>/dev/null; then
             sudo apt-get update
@@ -586,7 +586,7 @@ jobs:
             command -v ssh &>/dev/null || sudo apt-get install -y openssh-client
           fi
           cd wazuh-automation
-          pip3 install --retries 3 -r deployability/deps/requirements.txt
+          pip3 install --retries 3 ./deployability/modules/allocation
 
       - name: RPM - Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -606,7 +606,7 @@ jobs:
             INSTANCE_NAME="centos_8_arm_large_aws"
             COMPOSITE_NAME="centos_stream-8-arm64"
           fi
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
+          python3 -m allocation.main --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')
@@ -739,8 +739,7 @@ jobs:
         run: |
           if [ "${{ inputs.system }}" = "rpm" ]; then
             echo "Destroying Allocator Machine"
-            cd wazuh-automation/deployability
-            python3 modules/allocation/main.py --action delete --track-output "/tmp/track.yaml"
+            python3 -m allocation.main --action delete --track-output "/tmp/track.yaml"
           fi
 
   upload-package:

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -578,7 +578,8 @@ jobs:
         env:
           username: 'wazuh-devel-xdrsiem-dashboard'
         run: |
-          git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
+          # git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
+          git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b enhancement/2842-refactor-allocator-as-a-python-package-for-improved-dependency-management
           # Workaround: AWS CodeBuild ARM runners do not have pip3 or openssh-client pre-installed
           if ! command -v pip3 &>/dev/null || ! command -v ssh &>/dev/null; then
             sudo apt-get update

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -578,8 +578,7 @@ jobs:
         env:
           username: 'wazuh-devel-xdrsiem-dashboard'
         run: |
-          # git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
-          git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b enhancement/2842-refactor-allocator-as-a-python-package-for-improved-dependency-management
+          git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
           # Workaround: AWS CodeBuild runners may lack openssh-client, and the Allocator package
           # requires Python 3.12 specifically, while the runner's default python3 is 3.10
           if ! command -v ssh &>/dev/null || ! command -v python3.12 &>/dev/null; then

--- a/.github/workflows/5_builderpackage_dashboard.yml
+++ b/.github/workflows/5_builderpackage_dashboard.yml
@@ -580,14 +580,16 @@ jobs:
         run: |
           # git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash dev-tools/product_version.sh)
           git clone https://${{ env.username }}:${{ secrets.DASHBOARD_BOT_SMOKE_TEST_TOKEN }}@github.com/wazuh/wazuh-automation.git -b enhancement/2842-refactor-allocator-as-a-python-package-for-improved-dependency-management
-          # Workaround: AWS CodeBuild ARM runners do not have pip3 or openssh-client pre-installed
-          if ! command -v pip3 &>/dev/null || ! command -v ssh &>/dev/null; then
+          # Workaround: AWS CodeBuild runners may lack openssh-client, and the Allocator package
+          # requires Python 3.12 specifically, while the runner's default python3 is 3.10
+          if ! command -v ssh &>/dev/null || ! command -v python3.12 &>/dev/null; then
             sudo apt-get update
-            command -v pip3 &>/dev/null || sudo apt-get install -y python3-pip
             command -v ssh &>/dev/null || sudo apt-get install -y openssh-client
+            command -v python3.12 &>/dev/null || sudo apt-get install -y python3.12 python3.12-venv
           fi
+          python3.12 -m ensurepip --upgrade
           cd wazuh-automation
-          pip3 install --retries 3 ./deployability/modules/allocation
+          python3.12 -m pip install --retries 3 ./deployability/modules/allocation
 
       - name: RPM - Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -607,7 +609,7 @@ jobs:
             INSTANCE_NAME="centos_8_arm_large_aws"
             COMPOSITE_NAME="centos_stream-8-arm64"
           fi
-          python3 -m allocation.main --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
+          python3.12 -m allocation.main --action create --provider aws --size large --composite-name "${COMPOSITE_NAME}" --instance-name "${INSTANCE_NAME}" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team dashboard --label-termination-date 1d --label-creator github-actions --working-dir /tmp/dashboard --custom-tags "Product:wazuh-dashboard,Purpose:package-build,ExecutionId:${{ github.run_id }},Stage:ci"
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//')
           ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//')
@@ -740,7 +742,7 @@ jobs:
         run: |
           if [ "${{ inputs.system }}" = "rpm" ]; then
             echo "Destroying Allocator Machine"
-            python3 -m allocation.main --action delete --track-output "/tmp/track.yaml"
+            python3.12 -m allocation.main --action delete --track-output "/tmp/track.yaml"
           fi
 
   upload-package:


### PR DESCRIPTION
## Description

Adapt the `5_builderpackage_dashboard.yml` RPM smoke-test job to the new Allocator package layout (`wazuh-automation` refactored `deployability/modules/allocation` into an installable Python package.

## Proposed Changes

- Clone the `wazuh-automation` branch matching this repo's own version (`dev-tools/product_version.sh`) instead of always cloning the default branch, so the smoke test tracks the Allocator revision compatible with `5.0.0`.
- Install the Allocator via `pip3 install ./deployability/modules/allocation` instead of the removed `deployability/deps/requirements.txt`.
- Invoke the Allocator via `python3 -m allocation.main` (create/delete) instead of the old `deployability/modules/allocation/main.py` path.

### Results and Evidence

https://github.com/wazuh/wazuh-dashboard/actions/runs/31721533413/job/94535049799

### Artifacts Affected

- `.github/workflows/5_builderpackage_dashboard.yml`

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)