### PR TITLE
fix: remove inert opensearch_security.cookie.ttl setting

### DIFF
--- a/config/opensearch_dashboards.prod.yml
+++ b/config/opensearch_dashboards.prod.yml
@@ -4,16 +4,15 @@ opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 #opensearch.username:
 #opensearch.password:
-opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ['securitytenant', 'Authorization']
 opensearch_security.multitenancy.enabled: false
-opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+opensearch_security.readonly_mode.roles: ['kibana_read_only']
 server.ssl.enabled: true
-server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
-server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
-opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
+server.ssl.key: '/etc/wazuh-dashboard/certs/dashboard-key.pem'
+server.ssl.certificate: '/etc/wazuh-dashboard/certs/dashboard.pem'
+opensearch.ssl.certificateAuthorities: ['/etc/wazuh-dashboard/certs/root-ca.pem']
 uiSettings.overrides.defaultRoute: /app/wz-home
 # Session expiration settings
-opensearch_security.cookie.ttl: 900000
 opensearch_security.session.ttl: 900000
 opensearch_security.session.keepalive: true
 

--- a/docker/config/opensearch_dashboards.dev.security.yml
+++ b/docker/config/opensearch_dashboards.dev.security.yml
@@ -1,15 +1,14 @@
-server.host: "0.0.0.0"
+server.host: '0.0.0.0'
 
-opensearch.hosts: ["https://indexer:9200"]
+opensearch.hosts: ['https://indexer:9200']
 opensearch.ssl.verificationMode: none
-opensearch.username: "kibanaserver"
-opensearch.password: "kibanaserver"
-opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
+opensearch.username: 'kibanaserver'
+opensearch.password: 'kibanaserver'
+opensearch.requestHeadersWhitelist: [authorization, securitytenant]
 opensearch_security.multitenancy.enabled: true
-opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
-opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+opensearch_security.multitenancy.tenants.preferred: ['Private', 'Global']
+opensearch_security.readonly_mode.roles: ['kibana_read_only']
 # Session expiration settings
-opensearch_security.cookie.ttl: 900000
 opensearch_security.session.ttl: 900000
 opensearch_security.session.keepalive: true
 


### PR DESCRIPTION
## Description

`opensearch_security.cookie.ttl` is shipped in the default dashboard configuration and reads as a hard cookie lifetime, but the security plugin (`wazuh-security-dashboards-plugin`) never consumes it — only `opensearch_security.session.ttl` has any effect on session/cookie expiry. Verified by grepping the plugin's server code for every consumer of the `cookie` config block: `.secure`, `.name`, `.password`, `.isSameSite`, and `.domain` are all read; `.ttl` is not. Shipping a setting that silently does nothing misleads operators who set it expecting it to bound the cookie's lifetime.

## Proposed Changes

- Remove the inert `opensearch_security.cookie.ttl: 900000` line from:
  - `config/opensearch_dashboards.prod.yml`
  - `docker/config/opensearch_dashboards.dev.security.yml`
- `opensearch_security.session.ttl` (already present in both files) remains the only setting governing session/cookie expiry — no behavior change.

### Results and Evidence

No functional change: `cookie.ttl` had no effect before this change, so dashboard session expiry behavior is identical before/after. This only removes a misleading, unused config line.

### Artifacts Affected

- Default configuration files: `config/opensearch_dashboards.prod.yml`, `docker/config/opensearch_dashboards.dev.security.yml`

### Configuration Changes

- Removes `opensearch_security.cookie.ttl` from the shipped default config. Operators who had explicitly set this value in their own config are unaffected functionally (it never did anything); they should rely on `opensearch_security.session.ttl` instead.

### Documentation Updates

N/A

### Tests Introduced

N/A (config-only change)

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
