### PR TITLE
Fix RPM changelog entry order causing build failure

### DIFF
--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -481,12 +481,12 @@ rm -fr %{buildroot}
 %changelog
 * Wed Sep 16 2026 support <info@wazuh.com> - 4.14.9
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-9.html
+* Wed Sep 09 2026 support <info@wazuh.com> - 5.0.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 * Thu Sep 03 2026 support <info@wazuh.com> - 4.10.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
 * Wed Sep 02 2026 support <info@wazuh.com> - 4.14.8
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-8.html
-* Wed Sep 09 2026 support <info@wazuh.com> - 5.0.0
-- More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 * Wed Jul 29 2026 support <info@wazuh.com> - 4.14.7
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-7.html
 * Wed Jul 01 2026 support <info@wazuh.com> - 4.14.6


### PR DESCRIPTION
## Description

The RPM package build was failing while parsing the spec's `%changelog`
section, so `rpmbuild` aborted, no RPM artifact was produced, and the
subsequent `aws s3 cp` step failed with "The user-provided path ... does not
exist."

Root cause: the `5.0.0` changelog entry was placed out of descending
chronological date order relative to its neighboring entries. `rpmbuild`
treats an out-of-order `%changelog` as a fatal parse error, not a warning.

Closes #1514

## Proposed Changes

- Reordered the `5.0.0` changelog entry in
  `dev-tools/build-packages/rpm/wazuh-dashboard.spec` so all entries stay in
  strict descending date order.

### Results and Evidence

Verified the full `%changelog` block is now in strict descending date order
(no gaps/reversals) by listing every entry's date top to bottom.

[Build rpm wazuh-dashboard on x86_64](https://github.com/wazuh/wazuh-dashboard/actions/runs/32484659748)
[Build rpm wazuh-dashboard on aarch64](https://github.com/wazuh/wazuh-dashboard/actions/runs/32484652853)

### Artifacts Affected

- RPM package (x86_64 and aarch64) — build no longer aborts during
  `%changelog` parsing.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — spec file text-only change; no colocated test infrastructure for RPM
spec parsing in this repo.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (`no-changelog`)
- [ ] ...
