### PR TITLE
Fix empty error message in dashboard save failure toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | [#1277](https://github.com/wazuh/wazuh-dashboard/issues/1277) | Fixed health check padding styles                                                            |
 | [#1399](https://github.com/wazuh/wazuh-dashboard/issues/1399) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
+| [#1568](https://github.com/wazuh/wazuh-dashboard/issues/1568) | Fixed the empty error message in the dashboard save failure toast                            |
 
 ## Prior versions
 

--- a/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
@@ -450,7 +450,7 @@ export const getNavActions = (
           defaultMessage: `Dashboard '{dashTitle}' was not saved. Error: {errorMessage}`,
           values: {
             dashTitle: savedDashboard.title,
-            errorMessage: savedDashboard.message,
+            errorMessage: error.message,
           },
         }),
         'data-test-subj': 'saveDashboardFailure',


### PR DESCRIPTION
## Description

When saving a dashboard failed, the error toast ended at `Error:` with nothing after it, so the user never learned why the save was rejected.

The toast built its message from `savedDashboard.message`. `savedDashboard` is the saved-object instance and has no `message` property, so the value was always empty. The caught error is available in the same block and carries the real message.

Closes #1568

## Proposed Changes

`src/plugins/dashboard/public/application/utils/get_nav_actions.tsx`

```diff
             dashTitle: savedDashboard.title,
-            errorMessage: savedDashboard.message,
+            errorMessage: error.message,
```

Added the matching `CHANGELOG.md` entry under *Fixed*.

The same line exists in upstream OpenSearch Dashboards `main` and is worth reporting there too.

### Results and Evidence

Signed in as `readall`, a user with read-only permissions on all indices, then created a dashboard and saved it. The save request returns `403`, so the failure toast is shown.

| | Toast |
| --- | --- |
| Before | `Dashboard 'Issue 1568 evidence' was not saved. Error:` |
| After | `Dashboard 'Issue 1568 evidence' was not saved. Error: Forbidden` |

Both runs used the same session and the same `403` response; only the dashboard bundle differed.

<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/0425eb20-0c31-4527-baea-2437821d4dc5" />

### Artifacts Affected

None. The change only affects the dashboard plugin browser bundle.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. `get_nav_actions.tsx` has no test file today, and the change was verified manually as described above.

## How to Test

1. Start the dashboard and log in with a user that cannot write saved objects (for example `readall`).
2. Go to **Dashboards** > **Create new dashboard** > **Save**, give it a title and confirm.
3. The toast reads `Dashboard '<name>' was not saved. Error: Forbidden`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
