### PR TITLE
Dashboard hardening: session cookie missing Secure/SameSite and no HSTS header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@
 
 ### Fixed
 
-| Issue                                                       | Comment                                                                                      |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276) | Fixed health check padding styles                                                            |
-| [#1285](https://github.com/wazuh/wazuh-dashboard/pull/1285) | Sanitized redirect path to prevent open redirect                                             |
-| [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
+| Issue                                                         | Comment                                                                                      |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [#1520](https://github.com/wazuh/wazuh-dashboard/issues/1520) | Set the session cookie `SameSite` policy in the default configuration file                   |
+| [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276)   | Fixed health check padding styles                                                            |
+| [#1285](https://github.com/wazuh/wazuh-dashboard/pull/1285)   | Sanitized redirect path to prevent open redirect                                             |
+| [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400)   | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
 
 ### Removed
 

--- a/config/opensearch_dashboards.prod.yml
+++ b/config/opensearch_dashboards.prod.yml
@@ -4,18 +4,27 @@ opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 #opensearch.username:
 #opensearch.password:
-opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ['securitytenant', 'Authorization']
 opensearch_security.multitenancy.enabled: false
-opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+opensearch_security.readonly_mode.roles: ['kibana_read_only']
 server.ssl.enabled: true
-server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
-server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
-opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
+server.ssl.key: '/etc/wazuh-dashboard/certs/dashboard-key.pem'
+server.ssl.certificate: '/etc/wazuh-dashboard/certs/dashboard.pem'
+opensearch.ssl.certificateAuthorities: ['/etc/wazuh-dashboard/certs/root-ca.pem']
 uiSettings.overrides.defaultRoute: /app/wz-home
 # Session expiration settings
 opensearch_security.cookie.ttl: 900000
 opensearch_security.session.ttl: 900000
 opensearch_security.session.keepalive: true
+
+# HTTP hardening
+# isSameSite applies to the platform session cookie (security_authentication)
+# and to the Wazuh server API cookies (wz-token, wz-user, wz-api).
+# Use None only when embedding the dashboard in a cross-origin iframe; None
+# requires HTTPS. The Secure flag is derived from the server protocol and needs
+# no setting here; set opensearch_security.cookie.secure explicitly only when a
+# reverse proxy terminates TLS in front of the dashboard.
+opensearch_security.cookie.isSameSite: Lax
 
 # Define the Wazuh server hosts
 wazuh_core.hosts:


### PR DESCRIPTION
## Description

The default configuration serves the dashboard with TLS, but it did not set a `SameSite` value for the session cookie. A browser thus sends the cookie with a request from a different web site.

A security test of a 5.0 system found this problem.

Related issue: https://github.com/wazuh/wazuh-dashboard/issues/1520

## Proposed Changes

Add one line to `config/opensearch_dashboards.prod.yml`:

```yaml
opensearch_security.cookie.isSameSite: Lax
```

The value `Lax` stops a cross-site POST request. Normal links continue to operate.

The value `Strict` is not used. `Strict` removes the cookie when a user opens a link from an e-mail, a report or a ticket. `Strict` also stops the SAML login.

This value applies to the platform session cookie and to the Wazuh server API cookies. The Wazuh plugin reads the same setting.

The `Secure` flag needs no line here. A related pull request calculates it from the server protocol.

The pull request also changes five lines that are not related. The Prettier check of the repository refuses the file with the current quotation marks. The change is from `"` to `'` only. The values do not change.

### Results and Evidence

<img width="2340" height="1196" alt="image" src="https://github.com/user-attachments/assets/ec4df618-4f6c-45c1-bad1-9fbc8ce928f5" />


Test on a development system with HTTPS and this value:

```
security_authentication=<...>; Secure; HttpOnly; SameSite=Strict; Path=/
```

The login is complete and the session continues.

### Artifacts Affected

The default configuration file `/etc/wazuh-dashboard/opensearch_dashboards.yml`.

### Configuration Changes

One new line in the default configuration file. The package does not replace an existing file, thus an operator with an installed system must add the line manually. The upgrade instructions in the `wazuh-dashboard-plugins` repository give this step.

### Documentation Updates

`CHANGELOG.md` — a new line in the "Fixed" section.

The reference documents are in the `wazuh-dashboard-plugins` repository. See the related pull request.

### Tests Introduced

None. This pull request changes only a configuration file.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Configuration changes documented
- [x] Meets requirements and/or definition of done
- [x] PR is linked to the relevant issue(s)
- [ ] No unresolved dependencies with other issues

> **Note:** This pull request needs the two related pull requests. See the issue.
