### PR TITLE
Fix changelog not in descending chronological order

### DIFF
--- a/dev-tools/build-packages/rpm/wazuh-dashboard.spec
+++ b/dev-tools/build-packages/rpm/wazuh-dashboard.spec
@@ -479,10 +479,10 @@ rm -fr %{buildroot}
 %attr(644, root, root) "/usr/lib/systemd/system/wazuh-dashboard.service"
 
 %changelog
-* Wed Sep 16 2026 support <info@wazuh.com> - 4.14.9
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-14-9.html
 * Wed Sep 23 2026 support <info@wazuh.com> - 5.0.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
+* Wed Sep 16 2026 support <info@wazuh.com> - 4.14.9
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-14-9.html
 * Thu Sep 03 2026 support <info@wazuh.com> - 4.10.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
 * Wed Sep 02 2026 support <info@wazuh.com> - 4.14.8


### PR DESCRIPTION
### Description

The “bump repository" changes the changelog date of the RPM package and does not sort it in descending order. 

This pull request reorders the dates

### Issues Resolved

#1547

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
