### PR TITLE
Change resizable button emphasis style from :focus to :active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 | [#1330](https://github.com/wazuh/wazuh-dashboard/pull/1330)                                                             | Changed log level of the cross compatibility service on start                                                      |
 | [#1328](https://github.com/wazuh/wazuh-dashboard/pull/1328) [#1365](https://github.com/wazuh/wazuh-dashboard/pull/1365) | Changed pre install scripts to block Wazuh dashboard installation if there's an existing installation prior to 5.x |
 | [#8979](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979)                                                   | Changed the sidecar flyout to displace open flyouts instead of covering them                                       |
+| [#8989](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8989)                                                   | Changed the sidecar resizable button emphasis styles to trigger on `:active` instead of `:focus`                   |
 
 ## Prior versions
 

--- a/src/core/public/overlays/sidecar/components/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/core/public/overlays/sidecar/components/__snapshots__/resizable_button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`is rendered 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--horizontal"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -13,7 +13,7 @@ exports[`is rendered 1`] = `
 
 exports[`it should be horizontal when docked mode is right 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--horizontal"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -24,7 +24,7 @@ exports[`it should be horizontal when docked mode is right 1`] = `
 
 exports[`it should be vertical when docked mode is takeover 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--vertical"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--vertical"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -35,7 +35,7 @@ exports[`it should be vertical when docked mode is takeover 1`] = `
 
 exports[`it should emit onResize with min size when drag if new size is below the minimum 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--horizontal"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -46,7 +46,7 @@ exports[`it should emit onResize with min size when drag if new size is below th
 
 exports[`it should emit onResize with new flyout size when docked left and drag and horizontal 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--horizontal"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -57,7 +57,7 @@ exports[`it should emit onResize with new flyout size when docked left and drag 
 
 exports[`it should emit onResize with new flyout size when docked right and drag and horizontal 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--horizontal"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -68,7 +68,7 @@ exports[`it should emit onResize with new flyout size when docked right and drag
 
 exports[`it should emit onResize with new flyout size when drag and vertical 1`] = `
 <button
-  className="sidecar-resizableButton resizableButton--vertical"
+  className="sidecar-resizableButton osd-resetFocusState resizableButton--vertical"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}

--- a/src/core/public/overlays/sidecar/components/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/core/public/overlays/sidecar/components/__snapshots__/resizable_button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`is rendered 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
+  className="sidecar-resizableButton resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -13,7 +13,7 @@ exports[`is rendered 1`] = `
 
 exports[`it should be horizontal when docked mode is right 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
+  className="sidecar-resizableButton resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -24,7 +24,7 @@ exports[`it should be horizontal when docked mode is right 1`] = `
 
 exports[`it should be vertical when docked mode is takeover 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--vertical"
+  className="sidecar-resizableButton resizableButton--vertical"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -35,7 +35,7 @@ exports[`it should be vertical when docked mode is takeover 1`] = `
 
 exports[`it should emit onResize with min size when drag if new size is below the minimum 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
+  className="sidecar-resizableButton resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -46,7 +46,7 @@ exports[`it should emit onResize with min size when drag if new size is below th
 
 exports[`it should emit onResize with new flyout size when docked left and drag and horizontal 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
+  className="sidecar-resizableButton resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -57,7 +57,7 @@ exports[`it should emit onResize with new flyout size when docked left and drag 
 
 exports[`it should emit onResize with new flyout size when docked right and drag and horizontal 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--horizontal"
+  className="sidecar-resizableButton resizableButton--horizontal"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}
@@ -68,7 +68,7 @@ exports[`it should emit onResize with new flyout size when docked right and drag
 
 exports[`it should emit onResize with new flyout size when drag and vertical 1`] = `
 <button
-  className="sidecar-resizableButton osd-resetFocusState resizableButton--vertical"
+  className="sidecar-resizableButton resizableButton--vertical"
   data-test-subj="resizableButton"
   onClick={[Function]}
   onMouseDown={[Function]}

--- a/src/core/public/overlays/sidecar/components/resizable_button.scss
+++ b/src/core/public/overlays/sidecar/components/resizable_button.scss
@@ -8,12 +8,6 @@
   flex-shrink: 0;
   z-index: $euiZLevel1;
 
-  // Wazuh: suppress the native focus ring left over from the .focus() call on click/drag;
-  // keep it for keyboard users via :focus-visible
-  &:focus:not(:focus-visible) {
-    outline: none;
-  }
-
   &::before,
   &::after {
     content: "";

--- a/src/core/public/overlays/sidecar/components/resizable_button.scss
+++ b/src/core/public/overlays/sidecar/components/resizable_button.scss
@@ -74,8 +74,9 @@
     }
   }
 
-  // Add a transparent background to the container and emphasis the "grab" icon with primary color on :focus
-  &:focus:not(:disabled) {
+  // Wazuh: changed from :focus to :active (upstream OSD used :focus here)
+  // Add a transparent background to the container and emphasis the "grab" icon with primary color on :active
+  &:active:not(:disabled) {
     background-color: transparentize($euiColorPrimary, 0.9);
 
     &::before,
@@ -91,9 +92,10 @@
     }
   }
 
-  // Morph the "grab" icon into a fluid 2px straight line on :hover and :focus
+  // Wazuh: changed from :focus to :active (upstream OSD used :focus here)
+  // Morph the "grab" icon into a fluid 2px straight line on :hover and :active
   &:hover:not(:disabled),
-  &:focus:not(:disabled) {
+  &:active:not(:disabled) {
     &.resizableButton--horizontal {
       &::before,
       &::after {

--- a/src/core/public/overlays/sidecar/components/resizable_button.scss
+++ b/src/core/public/overlays/sidecar/components/resizable_button.scss
@@ -8,6 +8,12 @@
   flex-shrink: 0;
   z-index: $euiZLevel1;
 
+  // Wazuh: suppress the native focus ring left over from the .focus() call on click/drag;
+  // keep it for keyboard users via :focus-visible
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
   &::before,
   &::after {
     content: "";

--- a/src/core/public/overlays/sidecar/components/resizable_button.tsx
+++ b/src/core/public/overlays/sidecar/components/resizable_button.tsx
@@ -21,7 +21,7 @@ const RESIZE_DEBOUNCE_DELAY = 50;
 export const ResizableButton = ({ dockedMode, onResize, flyoutSize }: Props) => {
   const isHorizontal = dockedMode !== SIDECAR_DOCKED_MODE.TAKEOVER;
 
-  const classes = classNames('sidecar-resizableButton', {
+  const classes = classNames('sidecar-resizableButton', 'osd-resetFocusState', {
     'resizableButton--vertical': !isHorizontal,
     'resizableButton--horizontal': isHorizontal,
   });

--- a/src/core/public/overlays/sidecar/components/resizable_button.tsx
+++ b/src/core/public/overlays/sidecar/components/resizable_button.tsx
@@ -14,17 +14,22 @@ interface Props {
   onResize: (size: number) => void;
   flyoutSize: number;
   dockedMode: ISidecarConfig['dockedMode'] | undefined;
+  className?: string;
 }
 
 const RESIZE_DEBOUNCE_DELAY = 50;
 
-export const ResizableButton = ({ dockedMode, onResize, flyoutSize }: Props) => {
+export const ResizableButton = ({ dockedMode, onResize, flyoutSize, className }: Props) => {
   const isHorizontal = dockedMode !== SIDECAR_DOCKED_MODE.TAKEOVER;
 
-  const classes = classNames('sidecar-resizableButton', 'osd-resetFocusState', {
-    'resizableButton--vertical': !isHorizontal,
-    'resizableButton--horizontal': isHorizontal,
-  });
+  const classes = classNames(
+    'sidecar-resizableButton',
+    {
+      'resizableButton--vertical': !isHorizontal,
+      'resizableButton--horizontal': isHorizontal,
+    },
+    className
+  );
 
   const initialMouseXorY = useRef(0);
   const initialFlyoutSize = useRef(flyoutSize);

--- a/src/core/public/overlays/sidecar/components/sidecar.tsx
+++ b/src/core/public/overlays/sidecar/components/sidecar.tsx
@@ -91,6 +91,7 @@ export const Sidecar = ({ sidecarConfig$, options, setSidecarConfig, i18n, mount
           onResize={handleResize}
           dockedMode={sidecarConfig?.dockedMode}
           flyoutSize={sidecarConfig?.paddingSize ?? 0}
+          className={options.classNameButton}
         />
         <MountWrapper mount={mount} className="osdSidecarMountWrapper" />
       </div>

--- a/src/core/public/overlays/sidecar/sidecar_service.tsx
+++ b/src/core/public/overlays/sidecar/sidecar_service.tsx
@@ -97,6 +97,7 @@ export interface OverlaySidecarStart {
  */
 export interface OverlaySidecarOpenOptions {
   className?: string;
+  classNameButton?: string;
   'data-test-subj'?: string;
   config: ISidecarConfig;
 }


### PR DESCRIPTION
## Description

The sidecar resizable button (the drag handle used to resize the AI assistant context chat sidecar/flyout) emphasized its "grab" icon on `:focus`. Since the button is typically interacted with via mouse drag rather than keyboard focus, this produced styling that didn't match the actual interaction (e.g. the emphasis style could persist after the button lost visual interaction, or not appear during an actual drag).

Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/8989

## Proposed Changes

- Changed the `.sidecar-resizableButton` emphasis styles (background tint and "grab" icon color/morph) to trigger on `:active` instead of `:focus`, so the emphasis reflects the button actually being pressed/dragged.
- Added `// Wazuh:` comments noting the divergence from upstream OpenSearch Dashboards.
- Added a `CHANGELOG.md` entry under `### Changed` for v5.0.0.

### Results and Evidence

<!-- Manual verification pending: open the AI assistant sidecar, drag the resizable button, and confirm the primary-color emphasis now shows on :active (press/drag) rather than :focus. Screenshot/video to be attached by reviewer/developer. -->

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — this is a CSS-only pseudo-class change with no new behavior to unit test; existing `resizable_button.test.tsx` tests are unaffected (they don't assert on `:focus`/`:active` styling).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
