### PR TITLE
Show the root cause of the failure in the error toast full error modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,11 @@
 
 ### Fixed
 
-| Issue                                                         | Comment                                                                                      |
-| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [#1277](https://github.com/wazuh/wazuh-dashboard/issues/1277) | Fixed health check padding styles                                                            |
-| [#1399](https://github.com/wazuh/wazuh-dashboard/issues/1399) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading |
+| Issue                                                         | Comment                                                                                                                |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [#1277](https://github.com/wazuh/wazuh-dashboard/issues/1277) | Fixed health check padding styles                                                                                      |
+| [#1399](https://github.com/wazuh/wazuh-dashboard/issues/1399) | Prevent infinite remount loop when navigating from an app before its bundle finishes loading                           |
+| [#1569](https://github.com/wazuh/wazuh-dashboard/issues/1569) | Fixed the error toast full error modal to show the root cause of the failure instead of an unrelated backend exception |
 
 ## Prior versions
 

--- a/src/core/public/notifications/toasts/error_toast.test.tsx
+++ b/src/core/public/notifications/toasts/error_toast.test.tsx
@@ -30,9 +30,10 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mountWithIntl } from 'test_utils/enzyme_helpers';
 
-import { ErrorToast } from './error_toast';
+import { ErrorToast, redactInfrastructureDetails } from './error_toast';
 
 interface ErrorToastProps {
   error?: Error;
@@ -65,6 +66,142 @@ it('should open a modal when clicking button', () => {
   expect(openModal).not.toHaveBeenCalled();
   wrapper.find('button').simulate('click');
   expect(openModal).toHaveBeenCalled();
+});
+
+describe('redactInfrastructureDetails', () => {
+  it('redacts URLs, including the bundle URLs of the client', () => {
+    expect(
+      redactInfrastructureDetails(
+        'failed at https://dashboard.internal:5601/bundles/plugin/data/data.chunk.1.js'
+      )
+    ).toBe('failed at [redacted]');
+  });
+
+  it('redacts IPv4 addresses with and without a port', () => {
+    expect(
+      redactInfrastructureDetails('node [wazuh-indexer-1] at 10.0.13.7:9200 and 192.168.1.24')
+    ).toBe('node [wazuh-indexer-1] at [redacted] and [redacted]');
+  });
+
+  it('redacts IPv6 addresses but keeps clock values', () => {
+    expect(
+      redactInfrastructureDetails('2001:0db8:85a3:0000:0000:8a2e:0370:7334 failed at 10:30:45')
+    ).toBe('[redacted] failed at 10:30:45');
+  });
+
+  it('redacts POSIX and Windows filesystem paths', () => {
+    expect(
+      redactInfrastructureDetails(
+        'cannot read /usr/share/wazuh-indexer/data/nodes/0 nor C:\\indexer\\data'
+      )
+    ).toBe('cannot read [redacted] nor [redacted]');
+  });
+
+  it('keeps a message without infrastructure details as it is', () => {
+    expect(
+      redactInfrastructureDetails('Cannot search on field [event.original] since it is not indexed')
+    ).toBe('Cannot search on field [event.original] since it is not indexed');
+  });
+});
+
+describe('showErrorDialog', () => {
+  const openDialog = async (error: Error) => {
+    const wrapper = mountWithIntl(render({ error }));
+    wrapper.find('button').simulate('click');
+
+    const container = document.createElement('div');
+    await act(async () => {
+      openModal.mock.calls[0][0](container);
+    });
+
+    return container.textContent || '';
+  };
+
+  it('renders the stack trace of the error in the copyable block', async () => {
+    const error = new Error('Search Error');
+    error.stack = 'Error: Search Error\n    at Fetch.<anonymous> (http://localhost:5601/bundle.js)';
+
+    const text = await openDialog(error);
+
+    expect(text).toContain('Search Error');
+    expect(text).toContain('Fetch.<anonymous>');
+  });
+
+  it('shows the root cause reason above the technical detail', async () => {
+    const error: Error & { body?: unknown } = new Error('Bad Request');
+    error.body = {
+      attributes: {
+        error: {
+          type: 'search_phase_execution_exception',
+          reason: '',
+          root_cause: [
+            {
+              type: 'query_shard_exception',
+              reason:
+                'failed to create query: Cannot search on field [event.original] since it is both not indexed, and does not have doc_values enabled.',
+            },
+          ],
+          caused_by: {
+            type: 'null_pointer_exception',
+            reason:
+              'Cannot invoke "org.opensearch.search.aggregations.InternalAggregations.getSerializedSize()" because "reducePhase.aggregations" is null',
+          },
+        },
+      },
+    };
+
+    const text = await openDialog(error);
+
+    // The root cause is the message of the dialog, the caused by failure of the response
+    // stays in the copyable block below it
+    expect(text.indexOf('Cannot search on field [event.original]')).toBeGreaterThan(-1);
+    expect(text.indexOf('Cannot search on field [event.original]')).toBeLessThan(
+      text.indexOf('null_pointer_exception')
+    );
+    expect(text).toContain('reducePhase.aggregations');
+  });
+
+  it('falls back to the caused by detail when there is no root cause', async () => {
+    const error: Error & { body?: unknown } = new Error('Bad Request');
+    error.body = {
+      attributes: {
+        error: {
+          caused_by: {
+            type: 'illegal_argument_exception',
+            reason: 'text is analyzed',
+          },
+        },
+      },
+    };
+
+    const text = await openDialog(error);
+
+    expect(text).toContain('illegal_argument_exception');
+    expect(text).toContain('text is analyzed');
+  });
+
+  it('redacts the infrastructure details of the root cause reason', async () => {
+    const error: Error & { body?: unknown } = new Error('Search Error');
+    error.body = {
+      attributes: {
+        error: {
+          root_cause: [
+            {
+              type: 'query_shard_exception',
+              reason: 'failed to create query on node 10.0.13.7:9200',
+            },
+          ],
+        },
+      },
+    };
+
+    const text = await openDialog(error);
+
+    // The callout redacts the reason, while the copyable block keeps the payload of the
+    // backend and the stack trace as they are
+    expect(text).toContain('failed to create query on node [redacted]');
+    expect(text).toContain('failed to create query on node 10.0.13.7:9200');
+  });
 });
 
 afterAll(() => {

--- a/src/core/public/notifications/toasts/error_toast.tsx
+++ b/src/core/public/notifications/toasts/error_toast.tsx
@@ -54,16 +54,78 @@ interface ErrorToastProps {
   i18nContext: () => I18nStart['Context'];
 }
 
-interface RequestError extends Error {
-  body?: { attributes?: { error: { caused_by: { type: string; reason: string } } } };
+// Wazuh: added root_cause, which the upstream type does not declare
+interface ErrorDetail {
+  type: string;
+  reason: string;
 }
 
-const isRequestError = (e: Error | RequestError): e is RequestError => {
-  if ('body' in e) {
-    return e.body?.attributes?.error?.caused_by !== undefined;
-  }
-  return false;
+interface RequestError extends Error {
+  body?: {
+    attributes?: {
+      error?: {
+        caused_by?: ErrorDetail;
+        root_cause?: ErrorDetail[];
+      };
+    };
+  };
+}
+
+// Wazuh: added the root cause of the failure and the redaction of the infrastructure
+// details, from here down to redactInfrastructureDetails
+const getBackendError = (error: Error | RequestError) =>
+  'body' in error ? error.body?.attributes?.error : undefined;
+
+/**
+ * Returns the failure that actually made the request fail.
+ *
+ * `caused_by` can hold an unrelated failure raised while the response itself was being
+ * built, which hides the actual cause, so the root cause is the detail worth showing as
+ * the message of the dialog.
+ */
+const getRootCause = (error: Error | RequestError): ErrorDetail | undefined =>
+  getBackendError(error)?.root_cause?.[0];
+
+/**
+ * Returns the technical detail of a backend error, shown in the copyable block.
+ */
+const getErrorDetail = (error: Error | RequestError): ErrorDetail | undefined => {
+  const backendError = getBackendError(error);
+
+  return backendError?.caused_by ?? backendError?.root_cause?.[0];
 };
+
+const REDACTED = '[redacted]';
+
+/**
+ * Infrastructure details that must not be exposed to the browser. Backend exception
+ * reasons can carry the addresses and filesystem layout of the cluster, which are of
+ * no use to the user and should not end up in a copyable block.
+ */
+const INFRASTRUCTURE_PATTERNS: RegExp[] = [
+  // URLs, along with any credentials, host and port they carry
+  /\b[a-z][a-z0-9+.-]*:\/\/\S+/gi,
+  // IPv4 addresses, with an optional port
+  /\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b/g,
+  // IPv6 addresses. Three groups or more are required so that clock values such as
+  // 10:30:45 are kept as they are
+  /\b(?:[0-9a-f]{1,4})?(?::{1,2}[0-9a-f]{1,4}){3,}\b/gi,
+  // Filesystem paths, anchored on the usual POSIX roots and on Windows drives
+  /(?:[a-z]:\\|\/(?:usr|etc|var|opt|home|root|tmp|proc|mnt|srv|data)\/)[\w.\\/-]*/gi,
+];
+
+/**
+ * Replaces the infrastructure details of a backend error message with a placeholder,
+ * keeping the rest of the message readable.
+ */
+export function redactInfrastructureDetails(text: string): string {
+  // The error is built by whoever throws it, so the message is not guaranteed to be
+  // a string and the dialog must not fail while reporting another failure
+  return INFRASTRUCTURE_PATTERNS.reduce(
+    (redacted, pattern) => redacted.replace(pattern, REDACTED),
+    String(text ?? '')
+  );
+}
 
 /**
  * This should instead be replaced by the overlay service once it's available.
@@ -78,11 +140,14 @@ function showErrorDialog({
   i18nContext,
 }: Pick<ErrorToastProps, 'error' | 'title' | 'openModal' | 'i18nContext'>) {
   const I18nContext = i18nContext();
+  // Wazuh
+  const rootCause = getRootCause(error);
+  const detail = getErrorDetail(error);
   let text = '';
 
-  if (isRequestError(error)) {
-    text += `${error?.body?.attributes?.error?.caused_by.type}\n`;
-    text += `${error?.body?.attributes?.error?.caused_by.reason}\n\n`;
+  if (detail) {
+    text += `${detail.type}\n`;
+    text += `${detail.reason}\n\n`;
   }
 
   if (error.stack) {
@@ -97,7 +162,16 @@ function showErrorDialog({
             <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
-            <EuiCallOut size="s" color="danger" iconType="alert" title={error.message} />
+            <EuiCallOut
+              size="s"
+              color="danger"
+              iconType="alert"
+              // Wazuh: redact the message before showing it
+              title={redactInfrastructureDetails(error.message)}
+            >
+              {/* Wazuh: show the reason of the root cause, which caused_by can hide */}
+              {rootCause && <p>{redactInfrastructureDetails(rootCause.reason)}</p>}
+            </EuiCallOut>
             {text && (
               <React.Fragment>
                 <EuiSpacer size="s" />


### PR DESCRIPTION
## Description

The **See the full error** button on error toasts opens a modal whose copyable block reported `caused_by`, which can hold a failure raised while the response itself was being built rather than the failure that made the request fail. Querying a field that is not searchable in **Discover** showed `null_pointer_exception: Cannot invoke "org.opensearch.search.aggregations.InternalAggregations.getSerializedSize()" because "reducePhase.aggregations" is null` instead of the actual cause, `query_shard_exception: failed to create query: Cannot search on field [event.original] since it is both not indexed, and does not have doc_values enabled.`, which the backend reports under `root_cause`.

The modal now shows the reason of the root cause inside the danger callout, above the copyable block, so the user reads what actually failed. The copyable block keeps the same content it had on `5.0.0`, the client stack trace included.

**Note for the reviewer:** issue #1569 asks for the client stack trace not to be shown to end users and for the backend reason to be stripped of infrastructure details. This pull request keeps the stack trace in the copyable block, as decided during development, so the exposure the issue reports is still present there. The redaction of URLs, IP addresses and filesystem paths applies only to the message and to the root cause reason shown in the callout. Decide whether this pull request should close #1569 or whether the exposure is tracked separately.

Related to #1569

## Proposed Changes

- `src/core/public/notifications/toasts/error_toast.tsx`
  - Added `getRootCause()`, which reads `body.attributes.error.root_cause[0]`, and `getErrorDetail()`, which keeps feeding the copyable block from `caused_by` and falls back to the root cause when the backend reports no `caused_by`.
  - The reason of the root cause is rendered inside the danger `EuiCallOut`, under the message of the error, so the actual cause reads as part of the alert.
  - Added `redactInfrastructureDetails()`, which replaces URLs, IPv4 addresses (with an optional port), IPv6 addresses and POSIX/Windows filesystem paths with a `[redacted]` placeholder. It is applied to the message of the error and to the root cause reason shown in the callout.
  - The copyable `EuiCodeBlock` is left as it was on `5.0.0`: the exception type, the reason as the backend sends it, and the client stack trace.
  - Every addition is marked with a `// Wazuh` comment, as the file comes from OpenSearch Dashboards and carried no Wazuh changes before this pull request.

Deliberate decisions worth reviewing:

- The IPv6 pattern requires three or more colon-separated groups so that clock values such as `10:30:45` are kept as they are. The `::1` short form is not matched, as it carries no information about the deployment.
- Filesystem paths are anchored on the usual POSIX roots (`/usr`, `/etc`, `/var`, `/opt`, `/home`, `/root`, `/tmp`, `/proc`, `/mnt`, `/srv`, `/data`) and on Windows drives, so API routes such as `/api/status` are kept readable.
- Index and shard names are **not** redacted: they are data the user already works with in the dashboard, and hiding them would leave the message useless for troubleshooting.
- The redaction of the callout is of limited value while the copyable block below carries the stack trace with the host and the bundle URLs. It is kept because the message of the error is the part the user reads first.

Out of scope, same class of exposure in other places: `src/core/public/fatal_errors/fatal_errors_screen.tsx`, `src/plugins/healthcheck/public/components/common/error_boundary/error_boundary.tsx` and the shard failure modal of the `data` plugin.

### Results and Evidence

Reproduced on the osd-dev environment (Wazuh dashboard 5.0.0, OpenSearch Dashboards 3.6.0) in **Discover** on `wazuh-events-v5*` with the query `event.original:"test"`, where `event.original` is mapped as `keyword` with `index: false` and `doc_values: false`.

The backend answers `400` with the real cause under `root_cause` and an unrelated failure under `caused_by`:

```json
{
  "error": {
    "type": "search_phase_execution_exception",
    "reason": "",
    "phase": "fetch",
    "root_cause": [
      {
        "type": "query_shard_exception",
        "reason": "failed to create query: Cannot search on field [event.original] since it is both not indexed, and does not have doc_values enabled."
      }
    ],
    "caused_by": {
      "type": "null_pointer_exception",
      "reason": "Cannot invoke \"org.opensearch.search.aggregations.InternalAggregations.getSerializedSize()\" because \"reducePhase.aggregations\" is null"
    }
  },
  "status": 400
}
```

**Before** — the modal only showed the unrelated `null_pointer_exception` and the stack trace, with no sign of what actually failed:

<img width="1272" height="846" alt="Error modal before the change" src="https://github.com/user-attachments/assets/f2d7fc04-6037-40e4-a448-dba9df874642" />

**After** — the callout carries the reason of the root cause, and the copyable block is unchanged:

<img width="1272" height="846" alt="Error modal after the change" src="https://github.com/user-attachments/assets/a97a3bea-5027-4127-99f9-6d1fdc014cfc" />

### Artifacts Affected

None. The change is contained in the platform browser bundle.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Extended `src/core/public/notifications/toasts/error_toast.test.tsx`:

- `redactInfrastructureDetails`: URLs including bundle URLs, IPv4 with and without a port, IPv6 while keeping clock values, POSIX and Windows paths, and a message without infrastructure details that must be kept as it is.
- `showErrorDialog`: the root cause is rendered above the technical detail, the `caused_by` detail is still used when no root cause is reported, the reason shown in the callout is redacted while the copyable block keeps the payload as it is, and the stack trace is rendered in the copyable block.

`yarn test:jest src/core/public/notifications` → 4 suites, 40 tests passing. `yarn typecheck` reports no errors, and `eslint` and `prettier` pass on the changed files.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
