### PR TITLE
Recalculate flyout position when the sidecar is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 | [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278) [#1279](https://github.com/wazuh/wazuh-dashboard/pull/1279) | Excluded Wazuh dashboards and visualizations listing                                                               |
 | [#1330](https://github.com/wazuh/wazuh-dashboard/pull/1330)                                                             | Changed log level of the cross compatibility service on start                                                      |
 | [#1328](https://github.com/wazuh/wazuh-dashboard/pull/1328) [#1365](https://github.com/wazuh/wazuh-dashboard/pull/1365) | Changed pre install scripts to block Wazuh dashboard installation if there's an existing installation prior to 5.x |
+| [#8979](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979)                                                   | Changed the sidecar flyout to displace open flyouts instead of covering them                                       |
 
 ## Prior versions
 

--- a/src/core/public/overlays/sidecar/components/sidecar.scss
+++ b/src/core/public/overlays/sidecar/components/sidecar.scss
@@ -45,3 +45,19 @@
     height: 100%;
   }
 }
+
+// WAZUH
+// EuiFlyout is `position: fixed` and portaled to <body>, so it sits outside
+// the app-wrapper subtree that the sidecar pushes over via padding (see
+// getOsdSidecarPaddingStyle). Left to itself it keeps `right: 0` / `left: 0`
+// and ends up underneath the sidecar instead of beside it. `Sidecar` keeps
+// these attributes/custom property in sync with its own config while docked
+// left or right (not for `--dockedTakeover`, which is meant to cover
+// everything), so displace any open flyout by that same amount here.
+body[data-osd-sidecar-docked-mode='right'] .euiFlyout:not(.euiFlyout--left) {
+  right: var(--osdSidecarSize, 0);
+}
+
+body[data-osd-sidecar-docked-mode='left'] .euiFlyout--left {
+  left: var(--osdSidecarSize, 0);
+}

--- a/src/core/public/overlays/sidecar/components/sidecar.tsx
+++ b/src/core/public/overlays/sidecar/components/sidecar.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { BehaviorSubject } from 'rxjs';
 import classNames from 'classnames';
@@ -56,6 +56,33 @@ export const Sidecar = ({ sidecarConfig$, options, setSidecarConfig, i18n, mount
           },
     [sidecarConfig]
   );
+
+  // WAZUH
+  // Other overlays (e.g. EuiFlyout) are rendered outside this component's DOM
+  // subtree, so they can't be shifted via a padding/width style the way the
+  // app-wrapper is. Expose the docked side and size on `document.body` so
+  // global CSS can displace them instead of letting the sidecar cover them.
+  useEffect(() => {
+    const { body } = document;
+    const isSideDocked =
+      sidecarConfig &&
+      !sidecarConfig.isHidden &&
+      (sidecarConfig.dockedMode === SIDECAR_DOCKED_MODE.LEFT ||
+        sidecarConfig.dockedMode === SIDECAR_DOCKED_MODE.RIGHT);
+
+    if (isSideDocked) {
+      body.dataset.osdSidecarDockedMode = sidecarConfig!.dockedMode;
+      body.style.setProperty('--osdSidecarSize', `${sidecarConfig!.paddingSize}px`);
+    } else {
+      delete body.dataset.osdSidecarDockedMode;
+      body.style.removeProperty('--osdSidecarSize');
+    }
+
+    return () => {
+      delete body.dataset.osdSidecarDockedMode;
+      body.style.removeProperty('--osdSidecarSize');
+    };
+  }, [sidecarConfig]);
 
   return (
     <i18n.Context>


### PR DESCRIPTION
## Description

When a view has both an `EuiFlyout` and the platform's `SidecarFlyout` (`src/core/public/overlays/sidecar`) open at the same time, the sidecar renders on top of the flyout (z-index `$euiZMaskBelowHeader + 1` vs. the flyout's `$euiZFlyout`), covering its content and leaving it unreadable. The sidecar already knows how to displace normal in-flow app content by padding `#app-wrapper` and the header nav, but `EuiFlyout` is `position: fixed` and portaled to `<body>`, outside that padded subtree, so it never gets shifted — the two overlays only ever interacted through z-index stacking.

Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979

## Proposed Changes

- `Sidecar` (`sidecar.tsx`) now mirrors its live `dockedMode`/`paddingSize` onto `document.body` (`data-osd-sidecar-docked-mode` attribute + `--osdSidecarSize` custom property) whenever it's docked left or right — the one shared ancestor between the sidecar and any portaled flyout. Cleared on hide/close/unmount. `takeover` mode is intentionally excluded, matching the existing exclusion in `getOsdSidecarPaddingStyle`.
- `sidecar.scss` adds a small global rule that reads that state to shift any open `.euiFlyout` by the sidecar's current width, so the flyout is pushed aside instead of hidden underneath the sidecar. This updates live during sidecar resize.
- No changes required in individual plugins that open flyouts alongside a sidecar — the fix is centralized in the core sidecar component.
- Added a `CHANGELOG.md` entry under **Changed**.

### Results and Evidence

<img width="3265" height="1904" alt="image" src="https://github.com/user-attachments/assets/2022396a-2131-4808-bc5d-f2d38c87cafd" />


### Artifacts Affected

- `src/core/public/overlays/sidecar/components/sidecar.tsx`
- `src/core/public/overlays/sidecar/components/sidecar.scss`
- `CHANGELOG.md`

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None added in this PR. Existing unit tests for `Sidecar` (`sidecar.test.tsx`) were not modified; manual verification in the browser is still needed to confirm the flyout displacement looks correct in both docked-left and docked-right modes, including during sidecar resize.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
