### PR TITLE
Add dev image build tooling for 4.14.x

### DIFF
--- a/.github/workflows/4_builderpackage_dev_docker_image.yml
+++ b/.github/workflows/4_builderpackage_dev_docker_image.yml
@@ -1,0 +1,142 @@
+# This workflow automates the build and push of Wazuh dashboard development
+# Docker images for different architectures (amd64 and arm64).
+#
+# This workflow:
+# - Builds multi-architecture Docker images for Wazuh dashboard development.
+# - Pushes individual architecture images to Quay.io registry.
+# - Creates and pushes a multi-arch manifest combining both architectures.
+# - Automatically extracts the Node.js version from .nvmrc and the OpenSearch
+#   Dashboards version from package.json.
+# - Uses the branch the workflow runs on for wazuh-dashboard, and a single
+#   optional input for the branch/tag of the plugin repositories
+#   (wazuh-security-dashboards-plugin and wazuh-dashboard-plugins), which
+#   defaults to that same branch when not provided.
+
+name: (4.14.x) Build and Push Dev Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugins_branch:
+        description: 'Branch/tag/commit of wazuh-security-dashboards-plugin and wazuh-dashboard-plugins (defaults to the branch this workflow runs on)'
+        required: false
+        default: ''
+        type: string
+      tag:
+        description: 'Tag for the Docker image'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  extract-versions:
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    outputs:
+      node_version: ${{ steps.versions.outputs.node_version }}
+      opensearch_version: ${{ steps.versions.outputs.opensearch_version }}
+      tag: ${{ steps.versions.outputs.tag }}
+      wazuh_branch: ${{ steps.versions.outputs.wazuh_branch }}
+      plugins_branch: ${{ steps.versions.outputs.plugins_branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract versions from repository
+        id: versions
+        run: |
+          OPENSEARCH_VERSION=$(node -p "require('./package.json').version")
+          NODE_VERSION=$(cat .nvmrc)
+
+          WAZUH_BRANCH="${{ github.ref_name }}"
+          PLUGINS_BRANCH="${{ inputs.plugins_branch || github.ref_name }}"
+
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="$OPENSEARCH_VERSION"
+          fi
+
+          echo "node_version=${NODE_VERSION}" >> $GITHUB_OUTPUT
+          echo "opensearch_version=${OPENSEARCH_VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "wazuh_branch=${WAZUH_BRANCH}" >> $GITHUB_OUTPUT
+          echo "plugins_branch=${PLUGINS_BRANCH}" >> $GITHUB_OUTPUT
+
+          echo "📦 OpenSearch Dashboards Version: ${OPENSEARCH_VERSION}"
+          echo "🏷️  Tag: ${TAG}"
+          echo "📟 Node Version: ${NODE_VERSION}"
+          echo "🌿 Wazuh Dashboard Branch: ${WAZUH_BRANCH}"
+          echo "🌿 Plugins Branch: ${PLUGINS_BRANCH}"
+
+  build:
+    runs-on: ${{ matrix.runner }}
+    needs: [extract-versions]
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ${{ format('codebuild-github-actions-codebuild-runner-dashboard-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+            arch: amd64
+          - platform: linux/arm64
+            runner: ${{ format('codebuild-github-actions-codebuild-runner-dashboard-arm-{0}-{1}', github.run_id, github.run_attempt) }}
+            arch: arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Workaround: AWS CodeBuild runners do not start the Docker daemon automatically
+      - name: Start Docker daemon
+        run: |
+          sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+          timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build ${{ matrix.arch }} image
+        run: |
+          chmod +x ./dev-tools/build-dev-image/build-multiarch.sh
+          cd ./dev-tools/build-dev-image
+
+          ./build-multiarch.sh \
+            --node-version "${{ needs.extract-versions.outputs.node_version }}" \
+            --wazuh-branch "${{ needs.extract-versions.outputs.wazuh_branch }}" \
+            --security-branch "${{ needs.extract-versions.outputs.plugins_branch }}" \
+            --plugins-branch "${{ needs.extract-versions.outputs.plugins_branch }}" \
+            --tag "${{ needs.extract-versions.outputs.tag }}-${{ matrix.arch }}" \
+            --platform "${{ matrix.platform }}" \
+            --push
+
+  create-manifest:
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    needs: [extract-versions, build]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          TAG="${{ needs.extract-versions.outputs.tag }}"
+
+          docker buildx imagetools create -t quay.io/wazuh/osd-dev:${TAG} \
+            quay.io/wazuh/osd-dev:${TAG}-amd64 \
+            quay.io/wazuh/osd-dev:${TAG}-arm64
+
+          echo "✅ Multi-arch manifest created and pushed!"
+          echo "📦 Image available at: quay.io/wazuh/osd-dev:${TAG}"

--- a/.github/workflows/4_builderpackage_dev_docker_image.yml
+++ b/.github/workflows/4_builderpackage_dev_docker_image.yml
@@ -120,6 +120,12 @@ jobs:
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [extract-versions, build]
     steps:
+      # Workaround: AWS CodeBuild runners do not start the Docker daemon automatically
+      - name: Start Docker daemon
+        run: |
+          sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+          timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/dev-tools/build-dev-image/README.md
+++ b/dev-tools/build-dev-image/README.md
@@ -1,0 +1,226 @@
+# Wazuh Dashboard Development Images
+
+This directory contains tools and scripts for building Docker images for the Wazuh Dashboard development environment.
+
+For the `4.14.x` line, the image bundles only the three repositories this version actually uses:
+
+- `wazuh-dashboard` (base)
+- `wazuh-security-dashboards-plugin`
+- `wazuh-dashboard-plugins`
+
+## Files Overview
+
+- **build-multiarch.sh**: Multi-architecture build script (AMD64 and ARM64)
+- **wzd.dockerfile**: Dockerfile for building the development environment
+- **install-plugins.sh**: Script that installs Wazuh plugins during build
+- **entrypoint.sh**: Container startup script
+- **plugins**: List of plugin repositories to clone
+- **README.md**: This documentation
+
+## Quick Start
+
+### Using the Multi-Architecture Script (Recommended)
+
+Requirements:
+
+- `buildx` plugin: https://github.com/docker/buildx
+- QEMU (for arch emulation builds)
+
+```bash
+# Make the script executable
+chmod +x build-multiarch.sh
+
+# Build with default values (local only)
+./build-multiarch.sh
+
+# Build and push to registry
+./build-multiarch.sh --push
+
+# Build with custom branches
+./build-multiarch.sh -w 4.14.8 -s 4.14.8 -p 4.14.8 --tag 4.14.8 --push
+```
+
+### Manual Docker Build
+
+```bash
+docker build \
+  --build-arg NODE_VERSION=18.19.0 \
+  --build-arg WAZUH_DASHBOARD_BRANCH=4.14.8 \
+  --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.14.8 \
+  --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.14.8 \
+  -t quay.io/wazuh/osd-dev:4.14.8 \
+  -f wzd.dockerfile .
+```
+
+## Multi-Architecture Build Script
+
+The `build-multiarch.sh` script simplifies building images for both AMD64 and ARM64 architectures.
+
+### Script Options
+
+| Option              | Short | Description                      | Default                   |
+| ------------------- | ----- | --------------------------------- | -------------------------- |
+| `--node-version`    | `-n`  | Node.js version                   | `18.19.0`                  |
+| `--wazuh-branch`    | `-w`  | Wazuh Dashboard branch            | `4.14.8`                   |
+| `--security-branch` | `-s`  | Wazuh Dashboard Security branch   | `4.14.8`                   |
+| `--plugins-branch`  | `-p`  | Wazuh Dashboard Plugins branch    | `4.14.8`                   |
+| `--tag`             | `-t`  | Docker image tag                  | `4.14.8`                   |
+| `--platform`        | `-pl` | Target platform (architecture)    | `linux/amd64,linux/arm64`  |
+| `--push`            |       | Push image to registry            | `false` (local build)      |
+| `--help`            | `-h`  | Show help message                 |                            |
+
+### Examples
+
+```bash
+# Development build with a specific branch
+./build-multiarch.sh --wazuh-branch 4.14.8 --tag latest
+
+# All branches from a feature branch
+./build-multiarch.sh -w feature/my-feature -s feature/my-feature -p feature/my-feature --tag feature-test
+
+# Specific version build and push
+./build-multiarch.sh --node-version 18.19.0 --tag 4.14.8 --push
+```
+
+## Manual Docker Commands
+
+### Single Architecture Build
+
+```bash
+# For ARM64 (if you're on AMD64)
+docker build --platform linux/arm64 \
+  --build-arg NODE_VERSION=18.19.0 \
+  --build-arg WAZUH_DASHBOARD_BRANCH=4.14.8 \
+  -t quay.io/wazuh/osd-dev:4.14.8-arm64 \
+  -f wzd.dockerfile .
+
+# For AMD64 (if you're on ARM64)
+docker build --platform linux/amd64 \
+  --build-arg NODE_VERSION=18.19.0 \
+  --build-arg WAZUH_DASHBOARD_BRANCH=4.14.8 \
+  -t quay.io/wazuh/osd-dev:4.14.8-amd64 \
+  -f wzd.dockerfile .
+```
+
+### Multi-Architecture Manual Build
+
+```bash
+# Create builder
+docker buildx create --use --name multiarch
+
+# Build for multiple platforms
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg NODE_VERSION=18.19.0 \
+  --build-arg WAZUH_DASHBOARD_BRANCH=4.14.8 \
+  -t quay.io/wazuh/osd-dev:4.14.8 \
+  -f wzd.dockerfile \
+  --push .
+```
+
+## Registry Setup
+
+### Setting up Quay.io Credentials (One-time setup)
+
+1. Login to Quay.io and navigate to User Settings
+2. Click on `CLI Password: Generate Encrypted Password`
+3. In the new window that opens, click on `Docker Configuration` and follow the steps
+
+### Authentication
+
+```bash
+# Login to Quay.io
+docker login quay.io
+```
+
+### Push Images
+
+```bash
+# Push single image
+docker push quay.io/wazuh/osd-dev:version
+
+# Multi-arch images are pushed automatically with --push flag in buildx
+```
+
+## Build Arguments
+
+- **NODE_VERSION**: Node.js runtime version (check `.nvmrc` file for compatibility)
+- **WAZUH_DASHBOARD_BRANCH**: `wazuh-dashboard` repository branch
+- **WAZUH_DASHBOARD_SECURITY_BRANCH**: `wazuh-security-dashboards-plugin` branch
+- **WAZUH_DASHBOARD_PLUGINS_BRANCH**: `wazuh-dashboard-plugins` branch
+
+## What the Image Contains
+
+The built image includes:
+
+- Node.js runtime environment
+- Wazuh Dashboard with the specified branch
+- The Wazuh security plugin and the core Wazuh plugins (from `wazuh-dashboard-plugins`)
+- Development dependencies
+- Configured workspace at `/home/node/kbn`
+
+## Usage
+
+### Running the Container
+
+```bash
+# Run development server
+docker run -it --rm \
+  -p 5601:5601 \
+  quay.io/wazuh/osd-dev:4.14.8
+
+# Run with volume mounting for development
+docker run -it --rm \
+  -p 5601:5601 \
+  -v $(pwd):/workspace \
+  quay.io/wazuh/osd-dev:4.14.8
+```
+
+### Multi-Platform Support
+
+When you pull the image, Docker automatically downloads the correct architecture:
+
+```bash
+# This works on both AMD64 and ARM64
+docker pull quay.io/wazuh/osd-dev:4.14.8
+```
+
+## Troubleshooting
+
+### Builder Issues
+
+```bash
+# Remove and recreate builder
+docker buildx rm multiarch
+docker buildx create --use --name multiarch
+```
+
+### Platform Support Check
+
+```bash
+# Check available platforms
+docker buildx inspect multiarch
+```
+
+### Node Version Compatibility
+
+Always check the `.nvmrc` file in the target branch to ensure Node.js version compatibility.
+
+## Development Workflow
+
+1. **Feature Development**: Build with a feature branch for testing
+2. **Integration Testing**: Build with `4.14.8` (or the relevant patch/minor branch)
+3. **Release Preparation**: Build with release branches and push to registry
+
+Example workflow:
+
+```bash
+# Feature development
+./build-multiarch.sh --wazuh-branch feature/my-feature --tag feature-test
+
+# Integration testing
+./build-multiarch.sh -w 4.14.8 -s 4.14.8 -p 4.14.8 --tag 2.19.6
+
+# Release candidate
+./build-multiarch.sh -w migrate-4.14.8-to-2.19.6 -s migrate-4.14.8-to-2.19.6.0 -p migrate-4.14.8-to-2.19.6 --tag 2.19.6 --push
+```

--- a/dev-tools/build-dev-image/build-multiarch.sh
+++ b/dev-tools/build-dev-image/build-multiarch.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Default values
+NODE_VERSION="18.19.0"
+WAZUH_DASHBOARD_BRANCH="4.14.8"
+WAZUH_DASHBOARD_SECURITY_BRANCH="4.14.8"
+WAZUH_DASHBOARD_PLUGINS_BRANCH="4.14.8"
+PLATFORM="linux/amd64,linux/arm64"
+TAG="4.14.8"
+PUSH=false
+
+# Function to show help
+show_help() {
+cat << EOF
+Usage: $0 [OPTIONS]
+
+OPTIONS:
+    -n, --node-version               Node.js version (default: $NODE_VERSION)
+    -w, --wazuh-branch               Wazuh Dashboard branch (default: $WAZUH_DASHBOARD_BRANCH)
+    -s, --security-branch            Wazuh Dashboard Security branch (default: $WAZUH_DASHBOARD_SECURITY_BRANCH)
+    -p, --plugins-branch             Wazuh Dashboard Plugins branch (default: $WAZUH_DASHBOARD_PLUGINS_BRANCH)
+    -t, --tag                        Image tag (default: $TAG)
+    -pl, --platform                  Target platform (default: $PLATFORM)
+    --push                           Push image to registry
+    -h, --help                       Show this help
+
+EXAMPLES:
+    $0 --wazuh-branch 4.14.8 --tag latest
+    $0 -w 4.14.8 -s 4.14.8 -p 4.14.8 --push
+    $0 --node-version 18.19.0 --tag 4.14.8 --push
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--node-version)
+            NODE_VERSION="$2"
+            shift 2
+            ;;
+        -w|--wazuh-branch)
+            WAZUH_DASHBOARD_BRANCH="$2"
+            shift 2
+            ;;
+        -s|--security-branch)
+            WAZUH_DASHBOARD_SECURITY_BRANCH="$2"
+            shift 2
+            ;;
+        -p|--plugins-branch)
+            WAZUH_DASHBOARD_PLUGINS_BRANCH="$2"
+            shift 2
+            ;;
+        -t|--tag)
+            TAG="$2"
+            shift 2
+            ;;
+        -pl|--platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        --push)
+            PUSH=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Show configuration
+echo "=== Build Configuration ==="
+echo "Node Version: $NODE_VERSION"
+echo "Wazuh Dashboard Branch: $WAZUH_DASHBOARD_BRANCH"
+echo "Security Branch: $WAZUH_DASHBOARD_SECURITY_BRANCH"
+echo "Plugins Branch: $WAZUH_DASHBOARD_PLUGINS_BRANCH"
+echo "Tag: quay.io/wazuh/osd-dev:$TAG"
+echo "Platform: $PLATFORM"
+echo "Push: $PUSH"
+echo "==========================="
+
+# Create multiarch builder if it doesn't exist
+echo "Setting up multiarch builder..."
+docker buildx inspect multiarch >/dev/null 2>&1 || docker buildx create --use --name multiarch
+
+# Prepare buildx arguments
+BUILDX_ARGS=(
+    --platform "$PLATFORM"
+    --build-arg NODE_VERSION="$NODE_VERSION"
+    --build-arg WAZUH_DASHBOARD_BRANCH="$WAZUH_DASHBOARD_BRANCH"
+    --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH="$WAZUH_DASHBOARD_SECURITY_BRANCH"
+    --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH="$WAZUH_DASHBOARD_PLUGINS_BRANCH"
+    -t quay.io/wazuh/osd-dev:"$TAG"
+    -f wzd.dockerfile
+)
+
+# Add --push if enabled
+if [ "$PUSH" = true ]; then
+    BUILDX_ARGS+=(--push)
+else
+    BUILDX_ARGS+=(--load)
+fi
+
+BUILDX_ARGS+=(.)
+
+# Execute build
+echo "Running docker buildx build..."
+docker buildx build "${BUILDX_ARGS[@]}"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Build completed successfully!"
+    if [ "$PUSH" = true ]; then
+        echo "📤 Image pushed to: quay.io/wazuh/osd-dev:$TAG"
+    else
+        echo "💾 Image loaded locally: quay.io/wazuh/osd-dev:$TAG"
+    fi
+else
+    echo "❌ Build failed"
+    exit 1
+fi

