### PR TITLE
Review the 5.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 ### Added
 
-| Issue                                                                                        | Comment                                                                                     |
-| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [wazuh-dashboard-plugins#7610](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7610) | Health check service                                                                        |
-| [wazuh-dashboard-plugins#7697](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7697) | Added Health Check app                                                                      |
-| [#985](https://github.com/wazuh/wazuh-dashboard/issues/985)                                  | Added manager host configuration for the default configuration file                         |
-| [#1052](https://github.com/wazuh/wazuh-dashboard/issues/1052)                                | Set v9 theme as default                                                                     |
-| [wazuh-dashboard-plugins#8550](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8550) | Added version, revision, and stage to the Wazuh build metadata                              |
-| [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
-| [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                | Added automatic generation and storage of the AI assistant encryption key on first install  |
+| Issue                                                                                                                                                                                     | Comment                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [wazuh-dashboard-plugins#7610](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7610) [wazuh-dashboard-plugins#7697](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7697) | Added the health check service and app                                                      |
+| [#985](https://github.com/wazuh/wazuh-dashboard/issues/985)                                                                                                                               | Added manager host configuration for the default configuration file                         |
+| [#1052](https://github.com/wazuh/wazuh-dashboard/issues/1052)                                                                                                                             | Set v9 theme as default                                                                     |
+| [wazuh-dashboard-plugins#8550](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8550)                                                                                              | Added version, revision, and stage to the Wazuh build metadata                              |
+| [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                                                                                                             | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
+| [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                                                                                                             | Added automatic generation and storage of the AI assistant encryption key on first install  |
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ### Added
 
-| Issue                                                                                                                                                                                     | Comment                                                                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [wazuh-dashboard-plugins#7610](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7610) [wazuh-dashboard-plugins#7697](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7697) | Added the health check service and app                                                      |
-| [#985](https://github.com/wazuh/wazuh-dashboard/issues/985)                                                                                                                               | Added manager host configuration for the default configuration file                         |
-| [#1052](https://github.com/wazuh/wazuh-dashboard/issues/1052)                                                                                                                             | Set v9 theme as default                                                                     |
-| [wazuh-dashboard-plugins#8550](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8550)                                                                                              | Added version, revision, and stage to the Wazuh build metadata                              |
-| [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                                                                                                             | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
-| [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                                                                                                             | Added automatic generation and storage of the AI assistant encryption key on first install  |
+| Issue                                                                                        | Comment                                                                                     |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [wazuh-dashboard-plugins#7532](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7532) | Added the health check service and app                                                      |
+| [#985](https://github.com/wazuh/wazuh-dashboard/issues/985)                                  | Added manager host configuration for the default configuration file                         |
+| [#1052](https://github.com/wazuh/wazuh-dashboard/issues/1052)                                | Set v9 theme as default                                                                     |
+| [wazuh-dashboard-plugins#8550](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8550) | Added version, revision, and stage to the Wazuh build metadata                              |
+| [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
+| [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                | Added automatic generation and storage of the AI assistant encryption key on first install  |
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@
 | [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                                                                                                                                                                                                                                                                                     | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
 | [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                                                                                                                                                                                                                                                                                     | Added automatic generation and storage of the AI assistant encryption key on first install  |
 
-### Fixed
+### Changed
 
-| Issue                                                       | Comment                                                                                      |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276) | Fixed health check padding styles                                                            |
-| [#1285](https://github.com/wazuh/wazuh-dashboard/pull/1285) | Sanitized redirect path to prevent open redirect                                             |
-| [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
+| Issue                                                                                                                   | Comment                                                                                          |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [#805](https://github.com/wazuh/wazuh-dashboard/issues/805)                                                             | Changed the location of the wazuh-dashboard service to match with the other Wazuh components     |
+| [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)                                                               | Changed the default value of `metaFields` and `timepicker:timeDefaults` settings                 |
+| [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278) [#1279](https://github.com/wazuh/wazuh-dashboard/pull/1279) | Excluded Wazuh dashboards and visualizations listing                                             |
+| [#1330](https://github.com/wazuh/wazuh-dashboard/pull/1330)                                                             | Changed log level of the cross compatibility service on start                                    |
+| [wazuh-dashboard-plugins#8979](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979)                            | Changed the sidecar flyout to displace open flyouts instead of covering them                     |
+| [wazuh-dashboard-plugins#8989](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8989)                            | Changed the sidecar resizable button emphasis styles to trigger on `:active` instead of `:focus` |
 
 ### Removed
 
@@ -27,17 +30,12 @@
 | [#699](https://github.com/wazuh/wazuh-dashboard/issues/699) | Removed creation of /usr/lib/.build-id/\* links to prevent conflicts when installing Wazuh Dashboard alongside OpenSearch Dashboards on the same system |
 | [#1382](https://github.com/wazuh/wazuh-dashboard/pull/1382) | Removed the Anomaly Detection plugin from the default Wazuh dashboard package                                                                           |
 
-### Changed
+### Fixed
 
-| Issue                                                                                                                   | Comment                                                                                                            |
-| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| [#805](https://github.com/wazuh/wazuh-dashboard/issues/805)                                                             | Changed the location of the wazuh-dashboard service to match with the other Wazuh components                       |
-| [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)                                                               | Changed the default value of `metaFields` and `timepicker:timeDefaults` settings                                   |
-| [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278) [#1279](https://github.com/wazuh/wazuh-dashboard/pull/1279) | Excluded Wazuh dashboards and visualizations listing                                                               |
-| [#1330](https://github.com/wazuh/wazuh-dashboard/pull/1330)                                                             | Changed log level of the cross compatibility service on start                                                      |
-| [#1328](https://github.com/wazuh/wazuh-dashboard/pull/1328) [#1365](https://github.com/wazuh/wazuh-dashboard/pull/1365) | Changed pre install scripts to block Wazuh dashboard installation if there's an existing installation prior to 5.x |
-| [#8979](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979)                                                   | Changed the sidecar flyout to displace open flyouts instead of covering them                                       |
-| [#8989](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8989)                                                   | Changed the sidecar resizable button emphasis styles to trigger on `:active` instead of `:focus`                   |
+| Issue                                                       | Comment                                                                                      |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276) | Fixed health check padding styles                                                            |
+| [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
 
 ## Prior versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,40 +2,40 @@
 
 ### Added
 
-| Issue                                                                                                                                                                                                                                                                                                                                                             | Comment                                                                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [#811](https://github.com/wazuh/wazuh-dashboard/pull/811) [#866](https://github.com/wazuh/wazuh-dashboard/pull/866) [#961](https://github.com/wazuh/wazuh-dashboard/pull/961) [#1031](https://github.com/wazuh/wazuh-dashboard/pull/1031) [#1179](https://github.com/wazuh/wazuh-dashboard/pull/1179) [#1366](https://github.com/wazuh/wazuh-dashboard/pull/1366) | Health check service                                                                        |
-| [#870](https://github.com/wazuh/wazuh-dashboard/pull/870) [#946](https://github.com/wazuh/wazuh-dashboard/pull/946) [#1366](https://github.com/wazuh/wazuh-dashboard/pull/1366) [#1379](https://github.com/wazuh/wazuh-dashboard/pull/1379) [#1504](https://github.com/wazuh/wazuh-dashboard/issues/1504)                                                         | Added Health Check app                                                                      |
-| [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)                                                                                                                                                                                                                                                                                                         | Added manager host configuration for the default configuration file                         |
-| [#1092](https://github.com/wazuh/wazuh-dashboard/pull/1092)                                                                                                                                                                                                                                                                                                       | Set v9 theme as default                                                                     |
-| [#1327](https://github.com/wazuh/wazuh-dashboard/pull/1327) [#1421](https://github.com/wazuh/wazuh-dashboard/pull/1421)                                                                                                                                                                                                                                           | Added version, revision, and stage to the Wazuh build metadata                              |
-| [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                                                                                                                                                                                                                                                                                     | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
-| [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                                                                                                                                                                                                                                                                                     | Added automatic generation and storage of the AI assistant encryption key on first install  |
+| Issue                                                                                        | Comment                                                                                     |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [wazuh-dashboard-plugins#7610](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7610) | Health check service                                                                        |
+| [wazuh-dashboard-plugins#7697](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7697) | Added Health Check app                                                                      |
+| [#985](https://github.com/wazuh/wazuh-dashboard/issues/985)                                  | Added manager host configuration for the default configuration file                         |
+| [#1052](https://github.com/wazuh/wazuh-dashboard/issues/1052)                                | Set v9 theme as default                                                                     |
+| [wazuh-dashboard-plugins#8550](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8550) | Added version, revision, and stage to the Wazuh build metadata                              |
+| [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)                                | Made the Discover CSV download row limit configurable via the `reports.csv.maxRows` setting |
+| [#1480](https://github.com/wazuh/wazuh-dashboard/issues/1480)                                | Added automatic generation and storage of the AI assistant encryption key on first install  |
 
 ### Changed
 
-| Issue                                                                                                                   | Comment                                                                                          |
-| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| [#805](https://github.com/wazuh/wazuh-dashboard/issues/805)                                                             | Changed the location of the wazuh-dashboard service to match with the other Wazuh components     |
-| [#998](https://github.com/wazuh/wazuh-dashboard/pull/998)                                                               | Changed the default value of `metaFields` and `timepicker:timeDefaults` settings                 |
-| [#1278](https://github.com/wazuh/wazuh-dashboard/pull/1278) [#1279](https://github.com/wazuh/wazuh-dashboard/pull/1279) | Excluded Wazuh dashboards and visualizations listing                                             |
-| [#1330](https://github.com/wazuh/wazuh-dashboard/pull/1330)                                                             | Changed log level of the cross compatibility service on start                                    |
-| [wazuh-dashboard-plugins#8979](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979)                            | Changed the sidecar flyout to displace open flyouts instead of covering them                     |
-| [wazuh-dashboard-plugins#8989](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8989)                            | Changed the sidecar resizable button emphasis styles to trigger on `:active` instead of `:focus` |
+| Issue                                                                                        | Comment                                                                                          |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [#798](https://github.com/wazuh/wazuh-dashboard/issues/798)                                  | Changed the location of the wazuh-dashboard service to match with the other Wazuh components     |
+| [#985](https://github.com/wazuh/wazuh-dashboard/issues/985)                                  | Changed the default value of `metaFields` and `timepicker:timeDefaults` settings                 |
+| [wazuh-dashboard-plugins#8473](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8473) | Excluded Wazuh dashboards and visualizations listing                                             |
+| [#1329](https://github.com/wazuh/wazuh-dashboard/issues/1329)                                | Changed log level of the cross compatibility service on start                                    |
+| [wazuh-dashboard-plugins#8979](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8979) | Changed the sidecar flyout to displace open flyouts instead of covering them                     |
+| [wazuh-dashboard-plugins#8989](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8989) | Changed the sidecar resizable button emphasis styles to trigger on `:active` instead of `:focus` |
 
 ### Removed
 
-| Issue                                                       | Comment                                                                                                                                                 |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [#699](https://github.com/wazuh/wazuh-dashboard/issues/699) | Removed creation of /usr/lib/.build-id/\* links to prevent conflicts when installing Wazuh Dashboard alongside OpenSearch Dashboards on the same system |
-| [#1382](https://github.com/wazuh/wazuh-dashboard/pull/1382) | Removed the Anomaly Detection plugin from the default Wazuh dashboard package                                                                           |
+| Issue                                                         | Comment                                                                                                                                                 |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#699](https://github.com/wazuh/wazuh-dashboard/issues/699)   | Removed creation of /usr/lib/.build-id/\* links to prevent conflicts when installing Wazuh Dashboard alongside OpenSearch Dashboards on the same system |
+| [#1381](https://github.com/wazuh/wazuh-dashboard/issues/1381) | Removed the Anomaly Detection plugin from the default Wazuh dashboard package                                                                           |
 
 ### Fixed
 
-| Issue                                                       | Comment                                                                                      |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [#1276](https://github.com/wazuh/wazuh-dashboard/pull/1276) | Fixed health check padding styles                                                            |
-| [#1400](https://github.com/wazuh/wazuh-dashboard/pull/1400) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
+| Issue                                                         | Comment                                                                                      |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [#1277](https://github.com/wazuh/wazuh-dashboard/issues/1277) | Fixed health check padding styles                                                            |
+| [#1399](https://github.com/wazuh/wazuh-dashboard/issues/1399) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
 
 ## Prior versions
 


### PR DESCRIPTION
## Description

Review of the 5.0.0 changelog. Only `CHANGELOG.md` is touched.

## Proposed Changes

- Removed two entries:
  - `#1285` — Sanitized redirect path to prevent open redirect
  - `#1328 #1365` — Changed pre install scripts to block the installation when a pre-5.x installation exists
- Qualified the two cross-repository references as `wazuh-dashboard-plugins#8979` and `wazuh-dashboard-plugins#8989`; the URLs were already correct, but the `#8979` text read as a `wazuh-dashboard` issue.
- Merged the `Health check service` and `Added Health Check app` entries into a single `Added the health check service and app` entry. They describe one feature and were split only because the work landed in two pull request series. The entry references wazuh-dashboard-plugins#7532 (Dashboard no health check), which already is the parent of both wazuh-dashboard-plugins#7610 and wazuh-dashboard-plugins#7697.
- Put the sections in the Added, Changed, Removed, Fixed order (they were Added, Fixed, Removed, Changed).


## Issues instead of pull requests

Every entry now links the issue the pull request closed, so the reference carries the description and the discussion instead of just the diff. Where the references of one entry resolve the same issue, the entry collapses to it; where they resolve different issues, the entry keeps the main one and the rest are attached to it as sub-issues, following the shape of wazuh-dashboard-plugins#8789.

5 sub-issues attached, over 3 parent issues:

| Main issue | Sub-issues attached |
| --- | --- |
| wazuh-dashboard-plugins#7610 | wazuh-dashboard#960, wazuh-dashboard-plugins#8261, wazuh-dashboard#1358 |
| wazuh-dashboard-plugins#7697 | wazuh-dashboard#1504 |
| wazuh-dashboard-plugins#8550 | wazuh-dashboard#1419 |

wazuh-dashboard-plugins#7610 and wazuh-dashboard-plugins#7697 are themselves sub-issues of wazuh-dashboard-plugins#7532, the issue the merged health check entry points at, so every one of the above is reachable from the entry.

Not attached, left where they already are so existing tracking is not broken:

| Issue | Reason |
| --- | --- |
| wazuh-dashboard-plugins#8641 | already a sub-issue of internal-devel-requests#5021 (Dashboard analysis required for high-load performance compar) |
| wazuh-dashboard-plugins#7919 | already a sub-issue of wazuh-dashboard-plugins#7723 (Reporting revamp tier 2) |

One bundled pull request has no issue at all: wazuh-dashboard#946 (Refine health check), behind the health check entry. Its work is described by wazuh-dashboard-plugins#7744 (Refine health check view), already a sub-issue of wazuh-dashboard-plugins#7532, so the entry still reaches it. No issue is opened retroactively for a pull request that is already merged.

### Results and Evidence

Note that the open redirect fix is a security fix, so its removal takes it out of the release notes.

Checks run:

```
prettier --check CHANGELOG.md          # passes
git diff --name-only origin/5.0.0      # CHANGELOG.md only
```