--- a/dev-tools/build-dev-image/entrypoint.sh
+++ b/dev-tools/build-dev-image/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ] || { [ -f "${1}" ] && ! [ -x "${1}" ]; }; then
+  base_path_plugins="/home/node/kbn/plugins"
+  plugins=$(ls $base_path_plugins)
+  for plugin in $plugins; do
+    echo "Checking if $plugin has node_modules"
+    if [ ! -d "$base_path_plugins/$plugin/node_modules" ]; then
+      cd $base_path_plugins/$plugin
+      echo "Installing dependencies for $plugin"
+      yarn install
+    fi
+  done
+  cd /home/node/kbn
+  yarn start --no-base-path
+  tail -f /dev/null
+fi
+
+exec "$@"

--- a/dev-tools/build-dev-image/install-plugins.sh
+++ b/dev-tools/build-dev-image/install-plugins.sh
@@ -1,0 +1,25 @@
+plugins=$(cat /home/node/plugins)
+base_path_plugins="/home/node/kbn/plugins"
+for plugin in $plugins; do
+  cd $base_path_plugins
+  # Clone the Wazuh security plugin
+  if [[ $plugin == "wazuh-security-dashboards-plugin" ]]; then
+    git clone --depth 1 --branch ${WAZUH_DASHBOARD_SECURITY_BRANCH} https://github.com/wazuh/$plugin.git
+  fi
+  # Clone the Wazuh dashboards plugins and move the plugins to the plugins folder
+  if [[ $plugin == "wazuh-dashboard-plugins" ]]; then
+    git clone --depth 1 --branch ${WAZUH_DASHBOARD_PLUGINS_BRANCH} https://github.com/wazuh/$plugin.git
+    wazuh_dashboard_plugins=$(ls $base_path_plugins/$plugin/plugins)
+    mv $plugin/plugins/* ./
+    for wazuh_dashboard_plugin in $wazuh_dashboard_plugins; do
+      cd $base_path_plugins/$wazuh_dashboard_plugin
+      GIT_REF="${WAZUH_DASHBOARD_PLUGINS_BRANCH}" yarn install
+    done
+    cd $base_path_plugins
+    rm -rf $plugin
+  fi
+  if [[ $plugin != "wazuh-dashboard-plugins" ]]; then
+    cd $base_path_plugins/$plugin
+    yarn install
+  fi
+done

--- a/dev-tools/build-dev-image/plugins
+++ b/dev-tools/build-dev-image/plugins
@@ -1,0 +1,2 @@
+wazuh-security-dashboards-plugin
+wazuh-dashboard-plugins

--- a/dev-tools/build-dev-image/warmup-opensearch_dashboards.yml
+++ b/dev-tools/build-dev-image/warmup-opensearch_dashboards.yml
@@ -1,0 +1,7 @@
+server.host: 0.0.0.0
+server.port: 5601
+server.ssl.enabled: false
+opensearch.hosts: http://localhost:9200
+opensearch.ignoreVersionMismatch: true
+logging.silent: false
+uiSettings.overrides.defaultRoute: /app/wz-home

--- a/dev-tools/build-dev-image/warmup-optimizer.sh
+++ b/dev-tools/build-dev-image/warmup-optimizer.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+LOG_FILE="/tmp/osd-start.log"
+
+echo "Starting yarn start --no-base-path to warm up optimizer cache..."
+touch "$LOG_FILE"
+yarn start --no-base-path --config /home/node/warmup-opensearch_dashboards.yml > "$LOG_FILE" 2>&1 &
+OSD_PID=$!
+
+# Stream log to stdout so Docker shows progress
+tail -f "$LOG_FILE" &
+TAIL_PID=$!
+
+echo "Waiting for @osd/optimizer to complete..."
+until grep -q '\[success\]\[@osd/optimizer\]' "$LOG_FILE" 2>/dev/null; do
+  sleep 5
+  if ! kill -0 $OSD_PID 2>/dev/null; then
+    kill $TAIL_PID 2>/dev/null
+    echo "ERROR: yarn start exited before optimizer completed" >&2
+    tail -n 100 "$LOG_FILE" >&2
+    exit 1
+  fi
+done
+
+echo "Optimizer completed! Stopping service..."
+kill $TAIL_PID 2>/dev/null
+kill $OSD_PID 2>/dev/null
+wait $OSD_PID 2>/dev/null || true
+echo "Service stopped. Optimizer cache is ready."

--- a/dev-tools/build-dev-image/wzd.dockerfile
+++ b/dev-tools/build-dev-image/wzd.dockerfile
@@ -1,0 +1,37 @@
+# Usage:
+# docker build \
+#         --build-arg NODE_VERSION=18.19.0 \
+#         --build-arg WAZUH_DASHBOARD_BRANCH=4.14.8 \
+#         --build-arg WAZUH_DASHBOARD_SECURITY_BRANCH=4.14.8 \
+#         --build-arg WAZUH_DASHBOARD_PLUGINS_BRANCH=4.14.8 \
+#         -t quay.io/wazuh/osd-dev:4.14.8 \
+#         -f wzd.dockerfile .
+
+ARG NODE_VERSION=18.19.0
+FROM node:${NODE_VERSION} AS base
+ARG WAZUH_DASHBOARD_BRANCH
+ARG WAZUH_DASHBOARD_SECURITY_BRANCH
+ARG WAZUH_DASHBOARD_PLUGINS_BRANCH
+USER node
+RUN git clone --depth 1 --branch ${WAZUH_DASHBOARD_BRANCH} https://github.com/wazuh/wazuh-dashboard.git /home/node/kbn
+
+WORKDIR /home/node/kbn
+RUN yarn osd bootstrap --production
+
+WORKDIR /home/node/kbn/plugins
+
+COPY ./install-plugins.sh /home/node/install-plugins.sh
+COPY ./plugins /home/node/plugins
+RUN bash /home/node/install-plugins.sh
+
+WORKDIR /home/node/kbn
+COPY ./warmup-optimizer.sh /home/node/warmup-optimizer.sh
+COPY ./warmup-opensearch_dashboards.yml /home/node/warmup-opensearch_dashboards.yml
+RUN bash /home/node/warmup-optimizer.sh
+
+FROM node:${NODE_VERSION}
+USER node
+COPY --chown=node:node --from=base /home/node/kbn /home/node/kbn
+WORKDIR /home/node/kbn
+COPY --chmod=755 ./entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
## Summary
- Ports `dev-tools/build-dev-image` from `main`, trimmed to the three repositories the 4.14.x line uses: `wazuh-dashboard`, `wazuh-security-dashboards-plugin`, `wazuh-dashboard-plugins` (no reporting/security-analytics/alerting/notifications/opensearch-project plugins).
- Adds `.github/workflows/4_builderpackage_dev_docker_image.yml`, a `workflow_dispatch`-only workflow that builds and pushes the multi-arch `quay.io/wazuh/osd-dev` image, using the same CodeBuild runners as the other numbered workflows in this repo.
- The workflow takes one input, `plugins_branch`, covering both plugin repos (they're released in lockstep in 4.14.x), defaulting to the branch the workflow runs on. `wazuh-dashboard`'s branch is always the checked-out ref.

## Test plan
- [ ] `docker build` locally with `WAZUH_DASHBOARD_BRANCH=4.14.8`, `WAZUH_DASHBOARD_SECURITY_BRANCH=4.14.8`, `WAZUH_DASHBOARD_PLUGINS_BRANCH=4.14.8` and confirm only those 3 repos get cloned.
- [ ] Run the workflow manually (`workflow_dispatch`) and confirm the image builds/pushes for both `amd64` and `arm64` and the multi-arch manifest is created.
- [ ] `docker run` the resulting image and confirm the dashboard starts at `:5601`.